### PR TITLE
fix(deployment): retry docker exec TCP-upgrade race after container create

### DIFF
--- a/app/Traits/SshRetryable.php
+++ b/app/Traits/SshRetryable.php
@@ -41,6 +41,7 @@ trait SshRetryable
             'Authentication failed',
             'Too many authentication failures',
             'SSH command failed with exit code: 255',
+            'unable to upgrade to tcp',
         ];
 
         $lowerErrorOutput = strtolower($errorOutput);

--- a/tests/Unit/SshRetryMechanismTest.php
+++ b/tests/Unit/SshRetryMechanismTest.php
@@ -68,6 +68,30 @@ class SshRetryMechanismTest extends TestCase
         );
     }
 
+    public function test_docker_exec_tcp_upgrade_race_is_retryable()
+    {
+        $handler = new class
+        {
+            use SshRetryable;
+
+            // Make methods public for testing
+            public function test_is_retryable_ssh_error($error)
+            {
+                return $this->isRetryableSshError($error);
+            }
+        };
+
+        // `docker exec` attached immediately after `docker run -d` for the
+        // same container can transiently fail the HTTP hijack upgrade
+        // before the container is fully ready to accept exec sessions.
+        // Retrying (same backoff as any other transient error here) is
+        // safe - the container itself isn't in a bad state, just not
+        // ready yet.
+        $this->assertTrue(
+            $handler->test_is_retryable_ssh_error('Error: unable to upgrade to tcp, received 409')
+        );
+    }
+
     public function test_non_ssh_errors_are_not_retryable()
     {
         $handler = new class


### PR DESCRIPTION
## Changes

`SshRetryable::isRetryableSshError()` already retries transient errors with exponential backoff, but the pattern list only covers SSH-connection-layer error strings. I added one Docker-daemon-layer error I hit repeatedly on a real production deploy: `unable to upgrade to tcp, received 409`. This happens when `docker exec` is issued against a helper container immediately after `docker run -d` creates it, before the container is fully ready to accept an exec/attach session - a narrow, transient timing race, not a real problem with the container or command. Right now it makes the whole deployment fail immediately instead of retrying, forcing a manual re-trigger.

## Issues

- Fixes #11522

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable - this is a backend retry-logic change with no UI surface.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Anthropic), via Claude Code
- How extensively: Used to trace the error through `ExecuteRemoteCommand`/`SshRetryable` in a local clone of this repo and correlate it against real deployment failure logs I captured on my own host. I reviewed the diff, wrote/verified the added unit test, and ran the test suite myself before opening this PR - I understand what the change does and why.

## Testing

Ran the full `SshRetryMechanismTest` suite locally (no local PHP install, so via `php:8.4-cli` + `pdo_pgsql` in Docker): all 11 tests pass, 31 assertions, no regressions. Added `test_docker_exec_tcp_upgrade_race_is_retryable` following the existing test patterns in that file, and confirmed the new pattern doesn't collide with the existing `test_non_ssh_errors_are_not_retryable` negative cases.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

Note on the box above: I did not spin up a full local Coolify dev instance to trigger a real deployment through this retry path - I tested at the unit level only (see Testing section) and via the real production failure logs that motivated this fix, not a from-scratch local reproduction. Leaving this unchecked rather than overclaiming.
