### PR TITLE
feat(ui): add host vitals to top bar

### DIFF
--- a/app/Livewire/HostVitals.php
+++ b/app/Livewire/HostVitals.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Livewire;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class HostVitals extends Component
+{
+    #[Locked]
+    public array $metrics = [
+        'cpu' => [
+            'cores' => 0,
+            'used_percent' => null,
+            'free_percent' => null,
+        ],
+        'ram' => [
+            'used_gib' => 0.0,
+            'available_gib' => 0.0,
+            'total_gib' => 0.0,
+            'used_percent' => 0.0,
+            'available_percent' => 0.0,
+        ],
+        'disk' => [
+            'used_gib' => 0.0,
+            'free_gib' => 0.0,
+            'total_gib' => 0.0,
+            'used_percent' => 0.0,
+            'free_percent' => 0.0,
+        ],
+        'load' => [
+            'one' => 0.0,
+            'five' => 0.0,
+            'fifteen' => 0.0,
+        ],
+    ];
+
+    #[Locked]
+    public ?int $previousTotalTicks = null;
+
+    #[Locked]
+    public ?int $previousIdleTicks = null;
+
+    public function mount(): void
+    {
+        $this->ensureAvailable();
+        $this->readVitals(false);
+    }
+
+    public function refreshVitals(): void
+    {
+        $this->ensureAvailable();
+        $this->readVitals(true);
+    }
+
+    private function ensureAvailable(): void
+    {
+        if (isCloud() || ! isInstanceAdmin()) {
+            abort(403);
+        }
+    }
+
+    private function readVitals(bool $calculateCpu): void
+    {
+        [$totalTicks, $idleTicks] = $this->cpuTicks();
+
+        $cpuUsedPercent = $this->metrics['cpu']['used_percent'];
+        if ($calculateCpu && $this->previousTotalTicks !== null && $totalTicks > $this->previousTotalTicks) {
+            $deltaTotal = $totalTicks - $this->previousTotalTicks;
+            $deltaIdle = $idleTicks - (int) $this->previousIdleTicks;
+            $busyTicks = max(0, $deltaTotal - $deltaIdle);
+            $cpuUsedPercent = round(min(100, ($busyTicks / $deltaTotal) * 100), 1);
+        }
+
+        $this->previousTotalTicks = $totalTicks;
+        $this->previousIdleTicks = $idleTicks;
+
+        $cpuInfo = @file_get_contents('/proc/cpuinfo') ?: '';
+        preg_match_all('/^processor\s*:/m', $cpuInfo, $processorMatches);
+        $cores = max(1, count($processorMatches[0] ?? []));
+
+        $this->metrics['cpu'] = [
+            'cores' => $cores,
+            'used_percent' => $cpuUsedPercent,
+            'free_percent' => $cpuUsedPercent === null ? null : round(max(0, 100 - $cpuUsedPercent), 1),
+        ];
+
+        $memInfo = @file_get_contents('/proc/meminfo') ?: '';
+        preg_match('/^MemTotal:\s+(\d+)\s+kB/m', $memInfo, $totalMemoryMatch);
+        preg_match('/^MemAvailable:\s+(\d+)\s+kB/m', $memInfo, $availableMemoryMatch);
+
+        $totalMemoryKb = max(0, (int) ($totalMemoryMatch[1] ?? 0));
+        $availableMemoryKb = min($totalMemoryKb, max(0, (int) ($availableMemoryMatch[1] ?? 0)));
+        $usedMemoryKb = max(0, $totalMemoryKb - $availableMemoryKb);
+
+        $this->metrics['ram'] = [
+            'used_gib' => round($usedMemoryKb / 1048576, 1),
+            'available_gib' => round($availableMemoryKb / 1048576, 1),
+            'total_gib' => round($totalMemoryKb / 1048576, 1),
+            'used_percent' => $totalMemoryKb > 0 ? round(($usedMemoryKb / $totalMemoryKb) * 100, 1) : 0.0,
+            'available_percent' => $totalMemoryKb > 0 ? round(($availableMemoryKb / $totalMemoryKb) * 100, 1) : 0.0,
+        ];
+
+        $diskTotalBytes = max(0, (float) (@disk_total_space('/') ?: 0));
+        $diskFreeBytes = min($diskTotalBytes, max(0, (float) (@disk_free_space('/') ?: 0)));
+        $diskUsedBytes = max(0, $diskTotalBytes - $diskFreeBytes);
+
+        $this->metrics['disk'] = [
+            'used_gib' => round($diskUsedBytes / 1073741824, 1),
+            'free_gib' => round($diskFreeBytes / 1073741824, 1),
+            'total_gib' => round($diskTotalBytes / 1073741824, 1),
+            'used_percent' => $diskTotalBytes > 0 ? round(($diskUsedBytes / $diskTotalBytes) * 100, 1) : 0.0,
+            'free_percent' => $diskTotalBytes > 0 ? round(($diskFreeBytes / $diskTotalBytes) * 100, 1) : 0.0,
+        ];
+
+        $load = sys_getloadavg() ?: [0.0, 0.0, 0.0];
+        $this->metrics['load'] = [
+            'one' => round((float) ($load[0] ?? 0), 2),
+            'five' => round((float) ($load[1] ?? 0), 2),
+            'fifteen' => round((float) ($load[2] ?? 0), 2),
+        ];
+    }
+
+    private function cpuTicks(): array
+    {
+        $lines = @file('/proc/stat', FILE_IGNORE_NEW_LINES) ?: [];
+        $firstLine = $lines[0] ?? '';
+        $parts = preg_split('/\s+/', trim($firstLine)) ?: [];
+
+        if (($parts[0] ?? '') === 'cpu') {
+            array_shift($parts);
+        }
+
+        $ticks = array_map('intval', array_slice($parts, 0, 8));
+        $ticks = array_pad($ticks, 8, 0);
+
+        return [array_sum($ticks), $ticks[3] + $ticks[4]];
+    }
+
+    public function render(): View
+    {
+        return view('livewire.host-vitals');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -61,6 +61,9 @@
                         <x-top-breadcrumb />
                         <div id="server-topbar-context" class="min-w-0"></div>
                     </div>
+                    @if (isInstanceAdmin() && ! isCloud())
+                        <livewire:host-vitals />
+                    @endif
                     {{-- Dev Server-Timing HUD docks here (local only; empty in production) --}}
                     <div id="server-timing-hud-slot" data-server-timing-hud-slot class="hidden shrink-0 items-center"></div>
                     <div id="configuration-warning-hud-slot" class="relative shrink-0"></div>

--- a/resources/views/livewire/host-vitals.blade.php
+++ b/resources/views/livewire/host-vitals.blade.php
@@ -1,0 +1,48 @@
+<div wire:init="refreshVitals" wire:poll.15s="refreshVitals"
+    class="hidden min-[1440px]:flex min-w-0 shrink-0 items-center gap-1.5 text-[10.5px] text-neutral-600 dark:text-fg-dim"
+    aria-label="Local host resource usage"
+    title="Local host resources · red = used · green = free or available · refreshes every 15 seconds">
+    <div class="flex shrink-0 items-center gap-1.5 rounded-lg border border-neutral-200 bg-neutral-50/70 px-2 py-1 dark:border-white/[0.06] dark:bg-white/[0.03]"
+        title="CPU across {{ $metrics['cpu']['cores'] }} logical cores">
+        <span class="font-semibold text-neutral-700 dark:text-fg">CPU</span>
+        <span class="tabular-nums text-neutral-500 dark:text-fg-faint">{{ $metrics['cpu']['cores'] }}C</span>
+        <span class="text-neutral-300 dark:text-white/15">·</span>
+        @if ($metrics['cpu']['used_percent'] === null)
+            <span class="tabular-nums text-neutral-400 dark:text-fg-faint">--</span>
+        @else
+            <span class="tabular-nums font-semibold text-red-600 dark:text-red-400">{{ number_format($metrics['cpu']['used_percent'], 1) }}%</span>
+            <span class="text-neutral-300 dark:text-white/15">·</span>
+            <span class="tabular-nums font-semibold text-emerald-600 dark:text-emerald-400">{{ number_format($metrics['cpu']['free_percent'], 1) }}%</span>
+        @endif
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1.5 rounded-lg border border-neutral-200 bg-neutral-50/70 px-2 py-1 dark:border-white/[0.06] dark:bg-white/[0.03]"
+        title="RAM: used, available and total capacity">
+        <span class="font-semibold text-neutral-700 dark:text-fg">RAM</span>
+        <span class="tabular-nums font-semibold text-red-600 dark:text-red-400">{{ number_format($metrics['ram']['used_gib'], 1) }}G ({{ number_format($metrics['ram']['used_percent'], 1) }}%)</span>
+        <span class="text-neutral-300 dark:text-white/15">·</span>
+        <span class="tabular-nums font-semibold text-emerald-600 dark:text-emerald-400">{{ number_format($metrics['ram']['available_gib'], 1) }}G ({{ number_format($metrics['ram']['available_percent'], 1) }}%)</span>
+        <span class="hidden 2xl:inline text-neutral-300 dark:text-white/15">·</span>
+        <span class="hidden 2xl:inline tabular-nums text-neutral-500 dark:text-fg-faint">{{ number_format($metrics['ram']['total_gib'], 1) }}G</span>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1.5 rounded-lg border border-neutral-200 bg-neutral-50/70 px-2 py-1 dark:border-white/[0.06] dark:bg-white/[0.03]"
+        title="Root filesystem: used, free and total capacity">
+        <span class="font-semibold text-neutral-700 dark:text-fg">DISK</span>
+        <span class="tabular-nums font-semibold text-red-600 dark:text-red-400">{{ number_format($metrics['disk']['used_gib'], 1) }}G ({{ number_format($metrics['disk']['used_percent'], 1) }}%)</span>
+        <span class="text-neutral-300 dark:text-white/15">·</span>
+        <span class="tabular-nums font-semibold text-emerald-600 dark:text-emerald-400">{{ number_format($metrics['disk']['free_gib'], 1) }}G ({{ number_format($metrics['disk']['free_percent'], 1) }}%)</span>
+        <span class="hidden 2xl:inline text-neutral-300 dark:text-white/15">·</span>
+        <span class="hidden 2xl:inline tabular-nums text-neutral-500 dark:text-fg-faint">{{ number_format($metrics['disk']['total_gib'], 1) }}G</span>
+    </div>
+
+    <div class="hidden min-[1900px]:flex shrink-0 items-center gap-1.5 rounded-lg border border-neutral-200 bg-neutral-50/70 px-2 py-1 dark:border-white/[0.06] dark:bg-white/[0.03]"
+        title="Linux load averages for 1, 5 and 15 minutes">
+        <span class="font-semibold text-neutral-700 dark:text-fg">LOAD</span>
+        <span class="tabular-nums">{{ number_format($metrics['load']['one'], 2) }}</span>
+        <span class="text-neutral-300 dark:text-white/15">·</span>
+        <span class="tabular-nums">{{ number_format($metrics['load']['five'], 2) }}</span>
+        <span class="text-neutral-300 dark:text-white/15">·</span>
+        <span class="tabular-nums">{{ number_format($metrics['load']['fifteen'], 2) }}</span>
+    </div>
+</div>

--- a/tests/Feature/HostVitalsTopbarTest.php
+++ b/tests/Feature/HostVitalsTopbarTest.php
@@ -1,0 +1,31 @@
+<?php
+
+it('shows local host vitals only to self-hosted instance admins', function () {
+    $layout = file_get_contents(resource_path('views/layouts/app.blade.php'));
+
+    expect($layout)
+        ->toContain('@if (isInstanceAdmin() && ! isCloud())')
+        ->toContain('<livewire:host-vitals />');
+});
+
+it('keeps host vitals polling conservative in the desktop top bar', function () {
+    $view = file_get_contents(resource_path('views/livewire/host-vitals.blade.php'));
+
+    expect($view)
+        ->toContain('wire:init="refreshVitals"')
+        ->toContain('wire:poll.15s="refreshVitals"')
+        ->toContain('min-[1440px]:flex')
+        ->toContain('min-[1900px]:flex');
+});
+
+it('reads cpu memory disk and load from local host sources', function () {
+    $component = file_get_contents(app_path('Livewire/HostVitals.php'));
+
+    expect($component)
+        ->toContain("file_get_contents('/proc/cpuinfo')")
+        ->toContain("file_get_contents('/proc/meminfo')")
+        ->toContain("disk_total_space('/')")
+        ->toContain("disk_free_space('/')")
+        ->toContain('sys_getloadavg()')
+        ->toContain('isCloud() || ! isInstanceAdmin()');
+});


### PR DESCRIPTION
## Changes

- Adds compact host vitals to the desktop top bar for self-hosted instance admins.
- Shows CPU used/free, RAM used/available/total, disk used/free/total, and 1m/5m/15m load values.
- Uses conservative 15-second polling and responsive hiding for lower-priority values at narrower widths.
- Adds focused feature coverage for visibility, polling behavior, and local CPU/RAM/disk/load sources.

## Issues

- Discussion: https://github.com/coollabsio/coolify/discussions/11483

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

![Host vitals showing CPU, RAM and disk metrics](https://raw.githubusercontent.com/AAA-It-uae/coolify-community-enhancements/main/assets/screenshots/server-vitals-cpu-ram-disk.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: coding assistance
- How extensively: implementation support; changes were manually reviewed and validated on a local Coolify development instance.

## Testing

- Rebased onto the current `next` branch before validation.
- Built the official Coolify development image from the exact PR head commit.
- Started an isolated development stack with Coolify, PostgreSQL and Redis using separate containers, network and volumes.
- Waited for the official development init flow to complete, then verified the HTTP health endpoint from both inside the container and the host.
- Ran `php artisan test tests/Feature/HostVitalsTopbarTest.php`: 3 tests passed, 12 assertions.
- Ran Blade view cache/compile successfully.
- Ran a runtime metrics probe confirming CPU, RAM, disk and load values were populated from local system sources.
- Removed all temporary containers, network, volumes and test image after validation.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.