### PR TITLE
fix(navigation): keep <head> first in back button snapshots

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,9 +1,14 @@
 import { initializeTerminalComponent } from './terminal.js';
 import { registerLivewireRequestFailureHandler } from './livewire-request-failure.js';
+import { registerNavigateSnapshotGuard } from './navigate-snapshot-guard.js';
 
 document.addEventListener('livewire:init', () => {
     registerLivewireRequestFailureHandler(window.Livewire);
 });
+
+// Keep <head> first in the DOM so wire:navigate's back-button snapshot survives
+// elements that browser extensions inject before it.
+registerNavigateSnapshotGuard(document);
 
 // Livewire 3.5.19+ re-applies `x-cloak` to morphed elements during wire:navigate
 // (via replaceHtmlAttributes). With `[x-cloak]{display:none}` on the app wrapper,

--- a/resources/js/navigate-snapshot-guard.js
+++ b/resources/js/navigate-snapshot-guard.js
@@ -1,0 +1,46 @@
+/**
+ * `wire:navigate` stores the page for the back button by serializing
+ * `document.documentElement.outerHTML` and re-parsing it later. Browser
+ * extensions frequently inject their overlay host as the first child of
+ * `<html>`, before `<head>`. Re-parsing such a string ends the head before it
+ * starts, so the whole `<head>` is parsed into `<body>`: the restored page
+ * renders broken, inline head scripts run a second time, and navigation stays
+ * dead until a reload.
+ *
+ * Moving those strays behind `<head>` (but still outside `<body>`, so they
+ * survive the body swap) keeps the snapshot round-tripping correctly.
+ *
+ * @param {Document} document
+ * @return {number} How many elements were moved.
+ */
+export function moveStrayNodesBehindHead(document) {
+    const root = document.documentElement;
+    const head = document.head;
+    const body = document.body;
+
+    if (! root || ! head || ! body) {
+        return 0;
+    }
+
+    let moved = 0;
+
+    for (const child of Array.from(root.children)) {
+        if (child === head) {
+            break;
+        }
+
+        root.insertBefore(child, body);
+        moved++;
+    }
+
+    return moved;
+}
+
+/**
+ * Run the guard right before Livewire snapshots the current page.
+ *
+ * @param {Document} document
+ */
+export function registerNavigateSnapshotGuard(document) {
+    document.addEventListener('livewire:navigating', () => moveStrayNodesBehindHead(document));
+}

--- a/resources/js/navigate-snapshot-guard.test.js
+++ b/resources/js/navigate-snapshot-guard.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { moveStrayNodesBehindHead, registerNavigateSnapshotGuard } from './navigate-snapshot-guard.js';
+
+class FakeElement {
+    constructor(tagName) {
+        this.tagName = tagName;
+        this.children = [];
+    }
+
+    append(...children) {
+        this.children.push(...children);
+    }
+
+    insertBefore(child, reference) {
+        const current = this.children.indexOf(child);
+
+        if (current > -1) {
+            this.children.splice(current, 1);
+        }
+
+        this.children.splice(this.children.indexOf(reference), 0, child);
+    }
+}
+
+function createDocument(tagNamesBeforeHead = []) {
+    const documentElement = new FakeElement('HTML');
+    const head = new FakeElement('HEAD');
+    const body = new FakeElement('BODY');
+
+    documentElement.append(...tagNamesBeforeHead.map((tagName) => new FakeElement(tagName)), head, body);
+
+    return { documentElement, head, body };
+}
+
+const tagNames = (document) => document.documentElement.children.map((child) => child.tagName);
+
+test('an extension element injected before the head is moved behind it', () => {
+    const document = createDocument(['PLASMO-CSUI']);
+
+    assert.equal(moveStrayNodesBehindHead(document), 1);
+    assert.deepEqual(tagNames(document), ['HEAD', 'PLASMO-CSUI', 'BODY']);
+});
+
+test('every stray keeps its relative order', () => {
+    const document = createDocument(['FIRST-OVERLAY', 'SECOND-OVERLAY']);
+
+    assert.equal(moveStrayNodesBehindHead(document), 2);
+    assert.deepEqual(tagNames(document), ['HEAD', 'FIRST-OVERLAY', 'SECOND-OVERLAY', 'BODY']);
+});
+
+test('an untouched document is left alone', () => {
+    const document = createDocument();
+
+    assert.equal(moveStrayNodesBehindHead(document), 0);
+    assert.deepEqual(tagNames(document), ['HEAD', 'BODY']);
+});
+
+test('elements already sitting between the head and the body are not moved', () => {
+    const document = createDocument();
+    document.documentElement.insertBefore(new FakeElement('PLASMO-CSUI'), document.body);
+
+    assert.equal(moveStrayNodesBehindHead(document), 0);
+    assert.deepEqual(tagNames(document), ['HEAD', 'PLASMO-CSUI', 'BODY']);
+});
+
+test('the guard runs when Livewire is about to snapshot the page', () => {
+    const document = createDocument(['PLASMO-CSUI']);
+    const listeners = {};
+    document.addEventListener = (name, callback) => listeners[name] = callback;
+
+    registerNavigateSnapshotGuard(document);
+    listeners['livewire:navigating']();
+
+    assert.deepEqual(tagNames(document), ['HEAD', 'PLASMO-CSUI', 'BODY']);
+});


### PR DESCRIPTION
## Changes

- Keep `<head>` as the first child of `<html>` before `wire:navigate` snapshots the page for the back button.
- Move nodes injected ahead of it behind `<head>`, but still outside `<body>` so they survive the body swap.
- Add unit coverage for the reordering.

`wire:navigate` stores the back button snapshot as `document.documentElement.outerHTML` and re-parses it on `popstate`. That string only round-trips if `<head>` comes first: a node before it ends the head immediately, so the whole `<head>` is parsed into `<body>`. Browser extensions inject their overlay host exactly there, which is why this only hits some users. On the restored page the inline head scripts run a second time, the replayed `js/echo.js` overwrites the `window.Echo` instance, elements stay behind `x-cloak`, and no link responds until a reload.

The root cause is Livewire's navigate plugin assuming that serialization round-trips. This has to stay on our side for now, since the fix must land before Livewire takes the snapshot.

## Issues

- Fixes #8657

The reporter there confirmed it works in incognito with fewer extensions, which matches this cause.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not a UI change. Reproducing it needs an extension that injects before `<head>`:

```js
[...document.documentElement.children].map(e => e.tagName)
// broken: ["PLASMO-CSUI", "HEAD", "BODY"]
// fixed:  ["HEAD", "PLASMO-CSUI", "BODY"]
```

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: It drove the browser session that isolated the cause, and drafted the guard and its tests. I hit the bug on my own instance, reviewed the diagnosis against the Livewire source, and verified the fix on a local dev instance before opening this.

## Testing

Local dev instance, Chrome profile carrying the offending extension.

1. `/projects`, click a project, then browser back.
2. Before: blank page, `document.head.children.length === 0`, the whole head inside the body, `SyntaxError: ... Identifier 't' has already been declared`, then `Cannot read properties of undefined (reading 'pusher')` on a loop, 27 elements left with `x-cloak`. No `wire:navigate` link responds.
3. After: head untouched at 36 children, no `<meta>` in the body, no `x-cloak`, no console errors, `window.Echo` still the instance, and clicking the project navigates.
4. Also `/projects` to environment to back to click again, and `/projects` to `/servers` to back to forward to back. The extension node stays a single instance and still renders.
5. Control: deleting the injected node by hand before navigating away also fixes the back button, which isolates the cause.

`node --test resources/js/*.test.js` goes from 10 to 15 passing, the 5 new ones in `resources/js/navigate-snapshot-guard.test.js`.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
