### PR TITLE
fix(parsers): keep external docker compose volumes untouched

### DIFF
--- a/app/Models/LocalPersistentVolume.php
+++ b/app/Models/LocalPersistentVolume.php
@@ -155,6 +155,7 @@ class LocalPersistentVolume extends BaseModel
 
             $compose = Yaml::parse($composeContent);
             $services = data_get($compose, 'services', []);
+            $topLevelVolumes = data_get($compose, 'volumes', []);
 
             if ($this->isServiceResource()) {
                 $services = array_intersect_key($services, [$resource->name => true]);
@@ -165,6 +166,11 @@ class LocalPersistentVolume extends BaseModel
                     $parsedVolume = is_array($volume) ? $volume : parseDockerVolumeString($volume);
                     $source = data_get($parsedVolume, 'source');
                     $target = data_get($parsedVolume, 'target');
+                    // Volume names may contain dots, so the top-level definition is looked up directly.
+                    if ($source && isExternalVolume($topLevelVolumes[(string) $source] ?? null)) {
+                        continue;
+                    }
+
                     $resourceUuid = $resource instanceof Application ? $resource->uuid : data_get($resource, 'service.uuid');
                     $generatedName = $source ? $resourceUuid.'_'.Str::slug($source, '-') : null;
 

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -358,6 +358,21 @@ function parseDockerVolumeString(string $volumeString): array
     ];
 }
 
+/**
+ * Checks if a top-level volume definition is marked as external.
+ * Supports `external: true`, `external: "true"` and the legacy `external: { name: ... }` format.
+ */
+function isExternalVolume(mixed $topLevelVolume): bool
+{
+    $external = data_get($topLevelVolume, 'external');
+
+    if (is_array($external)) {
+        return filled(data_get($external, 'name'));
+    }
+
+    return filter_var($external, FILTER_VALIDATE_BOOLEAN);
+}
+
 function addTraefikDockerNetworkLabel(Collection $labels, string $network): Collection
 {
     $hasUserDefinedNetwork = $labels->contains(
@@ -857,6 +872,13 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                 } elseif ($type->value() === 'volume') {
                     if ($topLevel->get('volumes')->has($source->value())) {
                         $temp = $topLevel->get('volumes')->get($source->value());
+                        if (isExternalVolume($temp)) {
+                            // External volumes are owned outside of Coolify, so the name is kept
+                            // as-is and no persistent storage is tracked for them.
+                            $volumesParsed->put($index, $volume);
+
+                            continue;
+                        }
                         if (data_get($temp, 'driver_opts.type') === 'cifs') {
                             continue;
                         }
@@ -2243,6 +2265,13 @@ function serviceParser(Service $resource): Collection
                 } elseif ($type->value() === 'volume') {
                     if ($topLevel->get('volumes')->has($source->value())) {
                         $temp = $topLevel->get('volumes')->get($source->value());
+                        if (isExternalVolume($temp)) {
+                            // External volumes are owned outside of Coolify, so the name is kept
+                            // as-is and no persistent storage is tracked for them.
+                            $volumesParsed->put($index, $volume);
+
+                            continue;
+                        }
                         if (data_get($temp, 'driver_opts.type') === 'cifs') {
                             continue;
                         }

--- a/tests/Feature/DockerComposeExternalVolumeTest.php
+++ b/tests/Feature/DockerComposeExternalVolumeTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Feature tests for external volumes in Docker Compose files.
+ *
+ * Volumes declared with `external: true` are created and owned outside of Coolify
+ * (`docker volume create`, volume plugins like rclone, or another stack).
+ * The parser must keep their name untouched and must not register them as
+ * persistent storage, otherwise Coolify creates an empty volume of its own and
+ * deletes it together with the resource.
+ *
+ * Covers GitHub issue #3303.
+ */
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\LocalPersistentVolume;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use phpseclib3\Crypt\EC;
+use Symfony\Component\Yaml\Yaml;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // The parser dispatches ServerFilesFromServerJob, which would try to reach the server over SSH.
+    Queue::fake();
+
+    $this->team = Team::factory()->create();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $privateKey = PrivateKey::create([
+        'name' => 'test-key',
+        'private_key' => EC::createKey('Ed25519')->toString('OpenSSH'),
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $privateKey->id,
+    ]);
+
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'test-network-'.fake()->uuid(),
+    ]);
+
+    $this->makeApplication = function (string $dockerCompose): Application {
+        return Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+            'docker_compose_raw' => $dockerCompose,
+        ]);
+    };
+});
+
+test('applicationParser keeps external volumes untouched', function () {
+    $application = ($this->makeApplication)(<<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - 'rclone-http:/srv/httptesting'
+volumes:
+  rclone-http:
+    external: true
+YAML);
+
+    applicationParser($application);
+
+    $compose = Yaml::parse($application->refresh()->docker_compose);
+
+    expect(data_get($compose, 'services.filebrowser.volumes'))->toContain('rclone-http:/srv/httptesting');
+    expect(data_get($compose, 'volumes.rclone-http.external'))->toBeTrue();
+    expect(array_keys(data_get($compose, 'volumes', [])))->not->toContain("{$application->uuid}_rclone-http");
+    expect(LocalPersistentVolume::count())->toBe(0);
+});
+
+test('applicationParser keeps external volumes declared with the long syntax untouched', function () {
+    $application = ($this->makeApplication)(<<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - type: volume
+        source: shared-data
+        target: /srv/data
+volumes:
+  shared-data:
+    external: true
+    name: my-existing-volume
+YAML);
+
+    applicationParser($application);
+
+    $compose = Yaml::parse($application->refresh()->docker_compose);
+
+    expect(data_get($compose, 'services.filebrowser.volumes.0.source'))->toBe('shared-data');
+    expect(data_get($compose, 'volumes.shared-data.name'))->toBe('my-existing-volume');
+    expect(LocalPersistentVolume::count())->toBe(0);
+});
+
+test('applicationParser keeps external volumes that also define driver options', function () {
+    $application = ($this->makeApplication)(<<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - 'media:/srv/media'
+      - 'app-data:/srv/data'
+volumes:
+  media:
+    external: true
+    driver_opts:
+      type: nfs
+      o: addr=10.0.0.1,rw
+      device: ':/exports/media'
+  app-data:
+YAML);
+
+    applicationParser($application);
+
+    $compose = Yaml::parse($application->refresh()->docker_compose);
+
+    expect(data_get($compose, 'services.filebrowser.volumes'))->toContain('media:/srv/media');
+    expect(data_get($compose, 'services.filebrowser.volumes'))->toContain("{$application->uuid}_app-data:/srv/data");
+    expect(data_get($compose, 'volumes.media.external'))->toBeTrue();
+});
+
+test('applicationParser still prefixes regular named volumes', function () {
+    $application = ($this->makeApplication)(<<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - 'app-data:/srv/data'
+volumes:
+  app-data:
+YAML);
+
+    applicationParser($application);
+
+    $compose = Yaml::parse($application->refresh()->docker_compose);
+    $expectedName = "{$application->uuid}_app-data";
+
+    expect(data_get($compose, 'services.filebrowser.volumes'))->toContain("{$expectedName}:/srv/data");
+    expect(data_get($compose, "volumes.{$expectedName}.name"))->toBe($expectedName);
+    expect(LocalPersistentVolume::where('name', $expectedName)->count())->toBe(1);
+});
+
+test('serviceParser keeps external volumes untouched', function () {
+    $service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'docker_compose_raw' => <<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - 'rclone-http:/srv/httptesting'
+volumes:
+  rclone-http:
+    external: true
+YAML,
+    ]);
+
+    serviceParser($service);
+
+    $compose = Yaml::parse($service->refresh()->docker_compose);
+
+    expect(data_get($compose, 'services.filebrowser.volumes'))->toContain('rclone-http:/srv/httptesting');
+    expect(data_get($compose, 'volumes.rclone-http.external'))->toBeTrue();
+    expect(array_keys(data_get($compose, 'volumes', [])))->not->toContain("{$service->uuid}_rclone-http");
+    expect(LocalPersistentVolume::count())->toBe(0);
+});
+
+test('a storage record left over from an external volume is no longer reported as compose managed', function () {
+    $application = ($this->makeApplication)(<<<'YAML'
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - 'rclone-http:/srv/httptesting'
+      - 'app-data:/srv/data'
+volumes:
+  rclone-http:
+    external: true
+  app-data:
+YAML);
+
+    $externalLeftover = LocalPersistentVolume::create([
+        'name' => "{$application->uuid}_rclone-http",
+        'mount_path' => '/srv/httptesting',
+        'resource_id' => $application->id,
+        'resource_type' => Application::class,
+    ]);
+
+    $managed = LocalPersistentVolume::create([
+        'name' => "{$application->uuid}_app-data",
+        'mount_path' => '/srv/data',
+        'resource_id' => $application->id,
+        'resource_type' => Application::class,
+    ]);
+
+    expect($externalLeftover->isDeclaredInCompose())->toBeFalse();
+    expect($managed->isDeclaredInCompose())->toBeTrue();
+});
+
+test('isExternalVolume recognises the supported compose formats', function () {
+    expect(isExternalVolume(['external' => true]))->toBeTrue();
+    expect(isExternalVolume(['external' => 'true']))->toBeTrue();
+    expect(isExternalVolume(['external' => ['name' => 'my-volume']]))->toBeTrue();
+
+    expect(isExternalVolume(['external' => false]))->toBeFalse();
+    expect(isExternalVolume(['external' => 'false']))->toBeFalse();
+    expect(isExternalVolume(['external' => []]))->toBeFalse();
+    expect(isExternalVolume(['driver' => 'local']))->toBeFalse();
+    expect(isExternalVolume(null))->toBeFalse();
+});


### PR DESCRIPTION
## Changes

Volumes declared with `external: true` were still renamed to `{uuid}_{name}`, so Coolify mounted a new empty volume instead of the existing one and tracked it as persistent storage, which means it would be deleted together with the resource even though it is owned outside of Coolify.

`applicationParser()` and `serviceParser()` now keep the service reference and the top-level definition of an external volume exactly as written, and create no `LocalPersistentVolume` record for it. `isDeclaredInCompose()` skips them too, so a storage row left over from before this fix can be deleted from the UI instead of being reported as compose managed. Regular named volumes keep the existing prefixing behaviour. Resources on compose parsing version 1 or 2 use the legacy parser and are untouched.

## Issues

- Fixes #3303

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

```yaml
volumes:
  rclone-http:
    external: true
```

Before: the service mounted `{uuid}_rclone-http` and the container saw an empty directory. After: it mounts `rclone-http`.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant
- How extensively: locating the affected code paths and drafting tests. Reviewed and verified locally by me.

## Testing

`tests/Feature/DockerComposeExternalVolumeTest.php` covers short and long syntax, an external volume carrying `driver_opts`, a leftover storage row, the accepted `external` formats, a service compose, and a regular named volume as regression guard. Six of the seven fail on `main` and all pass here. Existing parser and storage tests gave identical results before and after.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
