### PR TITLE
fix(previews): drop container port from preview links in PR comments

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Url\Url;
 
 class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -104,7 +105,7 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
                     $firstDomain = str($domain)->explode(',')->first();
                     $firstDomain = trim($firstDomain);
                     if (! empty($firstDomain)) {
-                        $links[] = "[Open {$serviceName}]({$firstDomain})";
+                        $links[] = "[Open {$serviceName}](".$this->publicUrl($firstDomain).')';
                     }
                 }
             }
@@ -112,6 +113,19 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             return ! empty($links) ? implode(' | ', $links).' | ' : '';
         }
 
-        return $this->preview->fqdn ? "[Open Preview]({$this->preview->fqdn}) | " : '';
+        return $this->preview->fqdn ? '[Open Preview]('.$this->publicUrl($this->preview->fqdn).') | ' : '';
+    }
+
+    /**
+     * The port stored on a preview domain is the container port the proxy forwards to,
+     * not a port the visitor connects to, so it must not appear in a shared link.
+     */
+    private function publicUrl(string $url): string
+    {
+        try {
+            return (string) Url::fromString($url)->withPort(null);
+        } catch (\Throwable) {
+            return $url;
+        }
     }
 }

--- a/tests/Unit/PreviewCommentLinksTest.php
+++ b/tests/Unit/PreviewCommentLinksTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Enums\ProcessStatus;
+use App\Jobs\ApplicationPullRequestUpdateJob;
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+
+function previewLinks(Application $application, ApplicationPreview $preview): string
+{
+    $job = new ApplicationPullRequestUpdateJob($application, $preview, ProcessStatus::FINISHED);
+
+    return (new ReflectionMethod($job, 'getPreviewLinks'))->invoke($job);
+}
+
+it('omits the container port from a compose preview link', function () {
+    $application = new Application(['build_pack' => 'dockercompose']);
+    $preview = new ApplicationPreview([
+        'docker_compose_domains' => json_encode([
+            'frontend' => ['domain' => 'https://136.example.com:3000'],
+            'backend' => ['domain' => 'https://136.example.com:3001/backend'],
+        ]),
+    ]);
+
+    expect(previewLinks($application, $preview))
+        ->toBe('[Open frontend](https://136.example.com) | [Open backend](https://136.example.com/backend) | ');
+});
+
+it('omits the container port from a single preview link', function () {
+    $application = new Application(['build_pack' => 'nixpacks']);
+    $preview = new ApplicationPreview(['fqdn' => 'https://136.example.com:3000']);
+
+    expect(previewLinks($application, $preview))->toBe('[Open Preview](https://136.example.com) | ');
+});
+
+it('leaves a preview link without a port untouched', function () {
+    $application = new Application(['build_pack' => 'nixpacks']);
+    $preview = new ApplicationPreview(['fqdn' => 'https://136.example.com/app']);
+
+    expect(previewLinks($application, $preview))->toBe('[Open Preview](https://136.example.com/app) | ');
+});


### PR DESCRIPTION
## Changes

When a Compose application has services on non-standard ports, the domain must carry the port so the proxy knows where to forward. That port is internal: the generated router rule matches on host only, and the port is used solely for the load balancer server port. But the comment Coolify posts on the GitHub pull request reuses the stored domain verbatim, so reviewers get links like https://136.example.com:3000 that do not resolve.

This strips the port when rendering those links. The stored domain is untouched, only the shared link changes. The single-domain (non-Compose) branch had the same problem and is fixed too.

Reopening: #11556 was auto-closed by the quality check (no PR template, commit email not linked to my account). Both fixed here, code unchanged.

## Issues

- Fixes #11065

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable, the change is in the text of the GitHub comment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: to trace where the comment is built and to write the tests. I reviewed the change and ran the checks below myself.

## Testing

Added tests/Unit/PreviewCommentLinksTest.php covering the Compose case, the single-domain case, and a domain with no port that must stay untouched.

Verified they are a real guard: with the fix reverted 2 of the 3 fail, with it all 3 pass. Pint is clean.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
>
> On the last box: I verified this as described under Testing, but not through a full local Coolify instance, so I left it unchecked rather than overstate it.