### PR TITLE
fix(applications): widen http_basic_auth_password for encrypted values

### DIFF
--- a/database/migrations/2026_08_30_000000_widen_http_basic_auth_password_column.php
+++ b/database/migrations/2026_08_30_000000_widen_http_basic_auth_password_column.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->text('http_basic_auth_password')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('http_basic_auth_password')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Changes

The `http_basic_auth_password` column on applications is a varchar(255), but the model casts it to encrypted. A Laravel AES-256-CBC payload is base64 of a JSON envelope, so it is already ~200 characters for a very short secret and crosses 255 once the password reaches 32 characters. Postgres then rejects the save with "value too long for type character varying(255)", which is exactly the 31/32 boundary in the issue.

This migration widens the column to text. That is what the project already did for the other encrypted columns on the same table in the 2026_04_19 webhook secrets migration, for the same reason. The username column is not encrypted and is left alone.

## Issues

- Fixes #9643

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable, no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: to locate the column and the existing precedent, and to run the verification below. I reviewed and reproduced everything myself before opening this.

## Testing

Postgres 15 in Docker with the full Coolify migration set applied:

- Column type before this migration: character varying(255); after: text.
- Using the app's own encryption: a 31-character password stores as 228 characters, 32 stores as 256, 64 stores as 312. Matches the reported boundary.
- Inserting the 32-character payload into varchar(255) reproduces the reported error; the same insert into text succeeds and reads back at full length.

No automated test on purpose: the suite runs on SQLite, where varchar has no length enforcement and the type reports as text either way, so such a test would pass with and without this change.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [ ] I verified this at the database level against a real Postgres as described above, but not through a full local Coolify instance, so I am leaving this unchecked rather than overstating it.
