### PR TITLE
feat(gitlab): register project webhooks automatically for GitLab Apps

### DIFF
--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -11,6 +11,7 @@ use App\Enums\ApplicationDeploymentStatus;
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
 use App\Models\ApplicationPreview;
+use App\Models\GitlabApp;
 use App\Models\Service;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
@@ -99,6 +100,16 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             ]);
         }
 
+        try {
+            $this->removeGitlabProjectWebhookIfUnused();
+        } catch (\Throwable $e) {
+            Log::warning('Could not remove the GitLab webhook while deleting a resource; continuing with local deletion.', [
+                'resource_id' => $this->resource->id,
+                'resource_type' => $this->resource->type(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+
         DB::transaction(function (): void {
             try {
                 $this->deleteScheduledVolumeBackups();
@@ -131,6 +142,35 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
         });
 
         Artisan::queue('cleanup:stucked-resources');
+    }
+
+    /**
+     * Drop the project hook Coolify registered in GitLab, unless another application still
+     * deploys the same GitLab project through the same source.
+     */
+    private function removeGitlabProjectWebhookIfUnused(): void
+    {
+        if (! $this->resource instanceof Application) {
+            return;
+        }
+
+        $source = $this->resource->source;
+
+        if (! $source instanceof GitlabApp || blank($this->resource->repository_project_id)) {
+            return;
+        }
+
+        $stillUsed = Application::where('source_id', $source->id)
+            ->where('source_type', $source->getMorphClass())
+            ->where('repository_project_id', $this->resource->repository_project_id)
+            ->whereKeyNot($this->resource->getKey())
+            ->exists();
+
+        if ($stillUsed) {
+            return;
+        }
+
+        removeGitlabProjectWebhook($source, (int) $this->resource->repository_project_id);
     }
 
     private function isDatabase(): bool

--- a/app/Livewire/Project/New/GitlabPrivateRepository.php
+++ b/app/Livewire/Project/New/GitlabPrivateRepository.php
@@ -8,6 +8,7 @@ use App\Models\Project;
 use App\Rules\ValidGitBranch;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Livewire\Component;
 
@@ -218,6 +219,8 @@ class GitlabPrivateRepository extends Component
             $application->name = generate_application_name($this->selected_repository_path, $this->selected_branch_name, $application->uuid);
             $application->save();
 
+            $this->registerWebhook($gitlab_app, $application);
+
             return redirect()->route('project.application.configuration', [
                 'application_uuid' => $application->uuid,
                 'environment_uuid' => $environment->uuid,
@@ -225,6 +228,25 @@ class GitlabPrivateRepository extends Component
             ]);
         } catch (\Throwable $e) {
             return handleError($e, $this);
+        }
+    }
+
+    /**
+     * GitLab OAuth applications have no app-level webhook like GitHub Apps, so the project hook
+     * has to be registered explicitly. A failure here must not discard the created application:
+     * the webhook can be retried from the application's Webhooks tab.
+     */
+    private function registerWebhook(GitlabApp $gitlab_app, Application $application): void
+    {
+        try {
+            syncGitlabProjectWebhook($gitlab_app, $this->selected_project_id);
+        } catch (\Throwable $e) {
+            Log::warning('Could not register the GitLab webhook for a new application.', [
+                'application_id' => $application->id,
+                'gitlab_app_id' => $gitlab_app->id,
+                'project_id' => $this->selected_project_id,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/Livewire/Project/Shared/Webhooks.php
+++ b/app/Livewire/Project/Shared/Webhooks.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Project\Shared;
 
+use App\Models\Application;
+use App\Models\GitlabApp;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
@@ -30,9 +32,27 @@ class Webhooks extends Component
 
     public ?string $giteaManualWebhookSecret = null;
 
+    public ?string $gitlabAppWebhookUrl = null;
+
+    /**
+     * One of: unknown, active, missing, error.
+     */
+    public string $gitlabAppWebhookState = 'unknown';
+
+    public ?string $gitlabAppWebhookMessage = null;
+
     public function mount()
     {
         $this->deploywebhook = generateDeployWebhook($this->resource);
+
+        if ($this->gitlabSource()) {
+            try {
+                $this->gitlabAppWebhookUrl = gitlabWebhookUrl($this->gitlabSource());
+            } catch (\Throwable $e) {
+                $this->gitlabAppWebhookState = 'error';
+                $this->gitlabAppWebhookMessage = $e->getMessage();
+            }
+        }
 
         if ($this->canViewSecrets()) {
             $this->githubManualWebhookSecret = data_get($this->resource, 'manual_webhook_secret_github');
@@ -50,6 +70,71 @@ class Webhooks extends Component
     public function canViewSecrets(): bool
     {
         return auth()->user()->can('update', $this->resource);
+    }
+
+    /**
+     * The GitLab App backing this application, when the repository is connected through one.
+     */
+    public function gitlabSource(): ?GitlabApp
+    {
+        if (! $this->resource instanceof Application) {
+            return null;
+        }
+
+        $source = $this->resource->source;
+
+        if (! $source instanceof GitlabApp) {
+            return null;
+        }
+
+        return blank($this->resource->repository_project_id) ? null : $source;
+    }
+
+    /**
+     * Ask GitLab whether the project hook still exists. Kept out of mount() so a slow or
+     * unreachable GitLab instance never blocks rendering the page.
+     */
+    public function checkGitlabAppWebhook(): void
+    {
+        $source = $this->gitlabSource();
+        if (! $source) {
+            return;
+        }
+
+        try {
+            $existing = findGitlabProjectWebhook($source, (int) $this->resource->repository_project_id);
+            $this->gitlabAppWebhookState = $existing ? 'active' : 'missing';
+            $this->gitlabAppWebhookMessage = null;
+        } catch (\Throwable $e) {
+            $this->gitlabAppWebhookState = 'error';
+            $this->gitlabAppWebhookMessage = $e->getMessage();
+        }
+    }
+
+    public function syncGitlabAppWebhook()
+    {
+        try {
+            $this->authorize('update', $this->resource);
+
+            $source = $this->gitlabSource();
+            if (! $source) {
+                throw new \RuntimeException('This application is not connected to a GitLab App.');
+            }
+
+            $result = syncGitlabProjectWebhook($source, (int) $this->resource->repository_project_id);
+
+            $this->gitlabAppWebhookState = 'active';
+            $this->gitlabAppWebhookMessage = null;
+
+            $this->dispatch('success', $result['status'] === 'created'
+                ? 'Webhook created in GitLab.'
+                : 'Webhook updated in GitLab.');
+        } catch (\Throwable $e) {
+            $this->gitlabAppWebhookState = 'error';
+            $this->gitlabAppWebhookMessage = $e->getMessage();
+
+            return handleError($e, $this);
+        }
     }
 
     public function submit()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,7 @@ class AppServiceProvider extends ServiceProvider
         $this->configurePasswords();
         $this->configureSanctumModel();
         $this->configureGitHubHttp();
+        $this->configureGitLabHttp();
         $this->configureOidcSocialite();
     }
 
@@ -97,6 +98,20 @@ class AppServiceProvider extends ServiceProvider
                     'Accept' => 'application/vnd.github.v3+json',
                 ])->baseUrl($api_url);
             }
+        });
+    }
+
+    private function configureGitLabHttp(): void
+    {
+        Http::macro('GitLab', function (string $api_url, ?string $access_token = null) {
+            $client = Http::withHeaders([
+                'Accept' => 'application/json',
+            ])->baseUrl($api_url);
+            if ($access_token) {
+                $client = $client->withToken($access_token);
+            }
+
+            return $client;
         });
     }
 }

--- a/bootstrap/helpers/gitlab.php
+++ b/bootstrap/helpers/gitlab.php
@@ -160,3 +160,109 @@ function loadGitlabBranches(GitlabApp $source, int $projectId, int $page = 1): a
 
     return $response->json();
 }
+
+/**
+ * Public URL GitLab must call for the push / merge request events of this source.
+ *
+ * The base is taken from the OAuth redirect URI the user already validated against GitLab,
+ * so the webhook lands on the same public endpoint (tunnel, reverse proxy, custom domain).
+ */
+function gitlabWebhookUrl(GitlabApp $source): string
+{
+    $base = filled($source->redirect_uri)
+        ? rtrim(str($source->redirect_uri)->before('/webhooks/source/gitlab/redirect')->toString(), '/')
+        : '';
+
+    if (blank($base)) {
+        $base = rtrim((string) config('app.url'), '/');
+    }
+
+    if (blank($base)) {
+        throw new RuntimeException('Coolify has no public URL configured. Set the instance FQDN before configuring GitLab webhooks.');
+    }
+
+    return $base.'/webhooks/source/gitlab/events';
+}
+
+/**
+ * Find the Coolify webhook already registered on a GitLab project.
+ *
+ * @return array{id: int, url: string}|null
+ */
+function findGitlabProjectWebhook(GitlabApp $source, int $projectId, ?string $url = null): ?array
+{
+    $url ??= gitlabWebhookUrl($source);
+
+    $hooks = gitlabApi($source, "/projects/{$projectId}/hooks?per_page=100")['data'];
+
+    $hook = $hooks->first(
+        fn ($hook): bool => rtrim((string) data_get($hook, 'url'), '/') === rtrim($url, '/')
+    );
+
+    if (! $hook) {
+        return null;
+    }
+
+    return [
+        'id' => (int) data_get($hook, 'id'),
+        'url' => (string) data_get($hook, 'url'),
+    ];
+}
+
+/**
+ * Create (or refresh) the Coolify webhook on a GitLab project so pushes deploy automatically.
+ *
+ * GitLab OAuth applications have no app-level webhook like GitHub Apps do, so Coolify has to
+ * register a project hook itself. Requires the Maintainer role on the project.
+ *
+ * @return array{status: string, id: int, url: string}
+ */
+function syncGitlabProjectWebhook(GitlabApp $source, int $projectId): array
+{
+    if (! $source->isConnected()) {
+        throw new RuntimeException('This GitLab source is not connected. Authorize it before configuring webhooks.');
+    }
+
+    $token = (string) $source->webhook_token;
+    if (blank($token)) {
+        throw new RuntimeException('This GitLab source has no webhook token. Save the source again to generate one.');
+    }
+
+    $url = gitlabWebhookUrl($source);
+
+    $payload = [
+        'url' => $url,
+        'token' => $token,
+        'push_events' => true,
+        'merge_requests_events' => true,
+        'enable_ssl_verification' => str_starts_with($url, 'https://'),
+    ];
+
+    $existing = findGitlabProjectWebhook($source, $projectId, $url);
+
+    if ($existing) {
+        gitlabApi($source, "/projects/{$projectId}/hooks/{$existing['id']}", 'put', $payload);
+
+        return ['status' => 'updated', 'id' => $existing['id'], 'url' => $url];
+    }
+
+    $created = gitlabApi($source, "/projects/{$projectId}/hooks", 'post', $payload)['data'];
+
+    return ['status' => 'created', 'id' => (int) data_get($created, 'id'), 'url' => $url];
+}
+
+/**
+ * Remove the Coolify webhook from a GitLab project. Returns false when there was nothing to remove.
+ */
+function removeGitlabProjectWebhook(GitlabApp $source, int $projectId): bool
+{
+    $existing = findGitlabProjectWebhook($source, $projectId);
+
+    if (! $existing) {
+        return false;
+    }
+
+    gitlabApi($source, "/projects/{$projectId}/hooks/{$existing['id']}", 'delete');
+
+    return true;
+}

--- a/resources/views/livewire/project/shared/webhooks.blade.php
+++ b/resources/views/livewire/project/shared/webhooks.blade.php
@@ -86,6 +86,39 @@
                         </div>
                     </x-application.settings-section>
                 </form>
+            @elseif ($this->gitlabSource())
+                <x-application.settings-section id="gitlab-app-webhook-section" title="Repository webhook"
+                    helper="Coolify registers this webhook in GitLab so pushes and merge requests deploy automatically. Sync it again if it was removed in GitLab or if this instance URL changed."
+                    wire:init="checkGitlabAppWebhook">
+                    <x-slot:actions>
+                        @can('update', $resource)
+                            <x-forms.button wire:click="syncGitlabAppWebhook" wire:target="syncGitlabAppWebhook">
+                                Sync webhook
+                            </x-forms.button>
+                        @endcan
+                    </x-slot:actions>
+
+                    <div class="flex flex-col gap-4">
+                        <div class="text-[13px] leading-5">
+                            @if ($gitlabAppWebhookState === 'active')
+                                <span class="font-medium text-success">Active</span>
+                                <span class="text-neutral-500 dark:text-fg-dim">— GitLab notifies Coolify on every
+                                    push.</span>
+                            @elseif ($gitlabAppWebhookState === 'missing')
+                                <span class="font-medium text-warning">Not configured</span>
+                                <span class="text-neutral-500 dark:text-fg-dim">— automatic deployments are off until
+                                    the webhook is synced.</span>
+                            @elseif ($gitlabAppWebhookState === 'error')
+                                <span class="font-medium text-error">Could not read the webhook</span>
+                                <span class="text-neutral-500 dark:text-fg-dim">— {{ $gitlabAppWebhookMessage }}</span>
+                            @else
+                                <span class="text-neutral-500 dark:text-fg-dim">Checking the webhook in GitLab…</span>
+                            @endif
+                        </div>
+
+                        <x-forms.copy-input label="Webhook URL" :text="$gitlabAppWebhookUrl ?? ''" />
+                    </div>
+                </x-application.settings-section>
             @else
                 <x-application.settings-section id="manual-git-webhooks-section" title="Manual Git webhooks"
                     helper="Manual repository webhooks are only required when a repository is not connected through an official Git App.">

--- a/resources/views/livewire/source/gitlab/change.blade.php
+++ b/resources/views/livewire/source/gitlab/change.blade.php
@@ -211,6 +211,10 @@
                             <code class="rounded bg-neutral-100 px-1.5 py-0.5 text-[11px] dark:bg-white/[0.06]">read_repository</code>
                         </li>
                         <li>Uncheck <strong class="text-black dark:text-fg">Confidential</strong> if you run into issues</li>
+                        <li>
+                            The authorizing user needs the <strong class="text-black dark:text-fg">Maintainer</strong>
+                            role on the projects you deploy, so Coolify can register their webhooks for you
+                        </li>
                     </ul>
                 </div>
             </x-application.settings-section>

--- a/tests/Feature/GitlabAppWebhookManagementTest.php
+++ b/tests/Feature/GitlabAppWebhookManagementTest.php
@@ -1,0 +1,265 @@
+<?php
+
+use App\Jobs\DeleteResourceJob;
+use App\Livewire\Project\New\GitlabPrivateRepository;
+use App\Livewire\Project\Shared\Webhooks;
+use App\Models\Application;
+use App\Models\GitlabApp;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+const COOLIFY_GITLAB_EVENTS_URL = 'https://coolify.example.test/webhooks/source/gitlab/events';
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::updateOrCreate(['id' => 0], ['id' => 0]));
+
+    $this->team = Team::factory()->create();
+
+    $this->admin = User::factory()->create();
+    $this->admin->teams()->attach($this->team, ['role' => 'admin']);
+
+    $this->member = User::factory()->create();
+    $this->member->teams()->attach($this->team, ['role' => 'member']);
+
+    $keyId = DB::table('private_keys')->insertGetId([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'Test Key',
+        'private_key' => 'test-key',
+        'team_id' => $this->team->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $keyId,
+    ]);
+
+    $this->destination = StandaloneDocker::withoutEvents(fn () => StandaloneDocker::firstOrCreate(
+        ['server_id' => $server->id, 'network' => 'coolify'],
+        ['uuid' => (string) Str::uuid(), 'name' => 'test-docker']
+    ));
+
+    $this->project = Project::create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'Test Project',
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->environment = $this->project->environments()->first();
+
+    $this->gitlabApp = GitlabApp::create([
+        'name' => 'Test GitLab',
+        'api_url' => 'https://gitlab.example.test/api/v4',
+        'html_url' => 'https://gitlab.example.test',
+        'redirect_uri' => 'https://coolify.example.test/webhooks/source/gitlab/redirect',
+        'custom_user' => 'git',
+        'custom_port' => 22,
+        'webhook_token' => 'webhook-token-value', // ggignore
+        'access_token' => str_repeat('t', 20), // ggignore
+        'refresh_token' => str_repeat('r', 20), // ggignore
+        'expires_at' => time() + 3600,
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->application = Application::factory()->create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'Test App',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'source_id' => $this->gitlabApp->id,
+        'source_type' => $this->gitlabApp->getMorphClass(),
+        'repository_project_id' => 42,
+        'git_repository' => 'team/app',
+        'git_branch' => 'main',
+    ]);
+});
+
+it('exposes the GitLab events endpoint on the webhooks page', function () {
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->assertSet('gitlabAppWebhookUrl', COOLIFY_GITLAB_EVENTS_URL)
+        ->assertSet('gitlabAppWebhookState', 'unknown')
+        ->assertSee('Repository webhook');
+});
+
+it('reports the webhook as active when GitLab already has it', function () {
+    Http::fake(fn (Request $request) => Http::response([
+        ['id' => 9, 'url' => COOLIFY_GITLAB_EVENTS_URL],
+    ], 200));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->call('checkGitlabAppWebhook')
+        ->assertSet('gitlabAppWebhookState', 'active');
+});
+
+it('reports the webhook as missing when GitLab does not have it', function () {
+    Http::fake(fn (Request $request) => Http::response([], 200));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->call('checkGitlabAppWebhook')
+        ->assertSet('gitlabAppWebhookState', 'missing');
+});
+
+it('surfaces the GitLab error instead of failing the page', function () {
+    Http::fake(fn (Request $request) => Http::response(['message' => '403 Forbidden'], 403));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->call('checkGitlabAppWebhook')
+        ->assertSet('gitlabAppWebhookState', 'error')
+        ->assertSee('403 Forbidden');
+});
+
+it('lets an admin create the webhook from the webhooks page', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'POST'
+        ? Http::response(['id' => 7], 201)
+        : Http::response([], 200));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->call('syncGitlabAppWebhook')
+        ->assertSet('gitlabAppWebhookState', 'active')
+        ->assertDispatched('success');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/42/hooks'
+        && $request['url'] === COOLIFY_GITLAB_EVENTS_URL);
+});
+
+it('does not let a member create the webhook', function () {
+    Http::fake();
+
+    $this->actingAs($this->member);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application])
+        ->call('syncGitlabAppWebhook')
+        ->assertDispatched('error');
+
+    Http::assertNothingSent();
+});
+
+it('keeps the manual webhook form for applications without a Git App', function () {
+    $this->application->update(['source_id' => null, 'source_type' => null]);
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Webhooks::class, ['resource' => $this->application->fresh()])
+        ->assertSet('gitlabAppWebhookUrl', null)
+        ->assertSee('Manual Git webhooks')
+        ->assertDontSee('Repository webhook');
+});
+
+function runGitlabWebhookCleanup(Application $application): void
+{
+    $job = new DeleteResourceJob($application);
+
+    (new ReflectionMethod($job, 'removeGitlabProjectWebhookIfUnused'))->invoke($job);
+}
+
+it('removes the GitLab webhook when the last application using the project is deleted', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'GET'
+        ? Http::response([['id' => 9, 'url' => COOLIFY_GITLAB_EVENTS_URL]], 200)
+        : Http::response(null, 204));
+
+    runGitlabWebhookCleanup($this->application);
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/42/hooks/9');
+});
+
+it('keeps the GitLab webhook while another application still deploys the same project', function () {
+    Application::factory()->create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'Second App',
+        'environment_id' => $this->application->environment_id,
+        'destination_id' => $this->application->destination_id,
+        'destination_type' => $this->application->destination_type,
+        'source_id' => $this->gitlabApp->id,
+        'source_type' => $this->gitlabApp->getMorphClass(),
+        'repository_project_id' => 42,
+        'git_repository' => 'team/app',
+        'git_branch' => 'staging',
+    ]);
+
+    Http::fake();
+
+    runGitlabWebhookCleanup($this->application);
+
+    Http::assertNothingSent();
+});
+
+it('registers the GitLab webhook when an application is created from a GitLab App', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'POST'
+        ? Http::response(['id' => 7], 201)
+        : Http::response([], 200));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(GitlabPrivateRepository::class, ['type' => 'private-gitlab-app'])
+        ->set('gitlab_app_id', $this->gitlabApp->id)
+        ->set('selected_gitlab_app_id', $this->gitlabApp->id)
+        ->set('selected_project_id', 77)
+        ->set('selected_repository_path', 'team/new-app')
+        ->set('selected_branch_name', 'main')
+        ->set('parameters', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+        ])
+        ->set('query', ['destination' => $this->destination->uuid])
+        ->call('submit');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/77/hooks'
+        && $request['url'] === COOLIFY_GITLAB_EVENTS_URL);
+});
+
+it('still creates the application when GitLab refuses the webhook', function () {
+    Http::fake(fn (Request $request) => Http::response(['message' => '403 Forbidden'], 403));
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(GitlabPrivateRepository::class, ['type' => 'private-gitlab-app'])
+        ->set('gitlab_app_id', $this->gitlabApp->id)
+        ->set('selected_gitlab_app_id', $this->gitlabApp->id)
+        ->set('selected_project_id', 78)
+        ->set('selected_repository_path', 'team/other-app')
+        ->set('selected_branch_name', 'main')
+        ->set('parameters', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+        ])
+        ->set('query', ['destination' => $this->destination->uuid])
+        ->call('submit');
+
+    expect(Application::where('repository_project_id', 78)->exists())->toBeTrue();
+});

--- a/tests/Feature/GitlabProjectWebhookTest.php
+++ b/tests/Feature/GitlabProjectWebhookTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Models\GitlabApp;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Model::encryptUsing(new Encrypter(str_repeat('a', 32), 'AES-256-CBC'));
+});
+
+afterEach(function () {
+    Model::encryptUsing(null);
+});
+
+function connectedGitlabSource(array $overrides = []): GitlabApp
+{
+    return new GitlabApp(array_merge([
+        'api_url' => 'https://gitlab.example.test/api/v4',
+        'html_url' => 'https://gitlab.example.test',
+        'redirect_uri' => 'https://coolify.example.test/webhooks/source/gitlab/redirect',
+        'webhook_token' => 'webhook-token-value', // ggignore
+        'access_token' => str_repeat('t', 20), // ggignore
+        'refresh_token' => str_repeat('r', 20), // ggignore
+        'expires_at' => time() + 3600,
+    ], $overrides));
+}
+
+it('derives the events webhook URL from the OAuth redirect URI', function () {
+    expect(gitlabWebhookUrl(connectedGitlabSource()))
+        ->toBe('https://coolify.example.test/webhooks/source/gitlab/events');
+});
+
+it('falls back to the instance URL when the source has no redirect URI', function () {
+    config()->set('app.url', 'https://fallback.example.test/');
+
+    expect(gitlabWebhookUrl(connectedGitlabSource(['redirect_uri' => null])))
+        ->toBe('https://fallback.example.test/webhooks/source/gitlab/events');
+});
+
+it('creates the project webhook when GitLab has none', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'POST'
+        ? Http::response(['id' => 7], 201)
+        : Http::response([], 200));
+
+    $result = syncGitlabProjectWebhook(connectedGitlabSource(), 42);
+
+    expect($result)->toBe([
+        'status' => 'created',
+        'id' => 7,
+        'url' => 'https://coolify.example.test/webhooks/source/gitlab/events',
+    ]);
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/42/hooks'
+        && $request['url'] === 'https://coolify.example.test/webhooks/source/gitlab/events'
+        && $request['token'] === 'webhook-token-value' // ggignore
+        && $request['push_events'] === true
+        && $request['merge_requests_events'] === true
+        && $request['enable_ssl_verification'] === true);
+});
+
+it('updates the existing project webhook instead of adding a duplicate', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'GET'
+        ? Http::response([
+            ['id' => 3, 'url' => 'https://someone-else.example.test/hook'],
+            ['id' => 9, 'url' => 'https://coolify.example.test/webhooks/source/gitlab/events'],
+        ], 200)
+        : Http::response(['id' => 9], 200));
+
+    $result = syncGitlabProjectWebhook(connectedGitlabSource(), 42);
+
+    expect($result['status'])->toBe('updated');
+    expect($result['id'])->toBe(9);
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'PUT'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/42/hooks/9');
+    Http::assertNotSent(fn (Request $request) => $request->method() === 'POST');
+});
+
+it('disables SSL verification hints for plain http instances', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'POST'
+        ? Http::response(['id' => 1], 201)
+        : Http::response([], 200));
+
+    syncGitlabProjectWebhook(connectedGitlabSource([
+        'redirect_uri' => 'http://192.168.1.10:8000/webhooks/source/gitlab/redirect',
+    ]), 42);
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && $request['enable_ssl_verification'] === false);
+});
+
+it('refuses to configure a webhook for a source that is not connected', function () {
+    Http::fake();
+
+    syncGitlabProjectWebhook(connectedGitlabSource(['access_token' => null, 'refresh_token' => null]), 42);
+})->throws(RuntimeException::class, 'not connected');
+
+it('removes only the webhook that points at this Coolify instance', function () {
+    Http::fake(fn (Request $request) => $request->method() === 'GET'
+        ? Http::response([
+            ['id' => 3, 'url' => 'https://someone-else.example.test/hook'],
+            ['id' => 9, 'url' => 'https://coolify.example.test/webhooks/source/gitlab/events'],
+        ], 200)
+        : Http::response(null, 204));
+
+    expect(removeGitlabProjectWebhook(connectedGitlabSource(), 42))->toBeTrue();
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
+        && $request->url() === 'https://gitlab.example.test/api/v4/projects/42/hooks/9');
+});
+
+it('reports nothing to remove when GitLab has no Coolify webhook', function () {
+    Http::fake(fn (Request $request) => Http::response([
+        ['id' => 3, 'url' => 'https://someone-else.example.test/hook'],
+    ], 200));
+
+    expect(removeGitlabProjectWebhook(connectedGitlabSource(), 42))->toBeFalse();
+
+    Http::assertNotSent(fn (Request $request) => $request->method() === 'DELETE');
+});


### PR DESCRIPTION
## Problem

A GitLab App source connects the repository, but nothing configures the repository webhook. Every project has to have its webhook added by hand in GitLab before a push deploys — even though the Webhooks tab tells the user the opposite ("This application uses an official Git App, so Coolify configures repository webhooks automatically"), and the source picker advertises "with automatic webhooks and merge request previews".

The gap is structural, not accidental: a GitHub App carries its webhook at the App level, so one URL covers every repository of the installation. A GitLab OAuth application has no equivalent — hooks live on the project (`POST /projects/:id/hooks`), or on the group, which is Premium-only. So Coolify has to register them itself, and today it never does.

Everything needed was already in place:

- the OAuth scope requested already includes `api` (`app/Livewire/Source/Gitlab/Change.php`), so the token may manage hooks;
- `gitlabApi()` already supports `post`/`put`/`delete`;
- `/webhooks/source/gitlab/events` already resolves the source by webhook token and the application by `repository_project_id`, so **one hook per project** is enough.

## What this PR does

New helpers in `bootstrap/helpers/gitlab.php`:

- `gitlabWebhookUrl()` — derives the events endpoint from the OAuth redirect URI the user already validated against GitLab, so tunnels, reverse proxies and custom public endpoints keep working;
- `findGitlabProjectWebhook()` / `syncGitlabProjectWebhook()` / `removeGitlabProjectWebhook()` — idempotent: an existing Coolify hook is updated rather than duplicated, and hooks belonging to other services are never touched.

Wired into three places:

1. **Application creation** (`GitlabPrivateRepository::submit`) registers the hook with `push_events` + `merge_requests_events` and the source webhook token. A failure never discards the created application — it is logged and left for the user to retry.
2. **Webhooks tab** gains a *Repository webhook* section for GitLab App applications: it reports whether GitLab still has the hook (`wire:init`, so a slow GitLab never blocks the page) and offers a **Sync webhook** action, gated on `update` on the resource. GitLab's own error message is surfaced there — a missing Maintainer role is the common case.
3. **Deletion** (`DeleteResourceJob`) removes the hook, unless another application still deploys the same project through the same source.

The setup page now also states that the authorizing user needs the **Maintainer** role on the projects being deployed.

## Second commit — a regression on `next`

While testing on `next` I found that `Http::macro('GitLab', ...)` has disappeared from `AppServiceProvider` (lost in the revert/reapply merges), while `bootstrap/helpers/gitlab.php` still calls `Http::GitLab(...)`. On `next` today **every** GitLab API call throws:

```
BadMethodCallException: Method Illuminate\Http\Client\PendingRequest::GitLab does not exist.
```

That breaks repository listing, branch listing and clone-token refresh, not just this feature. The second commit restores the macro verbatim from `main`. Happy to split it into its own PR if you would rather land it separately.

## Tests

`tests/Feature/GitlabProjectWebhookTest.php` (8) — URL derivation, create, update-instead-of-duplicate, `enable_ssl_verification` for plain-HTTP instances, refusal on a disconnected source, and removal that only touches Coolify's own hook.

`tests/Feature/GitlabAppWebhookManagementTest.php` (11) — the Webhooks tab states (active / missing / error), admin sync, member refused, manual form untouched for non-Git-App applications, hook registered on application creation, application still created when GitLab refuses, and the delete-time cleanup including the shared-project case.

```
Tests: 19 passed (34 assertions)
```

Three failures remain in `tests/Feature/GitlabSourceChangeViewTest.php` and `tests/Feature/Authorization/SharedResourceAuthorizationTest.php`; they are pre-existing on `next` (assertions on copy that no longer matches the blades) and unrelated to these changes.

## Not covered

Group-level webhooks (`POST /groups/:id/hooks`) would register one hook for a whole group, but they are GitLab Premium — the per-project hook is the path that works on every tier, self-hosted included.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
