### PR TITLE
fix(previews): drop container port from preview links in PR comments

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Url\Url;
 
 class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -104,7 +105,7 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
                     $firstDomain = str($domain)->explode(',')->first();
                     $firstDomain = trim($firstDomain);
                     if (! empty($firstDomain)) {
-                        $links[] = "[Open {$serviceName}]({$firstDomain})";
+                        $links[] = "[Open {$serviceName}](".$this->publicUrl($firstDomain).')';
                     }
                 }
             }
@@ -112,6 +113,19 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             return ! empty($links) ? implode(' | ', $links).' | ' : '';
         }
 
-        return $this->preview->fqdn ? "[Open Preview]({$this->preview->fqdn}) | " : '';
+        return $this->preview->fqdn ? '[Open Preview]('.$this->publicUrl($this->preview->fqdn).') | ' : '';
+    }
+
+    /**
+     * The port stored on a preview domain is the container port the proxy forwards to,
+     * not a port the visitor connects to, so it must not appear in a shared link.
+     */
+    private function publicUrl(string $url): string
+    {
+        try {
+            return (string) Url::fromString($url)->withPort(null);
+        } catch (\Throwable) {
+            return $url;
+        }
     }
 }

--- a/tests/Unit/PreviewCommentLinksTest.php
+++ b/tests/Unit/PreviewCommentLinksTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Enums\ProcessStatus;
+use App\Jobs\ApplicationPullRequestUpdateJob;
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+
+function previewLinks(Application $application, ApplicationPreview $preview): string
+{
+    $job = new ApplicationPullRequestUpdateJob($application, $preview, ProcessStatus::FINISHED);
+
+    return (new ReflectionMethod($job, 'getPreviewLinks'))->invoke($job);
+}
+
+it('omits the container port from a compose preview link', function () {
+    $application = new Application(['build_pack' => 'dockercompose']);
+    $preview = new ApplicationPreview([
+        'docker_compose_domains' => json_encode([
+            'frontend' => ['domain' => 'https://136.example.com:3000'],
+            'backend' => ['domain' => 'https://136.example.com:3001/backend'],
+        ]),
+    ]);
+
+    expect(previewLinks($application, $preview))
+        ->toBe('[Open frontend](https://136.example.com) | [Open backend](https://136.example.com/backend) | ');
+});
+
+it('omits the container port from a single preview link', function () {
+    $application = new Application(['build_pack' => 'nixpacks']);
+    $preview = new ApplicationPreview(['fqdn' => 'https://136.example.com:3000']);
+
+    expect(previewLinks($application, $preview))->toBe('[Open Preview](https://136.example.com) | ');
+});
+
+it('leaves a preview link without a port untouched', function () {
+    $application = new Application(['build_pack' => 'nixpacks']);
+    $preview = new ApplicationPreview(['fqdn' => 'https://136.example.com/app']);
+
+    expect(previewLinks($application, $preview))->toBe('[Open Preview](https://136.example.com/app) | ');
+});


### PR DESCRIPTION
Closes #11065

### Problem

For a Docker Compose application whose services listen on non-standard ports, the domain has to carry the port so the proxy knows where to forward:

```
https://example.com:3000
https://example.com:3001/backend
```

That port is internal — the generated Traefik router rule is `Host(\`example.com\`)` with no port, and the port is only used for `loadbalancer.server.port`. But the comment Coolify posts on the GitHub pull request reuses the stored domain verbatim, so reviewers get links that do not resolve:

```
[Open frontend](https://136.example.com:3000)
```

### Fix

Strip the port when rendering the links in `ApplicationPullRequestUpdateJob`. The stored domain is untouched — only the shared link changes. The same applies to the single-domain (non-compose) branch, which had the same problem.

### Tests

`tests/Unit/PreviewCommentLinksTest.php` covers the compose case, the single-domain case, and a domain without a port (must stay untouched). Verified as a real guard: with the fix reverted, 2 of the 3 fail; with it, all 3 pass.
