### PR TITLE
feat(team): add operator role between member and admin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ function loginAsRoot(): mixed
 - **Services/** — Business logic services (ConfigurationGenerator, DockerImageParser, ContainerStatusAggregator, HetznerService, etc.). Use Services for complex orchestration; use Actions for single-purpose domain operations.
 - **Helpers/** — Global helpers loaded via `bootstrap/includeHelpers.php` from `bootstrap/helpers/` — organized into `shared.php`, `constants.php`, `versions.php`, `subscriptions.php`, `domains.php`, `docker.php`, `services.php`, `github.php`, `proxy.php`, `notifications.php`.
 - **Data/** — Spatie Laravel Data DTOs (e.g., `ServerMetadata`).
-- **Enums/** — PHP enums (TitleCase keys). Key enums: `ProcessStatus`, `Role` (MEMBER/ADMIN/OWNER with rank comparison), `BuildPackTypes`, `ProxyTypes`, `ContainerStatusTypes`.
+- **Enums/** — PHP enums (TitleCase keys). Key enums: `ProcessStatus`, `Role` (MEMBER/OPERATOR/ADMIN/OWNER with rank comparison), `BuildPackTypes`, `ProxyTypes`, `ContainerStatusTypes`.
 - **Rules/** — Custom validation rules (`ValidGitRepositoryUrl`, `ValidServerIp`, `ValidHostname`, `DockerImageFormat`, etc.).
 
 ### API Layer
@@ -125,7 +125,7 @@ function loginAsRoot(): mixed
 ### Authorization
 - Policy-based authorization with ~15 model-to-policy mappings in `AuthServiceProvider`
 - Custom gates: `createAnyResource`, `canAccessTerminal`
-- Role hierarchy: `Role::MEMBER` (1) < `Role::ADMIN` (2) < `Role::OWNER` (3) with `lt()`/`gt()` comparison methods
+- Role hierarchy: `Role::MEMBER` (1) < `Role::OPERATOR` (2) < `Role::ADMIN` (3) < `Role::OWNER` (4) with `lt()`/`gt()` comparison methods. Operator manages the resource lifecycle (`User::canManageResources()`/`canManageResourcesOfTeam()`) but has no access to terminals, team management, credentials (keys, git apps, cloud/API tokens), servers, or instance settings — those still require `isAdmin()`/`isAdminOfTeam()`
 - Multi-tenancy via Teams — team auto-initializes notification settings on creation
 
 ### Event Broadcasting

--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -5,6 +5,7 @@ namespace App\Enums;
 enum Role: string
 {
     case MEMBER = 'member';
+    case OPERATOR = 'operator';
     case ADMIN = 'admin';
     case OWNER = 'owner';
 
@@ -12,8 +13,9 @@ enum Role: string
     {
         return match ($this) {
             self::MEMBER => 1,
-            self::ADMIN => 2,
-            self::OWNER => 3,
+            self::OPERATOR => 2,
+            self::ADMIN => 3,
+            self::OWNER => 4,
         };
     }
 

--- a/app/Livewire/Boarding/Index.php
+++ b/app/Livewire/Boarding/Index.php
@@ -89,7 +89,7 @@ class Index extends Component
 
     public function mount()
     {
-        if (auth()->user()?->isMember() && auth()->user()->currentTeam()->show_boarding === true) {
+        if ((auth()->user()?->isMember() || auth()->user()?->isOperator()) && auth()->user()->currentTeam()->show_boarding === true) {
             return redirect()->route('dashboard');
         }
 
@@ -176,7 +176,7 @@ class Index extends Component
 
     public function skipBoarding()
     {
-        if (auth()->user()?->isMember()) {
+        if (auth()->user()?->isMember() || auth()->user()?->isOperator()) {
             return redirect()->route('dashboard');
         }
         Team::find(currentTeam()->id)->update([

--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\Application;
 use App\Models\Environment;
+use App\Models\GithubApp;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\Service;
@@ -970,8 +971,8 @@ class GlobalSearch extends Component
             ]);
         }
 
-        // GitHub Source - can be created if user has createAnyResource permission
-        if ($user->can('createAnyResource')) {
+        // GitHub Source - can be created if user can create GitHub apps
+        if ($user->can('create', GithubApp::class)) {
             $items->push([
                 'name' => 'GitHub App',
                 'description' => 'Connect a GitHub app for source control',

--- a/app/Livewire/Project/Shared/ConfigurationChecker.php
+++ b/app/Livewire/Project/Shared/ConfigurationChecker.php
@@ -100,8 +100,8 @@ class ConfigurationChecker extends Component
 
             $array = $diff->toArray();
 
-            // Fail closed: only owners/admins may see unlocked env values.
-            $redactEnvironment = ! (bool) auth()->user()?->isAdmin();
+            // Fail closed: only operators and above may see unlocked env values.
+            $redactEnvironment = ! (bool) auth()->user()?->canManageResources();
             $array['changes'] = $this->redactEnvironmentChanges($array['changes'] ?? [], $redactEnvironment);
             $this->configurationDiff = $array;
 

--- a/app/Livewire/Project/Shared/ExecuteContainerCommand.php
+++ b/app/Livewire/Project/Shared/ExecuteContainerCommand.php
@@ -39,6 +39,7 @@ class ExecuteContainerCommand extends Component
 
     public function mount(): void
     {
+        $this->authorize('canAccessTerminal');
         $this->parameters = get_route_parameters();
         $this->containers = collect();
         $this->servers = collect();
@@ -87,6 +88,8 @@ class ExecuteContainerCommand extends Component
 
     public function loadContainers(): void
     {
+        $this->authorize('canAccessTerminal');
+
         if ($this->containersLoaded) {
             return;
         }

--- a/app/Livewire/SharedVariables/Team/Index.php
+++ b/app/Livewire/SharedVariables/Team/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\SharedVariables\Team;
 
+use App\Models\SharedEnvironmentVariable;
 use App\Models\Team;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\DB;
@@ -22,7 +23,7 @@ class Index extends Component
     public function saveKey($data)
     {
         try {
-            $this->authorize('update', $this->team);
+            $this->authorize('create', SharedEnvironmentVariable::class);
 
             $found = $this->team->environment_variables()->where('key', $data['key'])->first();
             if ($found) {
@@ -88,7 +89,7 @@ class Index extends Component
     public function submit()
     {
         try {
-            $this->authorize('update', $this->team);
+            $this->authorize('create', SharedEnvironmentVariable::class);
             $this->handleBulkSubmit();
             $this->getDevView();
         } catch (\Throwable $e) {

--- a/app/Livewire/Source/Github/Create.php
+++ b/app/Livewire/Source/Github/Create.php
@@ -49,7 +49,7 @@ class Create extends Component
     public function createGitHubApp()
     {
         try {
-            $this->authorize('createAnyResource');
+            $this->authorize('create', GithubApp::class);
 
             $this->organization = normalizeGithubOrganization($this->organization);
             $this->api_url = filled($this->api_url)

--- a/app/Livewire/Source/Gitlab/Create.php
+++ b/app/Livewire/Source/Gitlab/Create.php
@@ -50,7 +50,7 @@ class Create extends Component
     public function createGitLabApp()
     {
         try {
-            $this->authorize('createAnyResource');
+            $this->authorize('create', GitlabApp::class);
 
             $this->html_url = rtrim($this->html_url, '/');
             $this->api_url = filled($this->api_url)

--- a/app/Livewire/Storage/Form.php
+++ b/app/Livewire/Storage/Form.php
@@ -120,7 +120,7 @@ class Form extends Component
     {
         $this->syncData(false);
 
-        $this->isPasswordHiddenForMember = auth()->user()?->isMember() ?? false;
+        $this->isPasswordHiddenForMember = ! (auth()->user()?->can('update', $this->storage) ?? false);
         if ($this->isPasswordHiddenForMember) {
             $this->key = '';
             $this->secret = '';

--- a/app/Livewire/Team/InviteLink.php
+++ b/app/Livewire/Team/InviteLink.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Team;
 
+use App\Enums\Role;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -21,7 +22,7 @@ class InviteLink extends Component
 
     protected $rules = [
         'email' => 'required|email',
-        'role' => 'required|string',
+        'role' => 'required|string|in:member,operator,admin,owner',
     ];
 
     public function mount()
@@ -57,11 +58,8 @@ class InviteLink extends Component
 
             // Prevent privilege escalation: users cannot invite someone with higher privileges
             $userRole = auth()->user()->role();
-            if (is_null($userRole) || ($userRole === 'member' && in_array($this->role, ['admin', 'owner']))) {
-                throw new \Exception('Members cannot invite admins or owners.');
-            }
-            if ($userRole === 'admin' && $this->role === 'owner') {
-                throw new \Exception('Admins cannot invite owners.');
+            if (is_null($userRole) || Role::from($this->role)->gt($userRole)) {
+                throw new \Exception('You cannot invite a user with a higher role than your own.');
             }
 
             $this->email = strtolower($this->email);

--- a/app/Livewire/Team/Member.php
+++ b/app/Livewire/Team/Member.php
@@ -56,6 +56,26 @@ class Member extends Component
         }
     }
 
+    public function makeOperator()
+    {
+        try {
+            $this->authorize('manageMembers', currentTeam());
+
+            if (Role::from(auth()->user()->role())->lt(Role::ADMIN)
+                || Role::from($this->getMemberRole())->gt(auth()->user()->role())) {
+                throw new \Exception('You are not authorized to perform this action.');
+            }
+            $teamId = currentTeam()->id;
+            DB::transaction(function () use ($teamId): void {
+                $this->member->teams()->updateExistingPivot($teamId, ['role' => Role::OPERATOR->value]);
+                RevokeUserTeamTokens::forUserTeam($this->member, $teamId);
+            });
+            $this->dispatch('reloadWindow');
+        } catch (\Exception $e) {
+            $this->dispatch('error', $e->getMessage());
+        }
+    }
+
     public function makeReadonly()
     {
         try {

--- a/app/Livewire/Terminal/Index.php
+++ b/app/Livewire/Terminal/Index.php
@@ -3,11 +3,14 @@
 namespace App\Livewire\Terminal;
 
 use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 class Index extends Component
 {
+    use AuthorizesRequests;
+
     public $selected_uuid = 'default';
 
     public $servers = [];
@@ -18,6 +21,7 @@ class Index extends Component
 
     public function mount()
     {
+        $this->authorize('canAccessTerminal');
         $this->servers = Server::isReachable()->get()->filter(function ($server) {
             return $server->isTerminalEnabled();
         });
@@ -25,6 +29,8 @@ class Index extends Component
 
     public function loadContainers()
     {
+        $this->authorize('canAccessTerminal');
+
         try {
             $this->containers = $this->getAllActiveContainers();
         } catch (\Exception $e) {

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -73,7 +73,7 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
         });
 
         static::updating(function ($team) {
-            if (auth()->user()?->isMember()) {
+            if (auth()->user()?->isMember() || auth()->user()?->isOperator()) {
                 throw new \Exception('You are not allowed to update this team.');
             }
         });

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Actions\User\RevokeUserTeamTokens;
+use App\Enums\Role;
 use App\Jobs\UpdateStripeCustomerEmailJob;
 use App\Notifications\Channels\SendsEmail;
 use App\Notifications\TransactionalEmails\EmailChangeVerification;
@@ -159,7 +160,9 @@ class User extends Authenticatable implements SendsEmail
                             continue;
                         } else {
                             $found_other_member_who_is_not_owner = $team->members->filter(function ($member) {
-                                return $member->pivot->role === 'member';
+                                return $member->pivot->role === 'operator' || $member->pivot->role === 'member';
+                            })->sortByDesc(function ($member) {
+                                return Role::from($member->pivot->role)->rank();
                             })->first();
 
                             if ($found_other_member_who_is_not_owner) {
@@ -311,6 +314,11 @@ class User extends Authenticatable implements SendsEmail
         return $this->role() === 'member';
     }
 
+    public function isOperator()
+    {
+        return $this->role() === 'operator';
+    }
+
     public function isAdminFromSession()
     {
         if (Auth::id() === 0) {
@@ -415,6 +423,22 @@ class User extends Authenticatable implements SendsEmail
         $role = $team->pivot->role ?? null;
 
         return $role === 'admin' || $role === 'owner';
+    }
+
+    /**
+     * Check if the user can manage resources (operator or above) in the current team
+     */
+    public function canManageResources(): bool
+    {
+        return $this->isAdmin() || $this->isOperator();
+    }
+
+    /**
+     * Check if the user can manage resources (operator or above) in a specific team
+     */
+    public function canManageResourcesOfTeam(int $teamId): bool
+    {
+        return $this->isAdminOfTeam($teamId) || $this->roleInTeam($teamId) === 'operator';
     }
 
     /**

--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -31,7 +31,7 @@ class ApplicationPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -45,11 +45,11 @@ class ApplicationPolicy
             return Response::deny('Application team not found.');
         }
 
-        if ($user->isAdminOfTeam($teamId)) {
+        if ($user->canManageResourcesOfTeam($teamId)) {
             return Response::allow();
         }
 
-        return Response::deny('You need at least admin or owner permissions to update this application.');
+        return Response::deny('You need at least operator permissions to update this application.');
     }
 
     /**
@@ -59,7 +59,7 @@ class ApplicationPolicy
     {
         $teamId = $this->getTeamId($application);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -89,11 +89,11 @@ class ApplicationPolicy
             return Response::deny('Application team not found.');
         }
 
-        if ($user->isAdminOfTeam($teamId)) {
+        if ($user->canManageResourcesOfTeam($teamId)) {
             return Response::allow();
         }
 
-        return Response::deny('You need at least admin or owner permissions to upload backups for this application.');
+        return Response::deny('You need at least operator permissions to upload backups for this application.');
     }
 
     /**
@@ -103,7 +103,7 @@ class ApplicationPolicy
     {
         $teamId = $this->getTeamId($application);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -113,7 +113,7 @@ class ApplicationPolicy
     {
         $teamId = $this->getTeamId($application);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -123,7 +123,7 @@ class ApplicationPolicy
     {
         $teamId = $this->getTeamId($application);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -131,7 +131,7 @@ class ApplicationPolicy
      */
     public function cleanupDeploymentQueue(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     private function getTeamId(Application $application): ?int

--- a/app/Policies/ApplicationPreviewPolicy.php
+++ b/app/Policies/ApplicationPreviewPolicy.php
@@ -31,7 +31,7 @@ class ApplicationPreviewPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -45,11 +45,11 @@ class ApplicationPreviewPolicy
             return Response::deny('Application preview team not found.');
         }
 
-        if ($user->isAdminOfTeam($teamId)) {
+        if ($user->canManageResourcesOfTeam($teamId)) {
             return Response::allow();
         }
 
-        return Response::deny('You need at least admin or owner permissions to update this preview.');
+        return Response::deny('You need at least operator permissions to update this preview.');
     }
 
     /**
@@ -59,7 +59,7 @@ class ApplicationPreviewPolicy
     {
         $teamId = $this->getTeamId($applicationPreview);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -85,7 +85,7 @@ class ApplicationPreviewPolicy
     {
         $teamId = $this->getTeamId($applicationPreview);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -95,7 +95,7 @@ class ApplicationPreviewPolicy
     {
         $teamId = $this->getTeamId($applicationPreview);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     private function getTeamId(ApplicationPreview $applicationPreview): ?int

--- a/app/Policies/ApplicationSettingPolicy.php
+++ b/app/Policies/ApplicationSettingPolicy.php
@@ -30,7 +30,7 @@ class ApplicationSettingPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -40,7 +40,7 @@ class ApplicationSettingPolicy
     {
         $teamId = $this->getTeamId($applicationSetting);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -50,7 +50,7 @@ class ApplicationSettingPolicy
     {
         $teamId = $this->getTeamId($applicationSetting);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**

--- a/app/Policies/DatabasePolicy.php
+++ b/app/Policies/DatabasePolicy.php
@@ -30,7 +30,7 @@ class DatabasePolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -44,11 +44,11 @@ class DatabasePolicy
             return Response::deny('Database team not found.');
         }
 
-        if ($user->isAdminOfTeam($teamId)) {
+        if ($user->canManageResourcesOfTeam($teamId)) {
             return Response::allow();
         }
 
-        return Response::deny('You need at least admin or owner permissions to update this database.');
+        return Response::deny('You need at least operator permissions to update this database.');
     }
 
     /**
@@ -58,7 +58,7 @@ class DatabasePolicy
     {
         $teamId = $this->getTeamId($database);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -84,7 +84,7 @@ class DatabasePolicy
     {
         $teamId = $this->getTeamId($database);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -98,11 +98,11 @@ class DatabasePolicy
             return Response::deny('Database team not found.');
         }
 
-        if ($user->isAdminOfTeam($teamId)) {
+        if ($user->canManageResourcesOfTeam($teamId)) {
             return Response::allow();
         }
 
-        return Response::deny('You need at least admin or owner permissions to upload backups for this database.');
+        return Response::deny('You need at least operator permissions to upload backups for this database.');
     }
 
     /**
@@ -112,7 +112,7 @@ class DatabasePolicy
     {
         $teamId = $this->getTeamId($database);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -122,7 +122,7 @@ class DatabasePolicy
     {
         $teamId = $this->getTeamId($database);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     private function getTeamId($database): ?int

--- a/app/Policies/EnvironmentPolicy.php
+++ b/app/Policies/EnvironmentPolicy.php
@@ -30,7 +30,7 @@ class EnvironmentPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -40,7 +40,7 @@ class EnvironmentPolicy
     {
         $teamId = $this->getTeamId($environment);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -50,7 +50,7 @@ class EnvironmentPolicy
     {
         $teamId = $this->getTeamId($environment);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**

--- a/app/Policies/EnvironmentVariablePolicy.php
+++ b/app/Policies/EnvironmentVariablePolicy.php
@@ -30,7 +30,7 @@ class EnvironmentVariablePolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -40,7 +40,7 @@ class EnvironmentVariablePolicy
     {
         $teamId = $this->getTeamId($environmentVariable);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -50,7 +50,7 @@ class EnvironmentVariablePolicy
     {
         $teamId = $this->getTeamId($environmentVariable);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -76,7 +76,7 @@ class EnvironmentVariablePolicy
     {
         $teamId = $this->getTeamId($environmentVariable);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     private function getTeamId(EnvironmentVariable $environmentVariable): ?int

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -28,7 +28,7 @@ class ProjectPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -36,7 +36,7 @@ class ProjectPolicy
      */
     public function update(User $user, Project $project): bool
     {
-        return $user->isAdminOfTeam($project->team_id);
+        return $user->canManageResourcesOfTeam($project->team_id);
     }
 
     /**
@@ -44,7 +44,7 @@ class ProjectPolicy
      */
     public function delete(User $user, Project $project): bool
     {
-        return $user->isAdminOfTeam($project->team_id);
+        return $user->canManageResourcesOfTeam($project->team_id);
     }
 
     /**

--- a/app/Policies/ResourceCreatePolicy.php
+++ b/app/Policies/ResourceCreatePolicy.php
@@ -38,7 +38,7 @@ class ResourceCreatePolicy
      */
     public function createAny(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -50,7 +50,7 @@ class ResourceCreatePolicy
             return false;
         }
 
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**

--- a/app/Policies/ScheduledTaskPolicy.php
+++ b/app/Policies/ScheduledTaskPolicy.php
@@ -29,7 +29,7 @@ class ScheduledTaskPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -37,8 +37,8 @@ class ScheduledTaskPolicy
      */
     public function update(User $user, ScheduledTask $scheduledTask): Response
     {
-        if (! $user->isAdminOfTeam($scheduledTask->team_id)) {
-            return Response::deny('You need at least admin or owner permissions to update this scheduled task.');
+        if (! $user->canManageResourcesOfTeam($scheduledTask->team_id)) {
+            return Response::deny('You need at least operator permissions to update this scheduled task.');
         }
 
         return Response::allow();
@@ -49,7 +49,7 @@ class ScheduledTaskPolicy
      */
     public function delete(User $user, ScheduledTask $scheduledTask): bool
     {
-        return $user->isAdminOfTeam($scheduledTask->team_id);
+        return $user->canManageResourcesOfTeam($scheduledTask->team_id);
     }
 
     /**

--- a/app/Policies/ServiceApplicationPolicy.php
+++ b/app/Policies/ServiceApplicationPolicy.php
@@ -21,7 +21,7 @@ class ServiceApplicationPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**

--- a/app/Policies/ServiceDatabasePolicy.php
+++ b/app/Policies/ServiceDatabasePolicy.php
@@ -21,7 +21,7 @@ class ServiceDatabasePolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**

--- a/app/Policies/ServicePolicy.php
+++ b/app/Policies/ServicePolicy.php
@@ -30,7 +30,7 @@ class ServicePolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -40,7 +40,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -50,7 +50,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -76,7 +76,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -86,7 +86,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -96,7 +96,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**
@@ -106,7 +106,7 @@ class ServicePolicy
     {
         $teamId = $this->getTeamId($service);
 
-        return $teamId !== null && $user->isAdminOfTeam($teamId);
+        return $teamId !== null && $user->canManageResourcesOfTeam($teamId);
     }
 
     /**

--- a/app/Policies/SharedEnvironmentVariablePolicy.php
+++ b/app/Policies/SharedEnvironmentVariablePolicy.php
@@ -28,7 +28,7 @@ class SharedEnvironmentVariablePolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -36,7 +36,7 @@ class SharedEnvironmentVariablePolicy
      */
     public function update(User $user, SharedEnvironmentVariable $sharedEnvironmentVariable): bool
     {
-        return $user->isAdminOfTeam($sharedEnvironmentVariable->team_id);
+        return $user->canManageResourcesOfTeam($sharedEnvironmentVariable->team_id);
     }
 
     /**
@@ -44,7 +44,7 @@ class SharedEnvironmentVariablePolicy
      */
     public function delete(User $user, SharedEnvironmentVariable $sharedEnvironmentVariable): bool
     {
-        return $user->isAdminOfTeam($sharedEnvironmentVariable->team_id);
+        return $user->canManageResourcesOfTeam($sharedEnvironmentVariable->team_id);
     }
 
     /**
@@ -68,6 +68,6 @@ class SharedEnvironmentVariablePolicy
      */
     public function manageEnvironment(User $user, SharedEnvironmentVariable $sharedEnvironmentVariable): bool
     {
-        return $user->isAdminOfTeam($sharedEnvironmentVariable->team_id);
+        return $user->canManageResourcesOfTeam($sharedEnvironmentVariable->team_id);
     }
 }

--- a/app/Policies/StandaloneDockerPolicy.php
+++ b/app/Policies/StandaloneDockerPolicy.php
@@ -28,7 +28,7 @@ class StandaloneDockerPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -36,7 +36,7 @@ class StandaloneDockerPolicy
      */
     public function update(User $user, StandaloneDocker $standaloneDocker): bool
     {
-        return $user->isAdminOfTeam($standaloneDocker->server->team_id);
+        return $user->canManageResourcesOfTeam($standaloneDocker->server->team_id);
     }
 
     /**
@@ -44,7 +44,7 @@ class StandaloneDockerPolicy
      */
     public function delete(User $user, StandaloneDocker $standaloneDocker): bool
     {
-        return $user->isAdminOfTeam($standaloneDocker->server->team_id);
+        return $user->canManageResourcesOfTeam($standaloneDocker->server->team_id);
     }
 
     /**

--- a/app/Policies/SwarmDockerPolicy.php
+++ b/app/Policies/SwarmDockerPolicy.php
@@ -28,7 +28,7 @@ class SwarmDockerPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -36,7 +36,7 @@ class SwarmDockerPolicy
      */
     public function update(User $user, SwarmDocker $swarmDocker): bool
     {
-        return $user->isAdminOfTeam($swarmDocker->server->team_id);
+        return $user->canManageResourcesOfTeam($swarmDocker->server->team_id);
     }
 
     /**
@@ -44,7 +44,7 @@ class SwarmDockerPolicy
      */
     public function delete(User $user, SwarmDocker $swarmDocker): bool
     {
-        return $user->isAdminOfTeam($swarmDocker->server->team_id);
+        return $user->canManageResourcesOfTeam($swarmDocker->server->team_id);
     }
 
     /**

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -28,7 +28,7 @@ class TagPolicy
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        return $user->canManageResources();
     }
 
     /**
@@ -36,7 +36,7 @@ class TagPolicy
      */
     public function update(User $user, Tag $tag): bool
     {
-        return $user->isAdminOfTeam((int) $tag->team_id);
+        return $user->canManageResourcesOfTeam((int) $tag->team_id);
     }
 
     /**
@@ -44,7 +44,7 @@ class TagPolicy
      */
     public function delete(User $user, Tag $tag): bool
     {
-        return $user->isAdminOfTeam((int) $tag->team_id);
+        return $user->canManageResourcesOfTeam((int) $tag->team_id);
     }
 
     /**

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -552,7 +552,7 @@ function showBoarding(): bool
         return false;
     }
 
-    if (Auth::user()?->isMember()) {
+    if (Auth::user()?->isMember() || Auth::user()?->isOperator()) {
         return false;
     }
 

--- a/resources/views/livewire/server/index.blade.php
+++ b/resources/views/livewire/server/index.blade.php
@@ -16,7 +16,7 @@
                     </a>
                 @endcan
             @endif
-            @can('createAnyResource')
+            @can('create', App\Models\Server::class)
                 <a href="{{ route('server.create') }}" {{ wireNavigate() }}
                     class="button w-fit shrink-0 whitespace-nowrap button-highlighted">
                     <x-reicon name="plus" class="size-3.5" />

--- a/resources/views/livewire/server/private-key/show.blade.php
+++ b/resources/views/livewire/server/private-key/show.blade.php
@@ -20,7 +20,7 @@
                             Check connection
                         </x-forms.button>
 
-                        @can('createAnyResource')
+                        @can('create', App\Models\PrivateKey::class)
                             <div x-data="{ open: false }" class="relative" @click.outside="open = false"
                                 @keydown.escape.window="open = false">
                                 <x-forms.button isHighlighted type="button" @click="open = !open"

--- a/resources/views/livewire/source/github/create.blade.php
+++ b/resources/views/livewire/source/github/create.blade.php
@@ -1,4 +1,4 @@
-@can('createAnyResource')
+@can('create', App\Models\GithubApp::class)
     <form wire:submit="createGitHubApp" class="flex w-full flex-col gap-4">
         <p class="text-[12px] leading-5 text-neutral-500 dark:text-fg-dim">
             Connect a GitHub App for private repositories, webhooks, and commit / pull request deployments.

--- a/resources/views/livewire/source/gitlab/create.blade.php
+++ b/resources/views/livewire/source/gitlab/create.blade.php
@@ -1,4 +1,4 @@
-@can('createAnyResource')
+@can('create', App\Models\GitlabApp::class)
     <form wire:submit="createGitLabApp" class="flex w-full flex-col gap-4">
         <p class="text-[12px] leading-5 text-neutral-500 dark:text-fg-dim">
             Connect a GitLab OAuth application for private repositories, webhooks, and deployments.

--- a/resources/views/livewire/team/invite-link.blade.php
+++ b/resources/views/livewire/team/invite-link.blade.php
@@ -29,6 +29,7 @@
                     <x-forms.listbox id="role" label="Role" :options="array_values(array_filter([
                         auth()->user()->role() === 'owner' ? ['value' => 'owner', 'label' => 'Owner'] : null,
                         ['value' => 'admin', 'label' => 'Admin'],
+                        ['value' => 'operator', 'label' => 'Operator'],
                         ['value' => 'member', 'label' => 'Member'],
                     ]))" />
                 </div>

--- a/resources/views/livewire/team/member.blade.php
+++ b/resources/views/livewire/team/member.blade.php
@@ -56,6 +56,12 @@
                                     Make admin
                                 </button>
                             @endif
+                            @if (data_get($member, 'pivot.role') !== 'operator')
+                                <button type="button" class="listbox-option justify-start!"
+                                    wire:click="makeOperator" @click="open = false">
+                                    Make operator
+                                </button>
+                            @endif
                             @if (data_get($member, 'pivot.role') !== 'member')
                                 <button type="button" class="listbox-option justify-start!"
                                     wire:click="makeReadonly" @click="open = false">
@@ -63,16 +69,25 @@
                                 </button>
                             @endif
                         @elseif (Auth::user()->isAdmin())
-                            @if (data_get($member, 'pivot.role') === 'admin')
-                                <button type="button" class="listbox-option justify-start!"
-                                    wire:click="makeReadonly" @click="open = false">
-                                    Make member
-                                </button>
-                            @elseif (data_get($member, 'pivot.role') === 'member')
-                                <button type="button" class="listbox-option justify-start!" wire:click="makeAdmin"
-                                    @click="open = false">
-                                    Make admin
-                                </button>
+                            @if (data_get($member, 'pivot.role') !== 'owner')
+                                @if (data_get($member, 'pivot.role') !== 'admin')
+                                    <button type="button" class="listbox-option justify-start!"
+                                        wire:click="makeAdmin" @click="open = false">
+                                        Make admin
+                                    </button>
+                                @endif
+                                @if (data_get($member, 'pivot.role') !== 'operator')
+                                    <button type="button" class="listbox-option justify-start!"
+                                        wire:click="makeOperator" @click="open = false">
+                                        Make operator
+                                    </button>
+                                @endif
+                                @if (data_get($member, 'pivot.role') !== 'member')
+                                    <button type="button" class="listbox-option justify-start!"
+                                        wire:click="makeReadonly" @click="open = false">
+                                        Make member
+                                    </button>
+                                @endif
                             @endif
                         @endif
                         <div class="my-1 border-t border-neutral-200 dark:border-white/[0.08]"></div>

--- a/resources/views/livewire/team/member/index.blade.php
+++ b/resources/views/livewire/team/member/index.blade.php
@@ -80,6 +80,7 @@
                                 ['value' => 'all', 'label' => 'All roles'],
                                 ['value' => 'owner', 'label' => 'Owner'],
                                 ['value' => 'admin', 'label' => 'Admin'],
+                                ['value' => 'operator', 'label' => 'Operator'],
                                 ['value' => 'member', 'label' => 'Member'],
                             ]" />
                     </div>

--- a/resources/views/source/all.blade.php
+++ b/resources/views/source/all.blade.php
@@ -11,7 +11,7 @@
                     {{ $sources->count() }} {{ Str::plural('Git source', $sources->count()) }} connected to your team
                 </p>
             </div>
-            @can('createAnyResource')
+            @can('create', App\Models\GithubApp::class)
                 <div x-data="{ dropdownOpen: false }" class="relative w-fit shrink-0"
                     @click.outside="dropdownOpen = false" @keydown.escape.window="dropdownOpen = false">
                     <button type="button" @click="dropdownOpen = !dropdownOpen"

--- a/routes/web.php
+++ b/routes/web.php
@@ -419,8 +419,8 @@ Route::middleware(['auth'])->group(function () {
             if (is_null($team)) {
                 return response()->json(['message' => 'Team not found.'], 404);
             }
-            if ($user->isAdminFromSession() === false) {
-                return response()->json(['message' => 'Only team admins/owners can download backups.'], 403);
+            if ($user->isAdminFromSession() === false && $user->isOperator() === false) {
+                return response()->json(['message' => 'Only team operators/admins/owners can download backups.'], 403);
             }
             $exeuctionId = request()->route('executionId');
             $execution = ScheduledDatabaseBackupExecution::where('id', $exeuctionId)->firstOrFail();
@@ -462,8 +462,8 @@ Route::middleware(['auth'])->group(function () {
             if (is_null($team)) {
                 return response()->json(['message' => 'Team not found.'], 404);
             }
-            if ($user->isAdminFromSession() === false) {
-                return response()->json(['message' => 'Only team admins/owners can download backups.'], 403);
+            if ($user->isAdminFromSession() === false && $user->isOperator() === false) {
+                return response()->json(['message' => 'Only team operators/admins/owners can download backups.'], 403);
             }
 
             $execution = ScheduledVolumeBackupExecution::query()

--- a/tests/Feature/Authorization/OperatorRoleAuthorizationTest.php
+++ b/tests/Feature/Authorization/OperatorRoleAuthorizationTest.php
@@ -1,0 +1,263 @@
+<?php
+
+use App\Livewire\Boarding\Index as BoardingIndex;
+use App\Livewire\Project\Shared\ExecuteContainerCommand;
+use App\Livewire\Team\InviteLink;
+use App\Livewire\Team\Member;
+use App\Livewire\Terminal\Index as TerminalIndex;
+use App\Models\Application;
+use App\Models\GithubApp;
+use App\Models\GitlabApp;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\S3Storage;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\SharedEnvironmentVariable;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\PersonalAccessToken;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.store' => 'array',
+        'cache.default' => 'array',
+    ]);
+
+    $this->withoutVite();
+
+    InstanceSettings::query()->forceCreate(['id' => 0, 'is_api_enabled' => true]);
+
+    $this->team = Team::factory()->create();
+
+    $this->owner = User::factory()->create();
+    $this->owner->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->admin = User::factory()->create();
+    $this->admin->teams()->attach($this->team, ['role' => 'admin']);
+
+    $this->operator = User::factory()->create();
+    $this->operator->teams()->attach($this->team, ['role' => 'operator']);
+
+    $this->member = User::factory()->create();
+    $this->member->teams()->attach($this->team, ['role' => 'member']);
+
+    session(['currentTeam' => $this->team]);
+});
+
+test('operator can create and manage resources while member stays read-only', function () {
+    expect($this->operator->can('createAnyResource'))->toBeTrue()
+        ->and($this->operator->can('create', Application::class))->toBeTrue()
+        ->and($this->operator->can('create', Service::class))->toBeTrue()
+        ->and($this->operator->can('create', StandalonePostgresql::class))->toBeTrue()
+        ->and($this->operator->can('create', Project::class))->toBeTrue()
+        ->and($this->operator->can('create', SharedEnvironmentVariable::class))->toBeTrue();
+
+    expect($this->member->can('createAnyResource'))->toBeFalse()
+        ->and($this->member->can('create', Application::class))->toBeFalse()
+        ->and($this->member->can('create', Project::class))->toBeFalse();
+});
+
+test('operator can update team-scoped resources', function () {
+    $project = Project::create([
+        'name' => 'Operator Project',
+        'team_id' => $this->team->id,
+    ]);
+
+    expect($this->operator->can('update', $project))->toBeTrue()
+        ->and($this->operator->can('delete', $project))->toBeTrue()
+        ->and($this->member->can('update', $project))->toBeFalse();
+});
+
+test('operator cannot access the terminal gate', function () {
+    expect($this->operator->can('canAccessTerminal'))->toBeFalse()
+        ->and($this->member->can('canAccessTerminal'))->toBeFalse()
+        ->and($this->admin->can('canAccessTerminal'))->toBeTrue()
+        ->and($this->owner->can('canAccessTerminal'))->toBeTrue();
+});
+
+test('operator cannot touch credential or persistent-access surfaces', function () {
+    expect($this->operator->can('create', GithubApp::class))->toBeFalse()
+        ->and($this->operator->can('create', GitlabApp::class))->toBeFalse()
+        ->and($this->operator->can('create', PrivateKey::class))->toBeFalse()
+        ->and($this->operator->can('create', Server::class))->toBeFalse()
+        ->and($this->operator->can('create', S3Storage::class))->toBeFalse()
+        ->and($this->operator->can('update', $this->team))->toBeFalse()
+        ->and($this->operator->can('manageMembers', $this->team))->toBeFalse()
+        ->and($this->operator->can('manageInvitations', $this->team))->toBeFalse()
+        ->and($this->operator->can('viewAdmin', $this->team))->toBeFalse()
+        ->and($this->operator->can('delete', $this->team))->toBeFalse();
+});
+
+test('operator cannot hold elevated api token permissions', function () {
+    expect($this->operator->can('useRootPermissions', PersonalAccessToken::class))->toBeFalse()
+        ->and($this->operator->can('useWritePermissions', PersonalAccessToken::class))->toBeFalse()
+        ->and($this->operator->can('useDeployPermissions', PersonalAccessToken::class))->toBeFalse()
+        ->and($this->operator->can('useSensitivePermissions', PersonalAccessToken::class))->toBeFalse();
+});
+
+test('operator can use a read-only api token', function () {
+    $read = $this->operator->createToken('operator-read', ['read']);
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$read->plainTextToken])
+        ->getJson('/api/v1/version')
+        ->assertSuccessful();
+});
+
+test('operator cannot use an elevated api token', function () {
+    $write = $this->operator->createToken('operator-write', ['write']);
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$write->plainTextToken])
+        ->getJson('/api/v1/version')
+        ->assertForbidden();
+});
+
+test('operator cannot update team settings through the model layer', function () {
+    $this->actingAs($this->operator);
+
+    expect(fn () => $this->team->update(['name' => 'Renamed by operator']))
+        ->toThrow(Exception::class, 'You are not allowed to update this team.');
+});
+
+test('operator can dismiss onboarding without hitting the team update guard', function () {
+    $this->actingAs($this->operator);
+
+    $showBoardingBefore = $this->team->fresh()->show_boarding;
+
+    Livewire::test(BoardingIndex::class)
+        ->call('skipBoarding')
+        ->assertRedirect(route('dashboard'));
+
+    expect($this->team->fresh()->show_boarding)->toBe($showBoardingBefore);
+});
+
+test('operator cannot mount terminal components', function () {
+    $this->actingAs($this->operator);
+
+    Livewire::test(TerminalIndex::class)->assertForbidden();
+    Livewire::test(ExecuteContainerCommand::class)->assertForbidden();
+});
+
+test('operator cannot invoke terminal container loading directly', function () {
+    $this->actingAs($this->admin);
+    $component = Livewire::test(TerminalIndex::class);
+
+    $this->actingAs($this->operator);
+    $component->call('loadContainers')->assertForbidden();
+});
+
+test('admin and owner can invite an operator', function () {
+    $this->actingAs($this->admin);
+
+    Livewire::test(InviteLink::class)
+        ->set('email', 'new-operator@example.com')
+        ->set('role', 'operator')
+        ->call('viaLink')
+        ->assertDispatched('success');
+
+    expect(TeamInvitation::whereEmail('new-operator@example.com')->first()?->role)->toBe('operator');
+});
+
+test('operator cannot invite anyone', function () {
+    $this->actingAs($this->operator);
+
+    Livewire::test(InviteLink::class)
+        ->set('email', 'invited-by-operator@example.com')
+        ->set('role', 'member')
+        ->call('viaLink')
+        ->assertDispatched('error');
+
+    expect(TeamInvitation::whereEmail('invited-by-operator@example.com')->exists())->toBeFalse();
+});
+
+test('admin cannot invite a role above their own', function () {
+    $this->actingAs($this->admin);
+
+    Livewire::test(InviteLink::class)
+        ->set('email', 'sneaky-owner@example.com')
+        ->set('role', 'owner')
+        ->call('viaLink')
+        ->assertDispatched('error');
+
+    expect(TeamInvitation::whereEmail('sneaky-owner@example.com')->exists())->toBeFalse();
+});
+
+test('invitation role must be a known role', function () {
+    $this->actingAs($this->admin);
+
+    Livewire::test(InviteLink::class)
+        ->set('email', 'garbage-role@example.com')
+        ->set('role', 'superadmin')
+        ->call('viaLink')
+        ->assertDispatched('error');
+
+    expect(TeamInvitation::whereEmail('garbage-role@example.com')->exists())->toBeFalse();
+});
+
+test('owner can change a member to operator and team tokens are revoked', function () {
+    $this->actingAs($this->member);
+    $this->member->createToken('member-token', ['read']);
+    expect($this->member->tokens()->count())->toBe(1);
+
+    $this->actingAs($this->owner);
+    Livewire::test(Member::class, ['member' => $this->member])
+        ->call('makeOperator')
+        ->assertDispatched('reloadWindow');
+
+    expect($this->member->fresh()->roleInTeam($this->team->id))->toBe('operator')
+        ->and($this->member->tokens()->count())->toBe(0);
+});
+
+test('operator cannot change member roles', function () {
+    $this->actingAs($this->operator);
+
+    Livewire::test(Member::class, ['member' => $this->member])
+        ->call('makeOperator')
+        ->assertDispatched('error');
+
+    expect($this->member->fresh()->roleInTeam($this->team->id))->toBe('member');
+});
+
+test('an operator is promoted over a member when the last owner is deleted', function () {
+    $team = Team::factory()->create();
+    $owner = User::factory()->create();
+    $owner->teams()->attach($team, ['role' => 'owner']);
+    $operator = User::factory()->create();
+    $operator->teams()->attach($team, ['role' => 'operator']);
+    $member = User::factory()->create();
+    $member->teams()->attach($team, ['role' => 'member']);
+
+    $owner->delete();
+
+    expect(Team::query()->find($team->id))->not->toBeNull()
+        ->and($operator->fresh()->roleInTeam($team->id))->toBe('owner')
+        ->and($member->fresh()->roleInTeam($team->id))->toBe('member');
+});
+
+test('an operator-only team is not deleted when the last owner is deleted', function () {
+    $team = Team::factory()->create();
+    $owner = User::factory()->create();
+    $owner->teams()->attach($team, ['role' => 'owner']);
+    $operator = User::factory()->create();
+    $operator->teams()->attach($team, ['role' => 'operator']);
+
+    $owner->delete();
+
+    expect(Team::query()->find($team->id))->not->toBeNull()
+        ->and($operator->fresh()->roleInTeam($team->id))->toBe('owner');
+});
+
+test('operator passes the backup download role gate but member does not', function () {
+    $this->actingAs($this->member);
+    $this->get('/download/backup/999999')->assertForbidden();
+
+    $this->actingAs($this->operator);
+    expect($this->get('/download/backup/999999')->status())->not->toBe(403);
+});

--- a/tests/Feature/Authorization/ResourceCreationAuthorizationTest.php
+++ b/tests/Feature/Authorization/ResourceCreationAuthorizationTest.php
@@ -36,6 +36,9 @@ beforeEach(function () {
     $this->member = User::factory()->create();
     $this->member->teams()->attach($this->team, ['role' => 'member']);
 
+    $this->operator = User::factory()->create();
+    $this->operator->teams()->attach($this->team, ['role' => 'operator']);
+
     $this->project = Project::create([
         'uuid' => (string) Str::uuid(),
         'name' => 'Test Project',
@@ -75,6 +78,17 @@ test('member cannot pass create resources middleware', function () {
 
     expect(fn () => $middleware->handle($request, fn () => response('ok')))
         ->toThrow(HttpException::class, 'You do not have permission to create resources.');
+});
+
+test('operator can pass create resources middleware', function () {
+    $this->actingAs($this->operator);
+    session(['currentTeam' => $this->team]);
+
+    $middleware = new CanCreateResources;
+    $request = Request::create('/project/new', 'GET');
+    $response = $middleware->handle($request, fn () => response('ok'));
+
+    expect($response->getStatusCode())->toBe(200);
 });
 
 test('admin can pass create resources middleware', function () {

--- a/tests/Feature/TerminalAuthRoutesAuthorizationTest.php
+++ b/tests/Feature/TerminalAuthRoutesAuthorizationTest.php
@@ -51,6 +51,17 @@ it('denies non-admin team members on POST /terminal/auth', function () {
         ->assertStatus(403);
 });
 
+it('denies team operators on POST /terminal/auth', function () {
+    $operator = User::factory()->create();
+    $operator->teams()->attach($this->team, ['role' => 'operator']);
+
+    $this->actingAs($operator);
+    session(['currentTeam' => $this->team]);
+
+    $this->postJson('/terminal/auth')
+        ->assertStatus(403);
+});
+
 it('allows team owners on POST /terminal/auth', function () {
     $owner = User::factory()->create();
     $owner->teams()->attach($this->team, ['role' => 'owner']);

--- a/tests/Unit/Policies/ApplicationPolicyTest.php
+++ b/tests/Unit/Policies/ApplicationPolicyTest.php
@@ -67,6 +67,7 @@ it('allows admin to create an application', function () {
 it('denies member to create an application', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ApplicationPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -86,6 +87,7 @@ it('allows team admin to update their own team application', function () {
 it('denies team member to update their own team application', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $application = Mockery::mock(Application::class)->makePartial();
     $application->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -118,6 +120,7 @@ it('allows team admin to delete their own team application', function () {
 it('denies team member to delete their own team application', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $application = Mockery::mock(Application::class)->makePartial();
     $application->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -150,6 +153,7 @@ it('allows team admin to deploy their own team application', function () {
 it('denies team member to deploy their own team application', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $application = Mockery::mock(Application::class)->makePartial();
     $application->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -172,6 +176,7 @@ it('allows team admin to manage deployments', function () {
 it('denies team member to manage deployments', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $application = Mockery::mock(Application::class)->makePartial();
     $application->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -194,6 +199,7 @@ it('allows team admin to manage environment variables', function () {
 it('denies team member to manage environment variables', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $application = Mockery::mock(Application::class)->makePartial();
     $application->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -213,6 +219,7 @@ it('allows admin to cleanup deployment queue', function () {
 it('denies member to cleanup deployment queue', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ApplicationPolicy;
     expect($policy->cleanupDeploymentQueue($user))->toBeFalse();

--- a/tests/Unit/Policies/ApplicationPreviewPolicyTest.php
+++ b/tests/Unit/Policies/ApplicationPreviewPolicyTest.php
@@ -76,6 +76,7 @@ it('allows admin user to create application preview', function () {
 it('denies non-admin user from creating application preview', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ApplicationPreviewPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -99,6 +100,7 @@ it('allows team admin to update application preview', function () {
 it('denies team member from updating application preview', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();
@@ -140,6 +142,7 @@ it('allows team admin to delete application preview', function () {
 it('denies team member from deleting application preview', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();
@@ -180,6 +183,7 @@ it('allows team admin to deploy application preview', function () {
 it('denies team member from deploying application preview', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();
@@ -210,6 +214,7 @@ it('allows team admin to manage preview deployments', function () {
 it('denies team member from managing preview deployments', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();

--- a/tests/Unit/Policies/ApplicationSettingPolicyTest.php
+++ b/tests/Unit/Policies/ApplicationSettingPolicyTest.php
@@ -76,6 +76,7 @@ it('allows admin user to create application setting', function () {
 it('denies non-admin user from creating application setting', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ApplicationSettingPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -99,6 +100,7 @@ it('allows team admin to update application setting', function () {
 it('denies team member from updating application setting', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();
@@ -139,6 +141,7 @@ it('allows team admin to delete application setting', function () {
 it('denies team member from deleting application setting', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $team = (object) ['id' => 1];
     $application = Mockery::mock(Application::class)->makePartial();

--- a/tests/Unit/Policies/DatabasePolicyTest.php
+++ b/tests/Unit/Policies/DatabasePolicyTest.php
@@ -67,6 +67,7 @@ it('allows admin to create a database', function () {
 it('denies member to create a database', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new DatabasePolicy;
     expect($policy->create($user))->toBeFalse();
@@ -86,6 +87,7 @@ it('allows team admin to update their own team database', function () {
 it('denies team member to update their own team database', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $database = Mockery::mock(StandalonePostgresql::class)->makePartial();
     $database->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -118,6 +120,7 @@ it('allows team admin to delete their own team database', function () {
 it('denies team member to delete their own team database', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $database = Mockery::mock(StandalonePostgresql::class)->makePartial();
     $database->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -150,6 +153,7 @@ it('allows team admin to manage their own team database', function () {
 it('denies team member to manage their own team database', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $database = Mockery::mock(StandalonePostgresql::class)->makePartial();
     $database->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -172,6 +176,7 @@ it('allows team admin to manage backups', function () {
 it('denies team member to manage backups', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $database = Mockery::mock(StandalonePostgresql::class)->makePartial();
     $database->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -194,6 +199,7 @@ it('allows team admin to manage database environment variables', function () {
 it('denies team member to manage database environment variables', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $database = Mockery::mock(StandalonePostgresql::class)->makePartial();
     $database->shouldReceive('team')->andReturn((object) ['id' => 1]);

--- a/tests/Unit/Policies/EnvironmentPolicyTest.php
+++ b/tests/Unit/Policies/EnvironmentPolicyTest.php
@@ -67,6 +67,7 @@ it('allows admin to create an environment', function () {
 it('denies member to create an environment', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new EnvironmentPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -86,6 +87,7 @@ it('allows team admin to update their own team environment', function () {
 it('denies team member to update their own team environment', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $environment = Mockery::mock(Environment::class)->makePartial();
     $environment->shouldReceive('getAttribute')->with('project')->andReturn((object) ['team_id' => 1]);
@@ -118,6 +120,7 @@ it('allows team admin to delete their own team environment', function () {
 it('denies team member to delete their own team environment', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $environment = Mockery::mock(Environment::class)->makePartial();
     $environment->shouldReceive('getAttribute')->with('project')->andReturn((object) ['team_id' => 1]);

--- a/tests/Unit/Policies/EnvironmentVariablePolicyTest.php
+++ b/tests/Unit/Policies/EnvironmentVariablePolicyTest.php
@@ -63,6 +63,7 @@ it('allows admin to create environment variable', function () {
 it('denies member from creating environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new EnvironmentVariablePolicy;
     expect($policy->create($user))->toBeFalse();
@@ -85,6 +86,7 @@ it('allows team admin to update environment variable', function () {
 it('denies non-admin from updating environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $resource = Mockery::mock(Application::class)->makePartial();
     $resource->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -123,6 +125,7 @@ it('allows team admin to delete environment variable', function () {
 it('denies non-admin from deleting environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $resource = Mockery::mock(Application::class)->makePartial();
     $resource->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -177,6 +180,7 @@ it('allows team admin to manage environment', function () {
 it('denies non-admin from managing environment', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $resource = Mockery::mock(Application::class)->makePartial();
     $resource->shouldReceive('team')->andReturn((object) ['id' => 1]);

--- a/tests/Unit/Policies/ProjectPolicyTest.php
+++ b/tests/Unit/Policies/ProjectPolicyTest.php
@@ -52,6 +52,7 @@ it('allows admin to create a project', function () {
 it('denies member to create a project', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ProjectPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -71,6 +72,7 @@ it('allows team admin to update their own team project', function () {
 it('denies team member to update their own team project', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $project = Mockery::mock(Project::class)->makePartial();
     $project->team_id = 1;
@@ -93,6 +95,7 @@ it('allows team admin to delete their own team project', function () {
 it('denies team member to delete their own team project', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $project = Mockery::mock(Project::class)->makePartial();
     $project->team_id = 1;

--- a/tests/Unit/Policies/ResourceCreatePolicyTest.php
+++ b/tests/Unit/Policies/ResourceCreatePolicyTest.php
@@ -15,9 +15,28 @@ it('allows admin to create any resource', function () {
 it('denies member from creating any resource', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ResourceCreatePolicy;
     expect($policy->createAny($user))->toBeFalse();
+});
+
+it('allows operator to create any resource', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(true);
+
+    $policy = new ResourceCreatePolicy;
+    expect($policy->createAny($user))->toBeTrue();
+});
+
+it('allows operator to create a valid resource class', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(true);
+
+    $policy = new ResourceCreatePolicy;
+    expect($policy->create($user, Application::class))->toBeTrue();
 });
 
 it('allows admin to create a valid resource class', function () {
@@ -31,6 +50,7 @@ it('allows admin to create a valid resource class', function () {
 it('denies member from creating a valid resource class', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ResourceCreatePolicy;
     expect($policy->create($user, Application::class))->toBeFalse();
@@ -55,6 +75,7 @@ it('allows admin to authorize all resource creation', function () {
 it('denies member from authorizing all resource creation', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ResourceCreatePolicy;
     expect($policy->authorizeAllResourceCreation($user))->toBeFalse();

--- a/tests/Unit/Policies/ServiceApplicationPolicyTest.php
+++ b/tests/Unit/Policies/ServiceApplicationPolicyTest.php
@@ -15,6 +15,7 @@ it('allows admin to create service application', function () {
 it('denies member from creating service application', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ServiceApplicationPolicy;
     expect($policy->create($user))->toBeFalse();

--- a/tests/Unit/Policies/ServiceDatabasePolicyTest.php
+++ b/tests/Unit/Policies/ServiceDatabasePolicyTest.php
@@ -15,6 +15,7 @@ it('allows admin to create service database', function () {
 it('denies member from creating service database', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ServiceDatabasePolicy;
     expect($policy->create($user))->toBeFalse();

--- a/tests/Unit/Policies/ServicePolicyTest.php
+++ b/tests/Unit/Policies/ServicePolicyTest.php
@@ -67,6 +67,7 @@ it('allows admin to create a service', function () {
 it('denies member to create a service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new ServicePolicy;
     expect($policy->create($user))->toBeFalse();
@@ -86,6 +87,7 @@ it('allows team admin to update their own team service', function () {
 it('denies team member to update their own team service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -108,6 +110,7 @@ it('allows team admin to delete their own team service', function () {
 it('denies team member to delete their own team service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -126,6 +129,29 @@ it('denies delete when service has no team', function () {
     expect($policy->delete($user, $service))->toBeFalse();
 });
 
+it('allows team operator to deploy their own team service', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('operator');
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
+
+    $policy = new ServicePolicy;
+    expect($policy->deploy($user, $service))->toBeTrue();
+});
+
+it('denies team operator to access terminal', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
+
+    $policy = new ServicePolicy;
+    expect($policy->accessTerminal($user, $service))->toBeFalse();
+});
+
 it('allows team admin to deploy their own team service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(true);
@@ -140,6 +166,7 @@ it('allows team admin to deploy their own team service', function () {
 it('denies team member to deploy their own team service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -162,6 +189,7 @@ it('allows team admin to stop their own team service', function () {
 it('denies team member to stop their own team service', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('team')->andReturn((object) ['id' => 1]);
@@ -184,6 +212,7 @@ it('allows team admin to manage service environment variables', function () {
 it('denies team member to manage service environment variables', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('team')->andReturn((object) ['id' => 1]);

--- a/tests/Unit/Policies/SharedEnvironmentVariablePolicyTest.php
+++ b/tests/Unit/Policies/SharedEnvironmentVariablePolicyTest.php
@@ -50,6 +50,7 @@ it('allows admin to create shared environment variable', function () {
 it('denies non-admin to create shared environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new SharedEnvironmentVariablePolicy;
     expect($policy->create($user))->toBeFalse();
@@ -68,6 +69,7 @@ it('allows team admin to update shared environment variable', function () {
 it('denies team member to update shared environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $model = mockSharedEnvironmentVariable(teamId: 1);
 
@@ -88,6 +90,7 @@ it('allows team admin to delete shared environment variable', function () {
 it('denies team member to delete shared environment variable', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $model = mockSharedEnvironmentVariable(teamId: 1);
 
@@ -126,6 +129,7 @@ it('allows team admin to manage environment', function () {
 it('denies team member to manage environment', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $model = mockSharedEnvironmentVariable(teamId: 1);
 

--- a/tests/Unit/Policies/StandaloneDockerPolicyTest.php
+++ b/tests/Unit/Policies/StandaloneDockerPolicyTest.php
@@ -52,6 +52,7 @@ it('allows admin to create standalone docker', function () {
 it('denies non-admin from creating standalone docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new StandaloneDockerPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -71,6 +72,7 @@ it('allows team admin to update standalone docker', function () {
 it('denies non-admin from updating standalone docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $standaloneDocker = Mockery::mock(StandaloneDocker::class)->makePartial();
     $standaloneDocker->shouldReceive('getAttribute')->with('server')->andReturn((object) ['team_id' => 1]);
@@ -93,6 +95,7 @@ it('allows team admin to delete standalone docker', function () {
 it('denies non-admin from deleting standalone docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $standaloneDocker = Mockery::mock(StandaloneDocker::class)->makePartial();
     $standaloneDocker->shouldReceive('getAttribute')->with('server')->andReturn((object) ['team_id' => 1]);

--- a/tests/Unit/Policies/SwarmDockerPolicyTest.php
+++ b/tests/Unit/Policies/SwarmDockerPolicyTest.php
@@ -52,6 +52,7 @@ it('allows admin to create swarm docker', function () {
 it('denies non-admin from creating swarm docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdmin')->andReturn(false);
+    $user->shouldReceive('isOperator')->andReturn(false);
 
     $policy = new SwarmDockerPolicy;
     expect($policy->create($user))->toBeFalse();
@@ -71,6 +72,7 @@ it('allows team admin to update swarm docker', function () {
 it('denies non-admin from updating swarm docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $swarmDocker = Mockery::mock(SwarmDocker::class)->makePartial();
     $swarmDocker->shouldReceive('getAttribute')->with('server')->andReturn((object) ['team_id' => 1]);
@@ -93,6 +95,7 @@ it('allows team admin to delete swarm docker', function () {
 it('denies non-admin from deleting swarm docker', function () {
     $user = Mockery::mock(User::class)->makePartial();
     $user->shouldReceive('isAdminOfTeam')->with(1)->andReturn(false);
+    $user->shouldReceive('roleInTeam')->with(1)->andReturn('member');
 
     $swarmDocker = Mockery::mock(SwarmDocker::class)->makePartial();
     $swarmDocker->shouldReceive('getAttribute')->with('server')->andReturn((object) ['team_id' => 1]);

--- a/tests/Unit/RoleEnumTest.php
+++ b/tests/Unit/RoleEnumTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Enums\Role;
+
+it('ranks roles in ascending order of privilege', function () {
+    expect(Role::MEMBER->rank())->toBeLessThan(Role::OPERATOR->rank())
+        ->and(Role::OPERATOR->rank())->toBeLessThan(Role::ADMIN->rank())
+        ->and(Role::ADMIN->rank())->toBeLessThan(Role::OWNER->rank());
+});
+
+it('compares operator against other roles', function () {
+    expect(Role::OPERATOR->lt(Role::ADMIN))->toBeTrue()
+        ->and(Role::OPERATOR->lt(Role::OWNER))->toBeTrue()
+        ->and(Role::OPERATOR->gt(Role::MEMBER))->toBeTrue()
+        ->and(Role::OPERATOR->gt('admin'))->toBeFalse()
+        ->and(Role::from('operator'))->toBe(Role::OPERATOR);
+});


### PR DESCRIPTION
## Changes

Since 4.2.0 the member role is read-only, leaving no role for people who deploy day to day without full admin. This adds an operator role between member and admin.

Operators manage resources (apps, services, databases, projects, env vars, scheduled tasks, backups, tags) but cannot open a terminal, manage the team, or touch anything granting lasting access: private keys, git app connections, cloud tokens, S3 credentials, servers, instance settings. Their API tokens stay read-only, like members.

Admin helpers are untouched, so sensitive checks keep failing closed; only resource-lifecycle policies opt in. Rank is member < operator < admin < owner. No migration: the role column is a plain string, and existing roles are unaffected.

## Issues

- Implements https://github.com/coollabsio/coolify/discussions/11486 (see also #11321, #5292)

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

![roles](https://raw.githubusercontent.com/Jedvanaways/coolify/screenshots/s/g.png)
![403](https://raw.githubusercontent.com/Jedvanaways/coolify/screenshots/s/t.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: an AI assistant
- How extensively: inventorying authorization checks and drafting tests. I set the boundary and verified the changes myself.

## Testing

New feature test covering operator gates, policies, terminal denial, token abilities, the invitation whitelist, role changes and owner-deletion succession, plus operator rows in existing tests. Policy unit suite passes (327), authorization suite has no new failures against next, Pint clean. Also driven by hand on a local instance holding all four roles.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
