### PR TITLE
fix(applications): widen http_basic_auth_password for encrypted values

### DIFF
--- a/database/migrations/2026_08_30_000000_widen_http_basic_auth_password_column.php
+++ b/database/migrations/2026_08_30_000000_widen_http_basic_auth_password_column.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->text('http_basic_auth_password')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('http_basic_auth_password')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Changes

The `http_basic_auth_password` column is a varchar(255), but the model casts it to encrypted. A Laravel AES-256-CBC payload is base64 of a JSON envelope, so it is ~200 characters even for a short secret and crosses 255 once the password reaches 32 characters. Postgres then rejects the save with "value too long for type character varying(255)" — exactly the 31/32 boundary in the issue.

This widens the column to text — the same thing already done for the other encrypted columns on this table in the 2026_04_19 webhook secrets migration. The username column is not encrypted and is left alone.

## Issues

- Fixes #9643

Reopening: #11555 was auto-closed by the quality check (no PR template, commit email unlinked). Both fixed, code unchanged.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A, no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: locating the column and the precedent, and running the verification below.

## Testing

Postgres 15 in Docker, full migration set applied:

- Column type before this migration: character varying(255); after: text.
- With the app's own encryption a 31-character password stores as 228 chars, 32 as 256, 64 as 312 — matching the reported boundary.
- Inserting the 32-character payload into varchar(255) reproduces the reported error; into text it succeeds and reads back at full length.

No automated test on purpose: the suite runs on SQLite, where varchar length is not enforced and the type reports as text either way, so it would pass with or without this change.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
>
> Last box: verified as described under Testing, but not through a full local Coolify instance, so left unchecked rather than overstated.