### PR TITLE
fix(previews): only remove docker resources created for the preview

### DIFF
--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -42,14 +42,26 @@ class ApplicationPreview extends BaseModel
                 $networks = data_get($composeFile, 'networks');
                 $networkKeys = collect($networks)->keys();
                 $volumeKeys = collect($volumes)->keys();
-                $volumeKeys->each(function ($key) use ($server) {
+                // The parsed compose also lists volumes and networks that Coolify does not own
+                // (the names written by the user, external ones, the shared Coolify network),
+                // so only the resources generated for this preview may be removed. Every
+                // generated volume name ends with the preview suffix, in both parser generations.
+                $volumeSuffix = '-pr-'.$preview->pull_request_id;
+                $previewNetwork = data_get($application, 'uuid').'-'.$preview->pull_request_id;
+                $volumeKeys->each(function ($key) use ($server, $volumeSuffix) {
                     if (! preg_match(ValidationPatterns::VOLUME_NAME_PATTERN, $key)) {
+                        return;
+                    }
+                    if (! str($key)->endsWith($volumeSuffix)) {
                         return;
                     }
                     instant_remote_process(['docker volume rm -f '.escapeshellarg($key)], $server, false);
                 });
-                $networkKeys->each(function ($key) use ($server) {
+                $networkKeys->each(function ($key) use ($server, $previewNetwork) {
                     if (! preg_match(ValidationPatterns::DOCKER_NETWORK_PATTERN, $key)) {
+                        return;
+                    }
+                    if ($key !== $previewNetwork) {
                         return;
                     }
                     $k = escapeshellarg($key);

--- a/tests/Feature/ApplicationPreviewComposeCleanupTest.php
+++ b/tests/Feature/ApplicationPreviewComposeCleanupTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Feature tests for the Docker cleanup that runs when a compose based preview deployment
+ * is deleted. The parsed compose file also contains resources Coolify does not own:
+ * the volume and network names written by the user, external volumes and the shared
+ * Coolify network. Removing those would destroy data and connectivity of other resources.
+ */
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    InstanceSettings::unguarded(fn () => InstanceSettings::firstOrCreate(['id' => 0]));
+
+    $team = Team::factory()->create();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'private_key_id' => $privateKey->id,
+        'user' => 'deploy',
+    ]);
+    $this->destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+
+    $this->application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'environment_id' => $environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:alpine
+    volumes:
+      - 'app-data:/srv/data'
+      - 'rclone-http:/srv/remote'
+    networks:
+      - backend
+volumes:
+  app-data:
+  rclone-http:
+    external: true
+networks:
+  backend:
+YAML,
+    ]);
+    $this->application->settings()->update(['connect_to_docker_network' => true]);
+
+    $this->preview = ApplicationPreview::create([
+        'uuid' => 'preview-compose-cleanup-test',
+        'application_id' => $this->application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repository/pull/42',
+    ]);
+});
+
+it('removes only the volumes generated for the preview', function () {
+    Process::fake(['*' => Process::result(output: '')]);
+    $uuid = $this->application->uuid;
+
+    $this->preview->forceDelete();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, "docker volume rm -f '{$uuid}_app-data-pr-42'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker volume rm -f 'app-data'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker volume rm -f 'rclone-http'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker volume rm -f '{$uuid}_app-data'"));
+});
+
+it('removes only the network created for the preview', function () {
+    Process::fake(['*' => Process::result(output: '')]);
+    $uuid = $this->application->uuid;
+
+    $this->preview->forceDelete();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, "docker network rm '{$uuid}-42'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker network rm 'backend'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker network rm 'coolify'"));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, "docker network disconnect 'coolify' coolify-proxy"));
+});


### PR DESCRIPTION
## Changes

Deleting a preview deployment of a compose application removed every top-level `volumes` and `networks` entry of the parsed compose file. That list also holds the names written by the user (the parser adds its generated names next to the original ones) and the shared Coolify network when "Connect to predefined network" is on, so the cleanup could delete a host volume belonging to another stack and disconnect `coolify-proxy` from the shared network.

The cleanup now only touches what Coolify generated for that preview: volumes carrying the `-pr-{id}` suffix, which both parser generations append to generated names, and the `{uuid}-{id}` network. Everything else is left alone.

## Issues

- Fixes #11534

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

For a compose file declaring `app-data`, `rclone-http` and a `backend` network, deleting the preview of PR 42 used to run `docker volume rm -f 'app-data'` and `docker network disconnect 'coolify' coolify-proxy`. Now only `{uuid}_app-data-pr-42` and the `{uuid}-42` network are removed.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant
- How extensively: locating the affected code paths and drafting tests. Reviewed and verified locally by me.

## Testing

`tests/Feature/ApplicationPreviewComposeCleanupTest.php` fakes the process runner and asserts which docker commands run when a compose preview is force deleted: the generated volume and network are removed, the raw compose names and the shared Coolify network are not. Both cases fail on `main` and pass here. The existing `ApplicationPreviewVolumeCleanupTest` still passes unchanged.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
