### PR TITLE
fix(docker): reap orphaned helper containers regardless of registry

### DIFF
--- a/app/Jobs/CleanupHelperContainersJob.php
+++ b/app/Jobs/CleanupHelperContainersJob.php
@@ -19,6 +19,11 @@ class CleanupHelperContainersJob implements ShouldBeEncrypted, ShouldBeUnique, S
 
     public function __construct(public Server $server) {}
 
+    private static function helperContainersCommand(): string
+    {
+        return 'docker container ps --format \'{{json .}}\' | jq -s \'map(select(.Image|test("^([^/]+/)?coollabsio/coolify-helper(:|@)")))\'';
+    }
+
     public function handle(): void
     {
         try {
@@ -36,7 +41,7 @@ class CleanupHelperContainersJob implements ShouldBeEncrypted, ShouldBeUnique, S
                 'active_deployment_uuids' => $activeDeployments,
             ]);
 
-            $containers = instant_remote_process_with_timeout(['docker container ps --format \'{{json .}}\' | jq -s \'map(select(.Image | contains("'.coolifyRegistryUrl().'/coollabsio/coolify-helper")))\''], $this->server, false);
+            $containers = instant_remote_process_with_timeout([self::helperContainersCommand()], $this->server, false);
             $helperContainers = collect(json_decode($containers));
 
             if ($helperContainers->count() > 0) {

--- a/app/Jobs/CleanupHelperContainersJob.php
+++ b/app/Jobs/CleanupHelperContainersJob.php
@@ -21,7 +21,7 @@ class CleanupHelperContainersJob implements ShouldBeEncrypted, ShouldBeUnique, S
 
     private static function helperContainersCommand(): string
     {
-        return 'docker container ps --format \'{{json .}}\' | jq -s \'map(select(.Image|test("^([^/]+/)?coollabsio/coolify-helper(:|@)")))\'';
+        return 'docker container ps --format \'{{json .}}\' | jq -s \'map(select(.Image|test("(^|/)coollabsio/coolify-helper(:|@)")))\'';
     }
 
     public function handle(): void

--- a/tests/Unit/CleanupHelperContainersJobTest.php
+++ b/tests/Unit/CleanupHelperContainersJobTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Jobs\CleanupHelperContainersJob;
+use App\Models\Server;
+use Symfony\Component\Process\Process;
+
+it('matches helper image references without matching similarly named images', function () {
+    $command = (new ReflectionMethod(CleanupHelperContainersJob::class, 'helperContainersCommand'))->invoke(null);
+    $directory = sys_get_temp_dir().'/coolify-helper-filter-'.bin2hex(random_bytes(4));
+    $docker = $directory.'/docker';
+    $images = [
+        'coollabsio/coolify-helper:1.0.15',
+        'docker.io/coollabsio/coolify-helper:1.0.16',
+        'ghcr.io/coollabsio/coolify-helper@sha256:abc',
+        'registry.example/team/coollabsio/coolify-helper:latest',
+        'evil/coollabsio/coolify-helper-copy:latest',
+        'coollabsio/not-coolify-helper:latest',
+    ];
+
+    mkdir($directory);
+    file_put_contents($docker, "#!/bin/sh\n".implode("\n", array_map(
+        fn (string $image): string => 'echo '.escapeshellarg(json_encode(['Image' => $image], JSON_THROW_ON_ERROR)),
+        $images
+    ))."\n");
+    chmod($docker, 0755);
+
+    try {
+        $process = new Process(['/bin/sh', '-c', $command], env: [
+            'PATH' => $directory.':'.getenv('PATH'),
+        ]);
+        $process->mustRun();
+
+        expect(array_column(json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR), 'Image'))
+            ->toBe(array_slice($images, 0, 3));
+    } finally {
+        unlink($docker);
+        rmdir($directory);
+    }
+});
+
+it('preserves the helper image filter for non-root servers', function () {
+    $command = (new ReflectionMethod(CleanupHelperContainersJob::class, 'helperContainersCommand'))->invoke(null);
+    $server = Mockery::mock(Server::class)->makePartial();
+    $server->user = 'ubuntu';
+    $command = parseCommandsByLineForSudo(collect([$command]), $server)[0];
+    $directory = sys_get_temp_dir().'/coolify-helper-sudo-filter-'.bin2hex(random_bytes(4));
+    $docker = $directory.'/docker';
+    $sudo = $directory.'/sudo';
+
+    mkdir($directory);
+    file_put_contents($docker, "#!/bin/sh\necho '{\"Image\":\"coollabsio/coolify-helper:1.0.15\"}'\n");
+    file_put_contents($sudo, "#!/bin/sh\nexec \"\$@\"\n");
+    chmod($docker, 0755);
+    chmod($sudo, 0755);
+
+    try {
+        $process = new Process(['/bin/sh', '-c', $command], env: [
+            'PATH' => $directory.':'.getenv('PATH'),
+        ]);
+        $process->mustRun();
+
+        expect(array_column(json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR), 'Image'))
+            ->toBe(['coollabsio/coolify-helper:1.0.15']);
+    } finally {
+        unlink($docker);
+        unlink($sudo);
+        rmdir($directory);
+    }
+});

--- a/tests/Unit/CleanupHelperContainersJobTest.php
+++ b/tests/Unit/CleanupHelperContainersJobTest.php
@@ -13,6 +13,11 @@ it('matches helper image references without matching similarly named images', fu
         'docker.io/coollabsio/coolify-helper:1.0.16',
         'ghcr.io/coollabsio/coolify-helper@sha256:abc',
         'registry.example/team/coollabsio/coolify-helper:latest',
+        'coollabsio/coolify:latest',
+        'coollabsio/coolify:4.3.12',
+        'coollabsio/coolify-realtime:1.0.10',
+        'coolify-helper:latest',
+        'someone/coolify-helper:1.0.16',
         'evil/coollabsio/coolify-helper-copy:latest',
         'coollabsio/not-coolify-helper:latest',
     ];
@@ -31,7 +36,7 @@ it('matches helper image references without matching similarly named images', fu
         $process->mustRun();
 
         expect(array_column(json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR), 'Image'))
-            ->toBe(array_slice($images, 0, 3));
+            ->toBe(array_slice($images, 0, 4));
     } finally {
         unlink($docker);
         rmdir($directory);


### PR DESCRIPTION
## Changes

- Match helper images as Docker renders them, with an optional registry prefix and a required tag or digest delimiter.
- Keep the jq expression valid after Coolify adapts commands for non-root SSH users.
- Cover unqualified, registry-prefixed, tagged, digest, nested-repository, similarly named image, and non-root command cases.

## Issues

- Fixes #11511

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; background cleanup behavior only.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used for investigation, test-first implementation, and independent review. I verified the final diff and test output locally.

## Testing

- `php artisan test --compact tests/Unit/CleanupHelperContainersJobTest.php tests/Feature/CleanupStuckedResourcesTest.php` — 3 passed, 5 assertions.
- `vendor/bin/pint --dirty --format agent` — passed.
- `php -l app/Jobs/CleanupHelperContainersJob.php` — passed.
- Local Docker reproduction: ran a container tagged `coollabsio/coolify-helper:codex-11511`, executed the production filter, confirmed it was selected, then verified container and temporary image cleanup.
- Independent review specifically checked jq quoting, non-root sudo adaptation, false positives, and false negatives; no blocking findings remained.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
