### PR TITLE
feat(ui): add project operational context

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server;
+use App\Support\ProjectStatusAggregator;
 use Illuminate\Support\Collection;
 use Livewire\Component;
 
@@ -15,6 +16,8 @@ class Dashboard extends Component
     public Collection $servers;
 
     public Collection $privateKeys;
+
+    public array $projectStatuses = [];
 
     public function mount()
     {
@@ -35,6 +38,8 @@ class Dashboard extends Component
                 'mariadbs',
             ])
             ->get();
+
+        $this->projectStatuses = ProjectStatusAggregator::forProjects($this->projects);
     }
 
     public function render()

--- a/app/Livewire/Project/Index.php
+++ b/app/Livewire/Project/Index.php
@@ -3,12 +3,18 @@
 namespace App\Livewire\Project;
 
 use App\Models\Project;
+use App\Support\ProjectDomainAggregator;
+use App\Support\ProjectStatusAggregator;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
 class Index extends Component
 {
     public $projects;
+
+    public array $projectStatuses = [];
+
+    public array $projectDomains = [];
 
     public function mount(): void
     {
@@ -29,6 +35,9 @@ class Index extends Component
                 'mariadbs',
             ])
             ->get();
+
+        $this->projectStatuses = ProjectStatusAggregator::forProjects($this->projects);
+        $this->projectDomains = ProjectDomainAggregator::forProjects($this->projects);
     }
 
     public function render(): View
@@ -60,6 +69,9 @@ class Index extends Component
                     'href' => $project->navigateTo(),
                     'environmentCount' => $project->environments->count(),
                     'resourceCount' => $resourceCount,
+                    'statusLabel' => data_get($this->projectStatuses, $project->uuid.'.label', 'Unknown'),
+                    'statusType' => data_get($this->projectStatuses, $project->uuid.'.type', 'neutral'),
+                    'domains' => data_get($this->projectDomains, $project->uuid, []),
                     'settingsHref' => auth()->user()->can('update', $project)
                         ? route('project.edit', ['project_uuid' => $project->uuid])
                         : null,

--- a/app/Support/ProjectDomainAggregator.php
+++ b/app/Support/ProjectDomainAggregator.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+final class ProjectDomainAggregator
+{
+    public static function forProjects(Collection $projects): array
+    {
+        if ($projects->isEmpty()) {
+            return [];
+        }
+
+        $projectIds = $projects->pluck('id')->map(fn ($id) => (int) $id)->sort()->values();
+        $cacheKey = 'project-dashboard-domains:v1:'.md5($projectIds->implode(','));
+
+        return Cache::remember($cacheKey, 10, function () use ($projects, $projectIds): array {
+            $byProjectId = [];
+            foreach ($projectIds as $projectId) {
+                $byProjectId[$projectId] = [];
+            }
+
+            $applications = DB::table('applications')
+                ->join('environments', 'environments.id', '=', 'applications.environment_id')
+                ->whereIn('environments.project_id', $projectIds)
+                ->whereNull('applications.deleted_at')
+                ->get([
+                    'environments.project_id as project_id',
+                    'applications.fqdn as fqdn',
+                    'applications.docker_compose_domains as docker_compose_domains',
+                ]);
+
+            foreach ($applications as $application) {
+                $projectId = (int) $application->project_id;
+                self::addRawDomains($byProjectId[$projectId], $application->fqdn);
+                self::addComposeDomains($byProjectId[$projectId], $application->docker_compose_domains);
+            }
+
+            $serviceApplications = DB::table('service_applications')
+                ->join('services', 'services.id', '=', 'service_applications.service_id')
+                ->join('environments', 'environments.id', '=', 'services.environment_id')
+                ->whereIn('environments.project_id', $projectIds)
+                ->whereNull('services.deleted_at')
+                ->whereNull('service_applications.deleted_at')
+                ->get([
+                    'environments.project_id as project_id',
+                    'service_applications.fqdn as fqdn',
+                ]);
+
+            foreach ($serviceApplications as $serviceApplication) {
+                $projectId = (int) $serviceApplication->project_id;
+                self::addRawDomains($byProjectId[$projectId], $serviceApplication->fqdn);
+            }
+
+            $result = [];
+            foreach ($projects as $project) {
+                $domains = array_values($byProjectId[(int) $project->id] ?? []);
+                usort($domains, fn (array $first, array $second) => strcasecmp($first['label'], $second['label']));
+                $result[$project->uuid] = $domains;
+            }
+
+            return $result;
+        });
+    }
+
+    private static function addRawDomains(array &$bucket, mixed $raw): void
+    {
+        if (! is_string($raw) || trim($raw) === '') {
+            return;
+        }
+
+        foreach (explode(',', $raw) as $value) {
+            self::addOne($bucket, $value);
+        }
+    }
+
+    private static function addComposeDomains(array &$bucket, mixed $raw): void
+    {
+        if (! is_string($raw) || trim($raw) === '') {
+            return;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            return;
+        }
+
+        array_walk_recursive($decoded, function ($value) use (&$bucket): void {
+            if (is_string($value)) {
+                self::addRawDomains($bucket, $value);
+            }
+        });
+    }
+
+    private static function addOne(array &$bucket, mixed $raw): void
+    {
+        if (! is_string($raw)) {
+            return;
+        }
+
+        $value = trim(html_entity_decode($raw, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $value = trim($value, " \t\n\r\0\x0B\"'");
+        if ($value === '') {
+            return;
+        }
+
+        if (str_starts_with($value, '//')) {
+            $value = 'https:'.$value;
+        } elseif (! preg_match('#^https?://#i', $value)) {
+            $value = 'https://'.$value;
+        }
+
+        $parts = parse_url($value);
+        if (! is_array($parts) || empty($parts['host'])) {
+            return;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? 'https'));
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return;
+        }
+
+        $host = strtolower((string) $parts['host']);
+        $port = isset($parts['port']) ? ':'.(int) $parts['port'] : '';
+        $path = (string) ($parts['path'] ?? '');
+        $path = $path === '/' ? '' : rtrim($path, '/');
+        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
+        $href = $scheme.'://'.$host.$port.$path.$query;
+        $key = strtolower(rtrim($href, '/'));
+
+        $bucket[$key] = [
+            'href' => $href,
+            'label' => $host.$port,
+        ];
+    }
+}

--- a/app/Support/ProjectStatusAggregator.php
+++ b/app/Support/ProjectStatusAggregator.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Project;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+final class ProjectStatusAggregator
+{
+    private const RELATIONS = [
+        'applications',
+        'services.applications',
+        'services.databases',
+        'postgresqls',
+        'redis',
+        'keydbs',
+        'dragonflies',
+        'clickhouses',
+        'mongodbs',
+        'mysqls',
+        'mariadbs',
+    ];
+
+    public static function forProjects(Collection $projects): array
+    {
+        if ($projects->isEmpty()) {
+            return [];
+        }
+
+        $projectIds = $projects->pluck('id')->map(fn ($id) => (int) $id)->sort()->values();
+        $cacheKey = 'project-dashboard-status:v1:'.md5($projectIds->implode(','));
+
+        return Cache::remember($cacheKey, 5, function () use ($projectIds): array {
+            $loaded = Project::query()
+                ->whereIn('id', $projectIds)
+                ->with(self::RELATIONS)
+                ->get();
+
+            return $loaded->mapWithKeys(function (Project $project): array {
+                return [$project->uuid => self::forLoadedProject($project)];
+            })->all();
+        });
+    }
+
+    private static function forLoadedProject(Project $project): array
+    {
+        $statuses = collect();
+        $resourceCount = 0;
+
+        foreach (['applications', 'postgresqls', 'redis', 'keydbs', 'dragonflies', 'clickhouses', 'mongodbs', 'mysqls', 'mariadbs'] as $relation) {
+            $resources = $project->{$relation};
+            $resourceCount += $resources->count();
+
+            foreach ($resources as $resource) {
+                self::pushStatus($statuses, data_get($resource, 'status'));
+            }
+        }
+
+        $resourceCount += $project->services->count();
+        foreach ($project->services as $service) {
+            self::pushStatus($statuses, $service->status);
+        }
+
+        if ($resourceCount === 0) {
+            return ['label' => 'Empty', 'type' => 'neutral'];
+        }
+
+        $hasUnhealthyRunning = $statuses->contains(function (string $status): bool {
+            return str_starts_with($status, 'degraded')
+                || (str_starts_with($status, 'running') && str_contains($status, 'unhealthy'));
+        });
+        if ($hasUnhealthyRunning) {
+            return ['label' => 'Unhealthy', 'type' => 'error'];
+        }
+
+        $hasStarting = $statuses->contains(function (string $status): bool {
+            return str_starts_with($status, 'starting')
+                || str_starts_with($status, 'restarting')
+                || str_starts_with($status, 'queued');
+        });
+        if ($hasStarting) {
+            return ['label' => 'Starting', 'type' => 'warning'];
+        }
+
+        if ($statuses->contains(fn (string $status): bool => str_starts_with($status, 'running'))) {
+            return ['label' => 'Running', 'type' => 'success'];
+        }
+
+        return ['label' => 'Stopped', 'type' => 'neutral'];
+    }
+
+    private static function pushStatus(Collection $statuses, mixed $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status !== '') {
+            $statuses->push($status);
+        }
+    }
+}

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -81,6 +81,21 @@
                                     <p class="mt-0.5 truncate text-[11px] text-neutral-500 dark:text-fg-faint">
                                         {{ $project->description ?: 'No description' }}
                                     </p>
+                                    @php
+                                        $projectStatus = $projectStatuses[$project->uuid] ?? ['label' => 'Unknown', 'type' => 'neutral'];
+                                        [$statusColor, $statusDot, $statusBg, $statusBorder] = match ($projectStatus['type']) {
+                                            'success' => ['#047857', '#10b981', 'rgba(16,185,129,.07)', 'rgba(16,185,129,.22)'],
+                                            'warning' => ['#b45309', '#f59e0b', 'rgba(245,158,11,.07)', 'rgba(245,158,11,.22)'],
+                                            'error' => ['#b91c1c', '#ef4444', 'rgba(239,68,68,.07)', 'rgba(239,68,68,.22)'],
+                                            default => ['#525252', '#a3a3a3', 'rgba(115,115,115,.05)', 'rgba(115,115,115,.18)'],
+                                        };
+                                    @endphp
+                                    <span class="mt-2 inline-flex w-fit items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-medium"
+                                        style="color:{{ $statusColor }};background:{{ $statusBg }};border-color:{{ $statusBorder }}"
+                                        title="Project status: {{ $projectStatus['label'] }}">
+                                        <span class="size-1.5 rounded-full" style="background:{{ $statusDot }}"></span>
+                                        {{ $projectStatus['label'] }}
+                                    </span>
                                 </div>
                             </div>
 

--- a/resources/views/livewire/project/index.blade.php
+++ b/resources/views/livewire/project/index.blade.php
@@ -64,7 +64,7 @@
                             <template x-for="option in sortOptions" :key="option.value">
                                 <button type="button"
                                     class="flex h-9 w-full items-center rounded-md px-2 text-left text-[12px] text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-black dark:text-fg-dim dark:hover:bg-white/[0.06] dark:hover:text-fg"
-                                    x-on:click="sortBy = option.value; close(); page = 1">
+                                    x-on:click="sortBy = option.value; localStorage.setItem('projects-sort', sortBy); close(); page = 1">
                                     <span class="flex-1" x-text="option.label"></span>
                                     <svg x-show="sortBy === option.value" class="size-3.5 text-warning"
                                         viewBox="0 0 12 12" fill="none" aria-hidden="true">
@@ -122,6 +122,29 @@
                                         x-text="project.name"></h2>
                                     <p class="mt-0.5 truncate text-[11px] text-neutral-500 dark:text-fg-faint"
                                         x-text="project.description || 'No description'"></p>
+                                    <span class="mt-2 inline-flex w-fit items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-medium"
+                                        :style="project.statusType === 'success' ? 'color:#047857;background:rgba(16,185,129,.07);border-color:rgba(16,185,129,.22)' : project.statusType === 'warning' ? 'color:#b45309;background:rgba(245,158,11,.07);border-color:rgba(245,158,11,.22)' : project.statusType === 'error' ? 'color:#b91c1c;background:rgba(239,68,68,.07);border-color:rgba(239,68,68,.22)' : 'color:#525252;background:rgba(115,115,115,.05);border-color:rgba(115,115,115,.18)'"
+                                        :title="`Project status: ${project.statusLabel}`">
+                                        <span class="size-1.5 rounded-full"
+                                            :style="project.statusType === 'success' ? 'background:#10b981' : project.statusType === 'warning' ? 'background:#f59e0b' : project.statusType === 'error' ? 'background:#ef4444' : 'background:#a3a3a3'"></span>
+                                        <span x-text="project.statusLabel"></span>
+                                    </span>
+                                    <div x-show="project.domains && project.domains.length"
+                                        class="relative z-10 mt-2 flex min-w-0 flex-wrap gap-1">
+                                        <template x-for="domain in project.domains.slice(0, 3)" :key="domain.href">
+                                            <a :href="domain.href" target="_blank" rel="noopener noreferrer" x-on:click.stop
+                                                class="inline-flex max-w-full items-center gap-1 rounded-md border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-[10.5px] font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:bg-neutral-100 hover:text-black dark:border-white/[0.09] dark:bg-white/[0.035] dark:text-fg-dim dark:hover:bg-white/[0.07] dark:hover:text-fg"
+                                                :title="domain.href">
+                                                <svg class="size-2.5 shrink-0 opacity-60" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                                                    <path d="M6.5 9.5 9.5 6.5M5.25 11.75H4a2.75 2.75 0 0 1 0-5.5h2M10.75 4.25H12a2.75 2.75 0 1 1 0 5.5h-2" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
+                                                </svg>
+                                                <span class="max-w-36 truncate" x-text="domain.label"></span>
+                                            </a>
+                                        </template>
+                                        <span x-show="project.domains.length > 3"
+                                            class="inline-flex items-center rounded-md border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-[10.5px] font-medium text-neutral-500 dark:border-white/[0.09] dark:bg-white/[0.035] dark:text-fg-faint"
+                                            x-text="`+${project.domains.length - 3}`"></span>
+                                    </div>
                                 </div>
                             </div>
 
@@ -157,19 +180,24 @@
             </div>
 
             <div x-show="viewMode === 'table'"
-                class="overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.025]">
+                class="rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.025]"
+                style="overflow-x:auto;">
                 <div
-                    class="projects-table-grid border-b border-neutral-200 bg-neutral-50 px-4 py-2.5 text-[11px] font-medium text-neutral-500 dark:border-white/[0.08] dark:bg-white/[0.025] dark:text-fg-faint">
+                    class="projects-table-grid border-b border-neutral-200 bg-neutral-50 px-4 py-2.5 text-[11px] font-medium text-neutral-500 dark:border-white/[0.08] dark:bg-white/[0.025] dark:text-fg-faint"
+                    style="min-width:1180px;grid-template-columns:minmax(230px,1.45fr) 115px 95px 85px minmax(260px,1.5fr) minmax(180px,1fr) 70px;">
                     <div>Project</div>
+                    <div>Status</div>
                     <div>Environments</div>
                     <div>Resources</div>
+                    <div>Domains</div>
                     <div class="project-description">Description</div>
                     <div></div>
                 </div>
 
                 <template x-for="project in paginatedProjects" :key="project.uuid">
                     <div
-                        class="projects-table-grid group min-h-14 items-center border-b border-neutral-200 px-4 py-2.5 transition-colors last:border-b-0 hover:bg-neutral-50 dark:border-white/[0.07] dark:hover:bg-white/[0.025]">
+                        class="projects-table-grid group min-h-14 items-center border-b border-neutral-200 px-4 py-2.5 transition-colors last:border-b-0 hover:bg-neutral-50 dark:border-white/[0.07] dark:hover:bg-white/[0.025]"
+                        style="min-width:1180px;grid-template-columns:minmax(230px,1.45fr) 115px 95px 85px minmax(260px,1.5fr) minmax(180px,1fr) 70px;">
                         <div class="flex min-w-0 items-center gap-3">
                             <div
                                 class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-neutral-200 bg-neutral-50 text-neutral-500 dark:border-white/[0.08] dark:bg-white/[0.035] dark:text-fg-dim">
@@ -185,10 +213,35 @@
                                 x-text="project.name"></a>
                         </div>
 
+                        <div>
+                            <span class="inline-flex w-fit items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-medium"
+                                :style="project.statusType === 'success' ? 'color:#047857;background:rgba(16,185,129,.07);border-color:rgba(16,185,129,.22)' : project.statusType === 'warning' ? 'color:#b45309;background:rgba(245,158,11,.07);border-color:rgba(245,158,11,.22)' : project.statusType === 'error' ? 'color:#b91c1c;background:rgba(239,68,68,.07);border-color:rgba(239,68,68,.22)' : 'color:#525252;background:rgba(115,115,115,.05);border-color:rgba(115,115,115,.18)'"
+                                :title="`Project status: ${project.statusLabel}`">
+                                <span class="size-1.5 rounded-full"
+                                    :style="project.statusType === 'success' ? 'background:#10b981' : project.statusType === 'warning' ? 'background:#f59e0b' : project.statusType === 'error' ? 'background:#ef4444' : 'background:#a3a3a3'"></span>
+                                <span x-text="project.statusLabel"></span>
+                            </span>
+                        </div>
+
                         <div class="text-[12px] text-neutral-600 dark:text-fg-dim"
                             x-text="project.environmentCount"></div>
                         <div class="text-[12px] text-neutral-600 dark:text-fg-dim"
                             x-text="project.resourceCount"></div>
+                        <div class="flex min-w-0 flex-wrap gap-1">
+                            <template x-if="!project.domains || project.domains.length === 0">
+                                <span class="text-[11px] text-neutral-400 dark:text-fg-faint">—</span>
+                            </template>
+                            <template x-for="domain in (project.domains || []).slice(0, 3)" :key="domain.href">
+                                <a :href="domain.href" target="_blank" rel="noopener noreferrer" x-on:click.stop
+                                    class="inline-flex max-w-36 items-center gap-1 rounded-md border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-[10.5px] font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:bg-neutral-100 hover:text-black dark:border-white/[0.09] dark:bg-white/[0.035] dark:text-fg-dim dark:hover:bg-white/[0.07] dark:hover:text-fg"
+                                    :title="domain.href">
+                                    <span class="truncate" x-text="domain.label"></span>
+                                </a>
+                            </template>
+                            <span x-show="project.domains && project.domains.length > 3"
+                                class="inline-flex items-center rounded-md border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-[10.5px] font-medium text-neutral-500 dark:border-white/[0.09] dark:bg-white/[0.035] dark:text-fg-faint"
+                                x-text="`+${project.domains.length - 3}`"></span>
+                        </div>
                         <p class="project-description truncate text-[12px] text-neutral-500 dark:text-fg-dim"
                             x-text="project.description || '-'"></p>
 
@@ -227,13 +280,17 @@
     function projectsIndex() {
         return {
             search: '',
-            sortBy: 'name-asc',
+            sortBy: localStorage.getItem('projects-sort') || 'running',
             sortOpen: false,
             viewMode: localStorage.getItem('projects-view') || 'grid',
             page: 1,
             pageSize: 12,
             projects: @js($projectsJs),
             sortOptions: [{
+                    value: 'running',
+                    label: 'Running first'
+                },
+                {
                     value: 'name-asc',
                     label: 'Name A–Z'
                 },
@@ -250,10 +307,16 @@
                     label: 'Most environments'
                 },
             ],
+            init() {
+                if (!this.sortOptions.some((option) => option.value === this.sortBy)) {
+                    this.sortBy = 'running';
+                    localStorage.setItem('projects-sort', this.sortBy);
+                }
+            },
             get filteredProjects() {
                 const query = this.search.trim().toLowerCase();
                 const projects = this.projects.filter((project) => {
-                    const searchable = [project.name, project.description]
+                    const searchable = [project.name, project.description, ...(project.domains || []).map((domain) => domain.label)]
                         .filter(Boolean)
                         .join(' ')
                         .toLowerCase();
@@ -262,6 +325,11 @@
                 });
 
                 return projects.sort((first, second) => {
+                    if (this.sortBy === 'running') {
+                        const priority = { success: 0, warning: 1, error: 2, neutral: 3 };
+                        return (priority[first.statusType] ?? 4) - (priority[second.statusType] ?? 4) ||
+                            first.name.localeCompare(second.name);
+                    }
                     if (this.sortBy === 'name-desc') {
                         return second.name.localeCompare(first.name);
                     }

--- a/tests/Feature/ProjectDashboardUxTest.php
+++ b/tests/Feature/ProjectDashboardUxTest.php
@@ -1,0 +1,55 @@
+<?php
+
+it('adds operational status and domains to project cards', function () {
+    $component = file_get_contents(app_path('Livewire/Project/Index.php'));
+    $view = file_get_contents(resource_path('views/livewire/project/index.blade.php'));
+
+    expect($component)
+        ->toContain('ProjectStatusAggregator::forProjects')
+        ->toContain('ProjectDomainAggregator::forProjects')
+        ->toContain("'statusLabel'")
+        ->toContain("'domains'");
+
+    expect($view)
+        ->toContain('Project status: ${project.statusLabel}')
+        ->toContain('project.domains.slice(0, 3)')
+        ->toContain('target="_blank" rel="noopener noreferrer"');
+});
+
+it('supports running first sorting and domain aware search', function () {
+    $view = file_get_contents(resource_path('views/livewire/project/index.blade.php'));
+
+    expect($view)
+        ->toContain("localStorage.getItem('projects-sort') || 'running'")
+        ->toContain("localStorage.setItem('projects-sort', sortBy)")
+        ->toContain("label: 'Running first'")
+        ->toContain('const priority = { success: 0, warning: 1, error: 2, neutral: 3 }')
+        ->toContain('...(project.domains || []).map((domain) => domain.label)');
+});
+
+it('shows the same project status context on dashboard cards', function () {
+    $component = file_get_contents(app_path('Livewire/Dashboard.php'));
+    $view = file_get_contents(resource_path('views/livewire/dashboard.blade.php'));
+
+    expect($component)
+        ->toContain('ProjectStatusAggregator::forProjects($this->projects)');
+
+    expect($view)
+        ->toContain('$projectStatuses[$project->uuid]')
+        ->toContain('Project status: {{ $projectStatus[\'label\'] }}');
+});
+
+it('uses bounded caches and excludes deleted service domains', function () {
+    $statuses = file_get_contents(app_path('Support/ProjectStatusAggregator.php'));
+    $domains = file_get_contents(app_path('Support/ProjectDomainAggregator.php'));
+
+    expect($statuses)
+        ->toContain('Cache::remember($cacheKey, 5')
+        ->toContain("['label' => 'Empty', 'type' => 'neutral']")
+        ->toContain("['label' => 'Unhealthy', 'type' => 'error']");
+
+    expect($domains)
+        ->toContain('Cache::remember($cacheKey, 10')
+        ->toContain("whereNull('services.deleted_at')")
+        ->toContain("whereNull('service_applications.deleted_at')");
+});


### PR DESCRIPTION
## Changes

- Adds operational status badges to project cards on both Dashboard and Projects views.
- Shows active project domains as safe clickable links in grid and table views.
- Adds `Running first` sorting with a persisted preference and domain-aware search.
- Extends table mode with status/domain columns and horizontal overflow for narrower widths.
- Uses short bounded caches for aggregate project status and domain data to avoid repeated relationship work.

## Issues

- Discussion: https://github.com/coollabsio/coolify/discussions/11483

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

![Running project with active domain](https://raw.githubusercontent.com/AAA-It-uae/coolify-community-enhancements/main/assets/screenshots/project-running-domain.webp)

![Stopped project status](https://raw.githubusercontent.com/AAA-It-uae/coolify-community-enhancements/main/assets/screenshots/project-stopped-status.webp)

![Running-first sorting](https://raw.githubusercontent.com/AAA-It-uae/coolify-community-enhancements/main/assets/screenshots/running-first-sort.webp)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: coding assistance
- How extensively: implementation support; changes were manually reviewed and validated on a local Coolify development instance.

## Testing

- Built the official Coolify development image from the exact PR head commit.
- Started an isolated development stack with Coolify, PostgreSQL and Redis using separate containers, network and volumes.
- Waited for the official development init flow to finish and verified the HTTP health endpoint from both inside the container and the host.
- Ran `php artisan test tests/Feature/ProjectDashboardUxTest.php`: 4 tests passed, 21 assertions.
- Verified project status/domain payloads, Running-first sorting, persisted sorting, domain-aware search, and Dashboard status context.
- Ran Blade view cache/compile successfully.
- Ran a runtime probe that created an isolated empty project, verified `Empty` status and no domains, then mounted/rendered both Projects and Dashboard components.
- Removed the temporary containers, network, volumes and test image after validation.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.