### PR TITLE
fix(database): persist service database public access

### DIFF
--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -299,26 +299,27 @@ class Index extends Component
     {
         try {
             $this->authorize('update', $this->serviceDatabase);
-            if ($this->isPublic && ! $this->publicPort) {
-                $this->dispatch('error', 'Public port is required.');
-                $this->isPublic = false;
-
-                return;
-            }
-            $this->syncDatabaseData(true);
-            if ($this->serviceDatabase->is_public) {
-                if (! str($this->serviceDatabase->status)->startsWith('running')) {
-                    $this->dispatch('error', 'Database must be started to be publicly accessible.');
+            if ($this->isPublic) {
+                if (! $this->publicPort) {
+                    $this->dispatch('error', 'Public port is required.');
                     $this->isPublic = false;
-                    $this->serviceDatabase->is_public = false;
                     $this->syncDatabaseData(true);
 
                     return;
                 }
+                if (! str($this->serviceDatabase->status)->startsWith('running')) {
+                    $this->dispatch('error', 'Database must be started to be publicly accessible.');
+                    $this->isPublic = false;
+                    $this->syncDatabaseData(true);
+
+                    return;
+                }
+                $this->syncDatabaseData(true);
                 StartDatabaseProxy::run($this->serviceDatabase);
                 $this->db_url_public = $this->serviceDatabase->getServiceDatabaseUrl();
                 $this->dispatch('success', 'Database is now publicly accessible.');
             } else {
+                $this->syncDatabaseData(true);
                 StopDatabaseProxy::run($this->serviceDatabase);
                 $this->db_url_public = null;
                 $this->dispatch('success', 'Database is no longer publicly accessible.');

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -303,14 +303,12 @@ class Index extends Component
                 if (! $this->publicPort) {
                     $this->dispatch('error', 'Public port is required.');
                     $this->isPublic = false;
-                    $this->syncDatabaseData(true);
 
                     return;
                 }
                 if (! str($this->serviceDatabase->status)->startsWith('running')) {
                     $this->dispatch('error', 'Database must be started to be publicly accessible.');
                     $this->isPublic = false;
-                    $this->syncDatabaseData(true);
 
                     return;
                 }

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -305,11 +305,13 @@ class Index extends Component
                 return;
             }
             $this->syncDatabaseData(true);
+            $this->serviceDatabase->save();
             if ($this->serviceDatabase->is_public) {
                 if (! str($this->serviceDatabase->status)->startsWith('running')) {
                     $this->dispatch('error', 'Database must be started to be publicly accessible.');
                     $this->isPublic = false;
                     $this->serviceDatabase->is_public = false;
+                    $this->serviceDatabase->save();
 
                     return;
                 }

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -170,6 +170,7 @@ class Index extends Component
             $this->serviceDatabase->public_port_timeout = $this->publicPortTimeout ?: null;
             $this->serviceDatabase->is_public = $this->isPublic;
             $this->serviceDatabase->is_log_drain_enabled = $this->isLogDrainEnabled;
+            $this->serviceDatabase->save();
         } else {
             $this->humanName = $this->serviceDatabase->human_name;
             $this->description = $this->serviceDatabase->description;
@@ -305,13 +306,12 @@ class Index extends Component
                 return;
             }
             $this->syncDatabaseData(true);
-            $this->serviceDatabase->save();
             if ($this->serviceDatabase->is_public) {
                 if (! str($this->serviceDatabase->status)->startsWith('running')) {
                     $this->dispatch('error', 'Database must be started to be publicly accessible.');
                     $this->isPublic = false;
                     $this->serviceDatabase->is_public = false;
-                    $this->serviceDatabase->save();
+                    $this->syncDatabaseData(true);
 
                     return;
                 }
@@ -334,7 +334,6 @@ class Index extends Component
             $this->authorize('update', $this->serviceDatabase);
             $this->validate();
             $this->syncDatabaseData(true);
-            $this->serviceDatabase->save();
             $this->serviceDatabase->refresh();
             $this->syncDatabaseData(false);
             updateCompose($this->serviceDatabase);


### PR DESCRIPTION
## Changes

The nested (compose/service) database page has no Save button for public access. The only control is **Make publicly available**, which calls `enablePublicAccess()` → `instantSave()`.

`instantSave()` copied `is_public` onto the in-memory model and started the TCP proxy, but never persisted the row. Status reconciliation then treated the proxy as orphaned (`is_public` still false) and deleted it a few seconds later.

This saves the service database after syncing, matching `submitDatabase()`. If the database is not running, it also persists the reverted `is_public = false`.

`syncDatabaseData(true)` only assigns Livewire properties onto the Eloquent model. It does not write to the database.

## Issues

- Fixes #11345

#11348 only patched standalone PostgreSQL. Service-nested databases still failed because `instantSave()` never called `save()`.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — backend persistence only. Enabling public access on a nested database keeps `is_public` true and leaves the `*-proxy` container running after a status refresh.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor agent
- How extensively: Helped locate the missing `save()` on the service-database path and prepare the patch. The change itself is two `save()` calls in `instantSave()`. Human-reviewed and verified in a local Coolify instance.

## Testing

Tested on a local Coolify development instance (`docker compose` from this branch; UI reported v4.3.15, the `main` version string).

1. Opened a nested (service/compose) Postgres database. Confirmed there is no Save button for public access.
2. Set a public port and clicked **Make publicly available**.
3. Success toast appeared and the `*-proxy` container started.
4. Waited for container status refresh (~5–10 seconds) and refreshed the page.
5. Public access stayed enabled and the proxy container remained running.

Without this patch, the same flow reverted to private and Docker reported `No such container: <uuid>-proxy`.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.