### PR TITLE
fix(notifications): use instance base url instead of localhost

### DIFF
--- a/app/Notifications/ApiTokenExpiringNotification.php
+++ b/app/Notifications/ApiTokenExpiringNotification.php
@@ -21,7 +21,7 @@ class ApiTokenExpiringNotification extends CustomEmailNotification
         $this->onQueue('high');
         $this->tokenName = $token->name;
         $this->expiresAt = $token->expires_at?->format('Y-m-d H:i:s') ?? '';
-        $this->manageUrl = route('security.api-tokens');
+        $this->manageUrl = base_url().'/security/api-tokens';
     }
 
     public function via(object $notifiable): array

--- a/app/Notifications/Application/RestartLimitReached.php
+++ b/app/Notifications/Application/RestartLimitReached.php
@@ -41,7 +41,7 @@ class RestartLimitReached extends CustomEmailNotification
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
         }
-        $this->resource_url = $this->resource->link() ?? base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->resource->uuid}";
+        $this->resource_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->resource->uuid}";
     }
 
     public function via(object $notifiable): array

--- a/tests/Feature/ApiTokenExpirationWarningTest.php
+++ b/tests/Feature/ApiTokenExpirationWarningTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Jobs\ApiTokenExpirationWarningJob;
+use App\Models\InstanceSettings;
 use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Notification;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
     $this->team->members()->attach($this->user->id, ['role' => 'owner']);
@@ -136,5 +138,16 @@ describe('ApiTokenExpirationWarningJob', function () {
 
         Notification::assertNothingSent();
         expect($token->fresh()->api_token_expiration_warning_sent_at)->toBeNull();
+    });
+
+    test('manage url uses the instance fqdn when configured', function () {
+        InstanceSettings::query()->update(['fqdn' => 'https://coolify.example.com']);
+        $token = createTokenExpiring($this->user, $this->team, Carbon::now()->addHours(12));
+
+        $notification = new ApiTokenExpiringNotification($token);
+
+        expect($notification->toSlack()->description)
+            ->toContain('https://coolify.example.com/security/api-tokens')
+            ->not->toContain('localhost');
     });
 });

--- a/tests/Feature/ApplicationStoppedAfterRestartLimitTest.php
+++ b/tests/Feature/ApplicationStoppedAfterRestartLimitTest.php
@@ -2,7 +2,11 @@
 
 use App\Actions\Application\StopApplication;
 use App\Models\Application;
+use App\Models\InstanceSettings;
 use App\Notifications\Application\RestartLimitReached;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 function applicationWithRestartState(array $attributes = []): Application
 {
@@ -56,14 +60,10 @@ it('keeps restart tracking configurable when stopping an application', function 
         ->and($resetRestartCount->getDefaultValue())->toBeTrue();
 });
 
-it('uses the application link for restart limit notifications', function () {
-    $application = new class extends Application
-    {
-        public function link()
-        {
-            return 'https://coolify.test/project/link-from-model';
-        }
-    };
+it('builds restart limit notification urls from the instance base url', function () {
+    InstanceSettings::forceCreate(['id' => 0, 'fqdn' => 'https://coolify.test']);
+
+    $application = new Application;
     $application->forceFill([
         'name' => 'crashy-app',
         'uuid' => 'application-uuid',
@@ -78,5 +78,5 @@ it('uses the application link for restart limit notifications', function () {
 
     $notification = new RestartLimitReached($application);
 
-    expect($notification->resource_url)->toBe('https://coolify.test/project/link-from-model');
+    expect($notification->resource_url)->toBe('https://coolify.test/project/project-uuid/environment/environment-uuid/application/application-uuid');
 });

--- a/tests/Feature/RestartLimitReachedNotificationUrlTest.php
+++ b/tests/Feature/RestartLimitReachedNotificationUrlTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Application;
+use App\Models\InstanceSettings;
+use App\Notifications\Application\RestartLimitReached;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function restartLimitApplication(): Application
+{
+    $application = new Application;
+    $application->forceFill([
+        'name' => 'crashy-app',
+        'uuid' => 'application-uuid',
+        'restart_count' => 2,
+        'max_restart_count' => 2,
+    ]);
+    $application->setRelation('environment', (object) [
+        'uuid' => 'environment-uuid',
+        'name' => 'production',
+        'project' => (object) ['uuid' => 'project-uuid'],
+    ]);
+
+    return $application;
+}
+
+it('uses the instance fqdn for restart limit notification urls', function () {
+    InstanceSettings::forceCreate(['id' => 0, 'fqdn' => 'https://coolify.example.com']);
+
+    $notification = new RestartLimitReached(restartLimitApplication());
+
+    expect($notification->resource_url)
+        ->toBe('https://coolify.example.com/project/project-uuid/environment/environment-uuid/application/application-uuid');
+});
+
+it('falls back to the app url when no instance fqdn is configured', function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $notification = new RestartLimitReached(restartLimitApplication());
+
+    expect($notification->resource_url)
+        ->toBe(config('app.url').'/project/project-uuid/environment/environment-uuid/application/application-uuid');
+});


### PR DESCRIPTION
## Changes

- The "Restart limit reached" notification linked to http://localhost/... because it built its URL from Application::link() (a bare route(), resolved against APP_URL); the "API token expiring" notification had the same problem via route('security.api-tokens').
- Both now use base_url()."/path", the same pattern every other notification (status changed, deployments, backups, etc.) already uses.
Only these two notifications were affected; the rest of the notification classes were checked and are already correct.

## Issues

- Haven't prepared the issue, went straight into fixing it (since Coolify solves so many my issues I'm more than happy to pay back my time a little😇)

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before (Slack, restart limit reached): link points to `http://localhost/project/...`
After: link points to `https://<instance-fqdn>/project/...`

<img width="1017" height="265" alt="Screenshot 2026-08-27 at 18 36 19" src="https://github.com/user-attachments/assets/7c806bb8-5630-499a-8cb4-50374ca60092" />
<img width="1023" height="273" alt="Screenshot 2026-08-27 at 18 36 28" src="https://github.com/user-attachments/assets/c397abb6-2689-4912-88a9-6cdb4233aad8" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic)
- How extensively: The bug was reported and reproduced by me on my own instance. AI located the root cause, wrote the two-line fix and the tests, and audited the remaining notification classes for the same issue. I reviewed and directed the changes (including rejecting an initial larger refactor in favor of reusing the existing `base_url()` pattern).

## Testing

- TDD: added `tests/Feature/RestartLimitReachedNotificationUrlTest.php` first and confirmed it failed with `http://localhost/...` before the fix; it now passes, covering both the FQDN case and the no-FQDN fallback.
- Extended `tests/Feature/ApiTokenExpirationWarningTest.php` with a case asserting the Slack message links to the instance FQDN and never `localhost`.
- Updated the existing restart-limit test to the new URL behavior.
- All 18 tests across the three touched test files pass in the local Docker dev environment; `vendor/bin/pint --dirty` clean.
- Audited every other notification class (`Server/*`, `Database/*`, deployments, containers, SSL, scheduled tasks, password reset): they already build URLs via `base_url()` or `taskLink()`, so these two were the only affected ones.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.