### PR TITLE
fix(applications): accept older configuration hash formats

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1323,7 +1323,7 @@ class Application extends BaseModel
 
         if (! $previousSnapshot) {
             $oldConfigHash = data_get($this, 'config_hash');
-            $hasLegacyChange = $oldConfigHash === null || $oldConfigHash !== $this->legacyConfigurationHash();
+            $hasLegacyChange = $oldConfigHash === null || ! in_array($oldConfigHash, $this->legacyConfigurationHashes(), true);
 
             if (! $hasLegacyChange) {
                 return ConfigurationDiff::unchanged();
@@ -1385,12 +1385,41 @@ class Application extends BaseModel
 
     private function legacyConfigurationHash(): string
     {
-        $newConfigHash = base64_encode($this->fqdn.json_encode($this->noindexDomains()->all()).$this->git_repository.$this->git_branch.$this->git_commit_sha.$this->build_pack.$this->static_image.$this->install_command.$this->build_command.$this->start_command.$this->ports_exposes.$this->ports_mappings.$this->custom_network_aliases.$this->base_directory.$this->publish_directory.$this->dockerfile.$this->dockerfile_location.$this->custom_labels.$this->custom_docker_run_options.$this->dockerfile_target_build.$this->redirect.$this->custom_nginx_configuration.$this->settings?->use_build_secrets.$this->settings?->inject_build_args_to_dockerfile.$this->settings?->include_source_commit_in_build);
+        return $this->buildLegacyConfigurationHash(withNoindexDomains: true, withEnvironmentValues: true);
+    }
+
+    /**
+     * Every hash the current configuration would have produced under a past recipe.
+     *
+     * The recipe changed twice without a data migration: environment variable values
+     * were added on 2026-07-07 and noindex domains on 2026-08-10. A resource deployed
+     * before either change still carries a hash in the older format, and comparing it
+     * against the current recipe alone reports the whole configuration as pending.
+     *
+     * @return array<int, string>
+     */
+    private function legacyConfigurationHashes(): array
+    {
+        return [
+            $this->buildLegacyConfigurationHash(withNoindexDomains: true, withEnvironmentValues: true),
+            $this->buildLegacyConfigurationHash(withNoindexDomains: false, withEnvironmentValues: true),
+            $this->buildLegacyConfigurationHash(withNoindexDomains: false, withEnvironmentValues: false),
+        ];
+    }
+
+    private function buildLegacyConfigurationHash(bool $withNoindexDomains, bool $withEnvironmentValues): string
+    {
+        $noindexDomains = $withNoindexDomains ? json_encode($this->noindexDomains()->all()) : '';
+        $newConfigHash = base64_encode($this->fqdn.$noindexDomains.$this->git_repository.$this->git_branch.$this->git_commit_sha.$this->build_pack.$this->static_image.$this->install_command.$this->build_command.$this->start_command.$this->ports_exposes.$this->ports_mappings.$this->custom_network_aliases.$this->base_directory.$this->publish_directory.$this->dockerfile.$this->dockerfile_location.$this->custom_labels.$this->custom_docker_run_options.$this->dockerfile_target_build.$this->redirect.$this->custom_nginx_configuration.$this->settings?->use_build_secrets.$this->settings?->inject_build_args_to_dockerfile.$this->settings?->include_source_commit_in_build);
         if ($this->pull_request_id === 0 || $this->pull_request_id === null) {
-            $newConfigHash .= json_encode($this->environment_variables()->get(['value',  'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->makeVisible('value')->sort());
+            $variables = $this->environment_variables()->get(['value',  'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime']);
         } else {
-            $newConfigHash .= json_encode($this->environment_variables_preview()->get(['value', 'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->makeVisible('value')->sort());
+            $variables = $this->environment_variables_preview()->get(['value', 'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime']);
         }
+        if ($withEnvironmentValues) {
+            $variables = $variables->makeVisible('value');
+        }
+        $newConfigHash .= json_encode($variables->sort());
 
         return md5($newConfigHash);
     }

--- a/tests/Feature/ApplicationLegacyConfigurationHashTest.php
+++ b/tests/Feature/ApplicationLegacyConfigurationHashTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::updateOrCreate(['id' => 0], []));
+
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $project->id]);
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $server = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $this->destination = StandaloneDocker::factory()->create(['server_id' => $server->id, 'network' => 'coolify-test']);
+});
+
+function makeApplicationWithEnv(): Application
+{
+    $application = Application::factory()->create([
+        'environment_id' => test()->environment->id,
+        'destination_id' => test()->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'nixpacks',
+        'base_directory' => '/',
+        'redirect' => 'no',
+        'git_repository' => 'coollabsio/coolify',
+        'git_branch' => 'main',
+        'ports_exposes' => '3000',
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'SECRET_TOKEN',
+        'value' => 'super-secret',
+        'is_preview' => false,
+        'resourceable_id' => $application->id,
+        'resourceable_type' => $application->getMorphClass(),
+    ]);
+
+    return $application->refresh();
+}
+
+/**
+ * The hash recipe as it was before environment variable values and noindex domains
+ * were folded into it. Spelled out here on purpose so the test does not lean on the
+ * implementation it is guarding.
+ */
+function preValuesConfigurationHash(Application $application): string
+{
+    $hash = base64_encode($application->fqdn.$application->git_repository.$application->git_branch.$application->git_commit_sha.$application->build_pack.$application->static_image.$application->install_command.$application->build_command.$application->start_command.$application->ports_exposes.$application->ports_mappings.$application->custom_network_aliases.$application->base_directory.$application->publish_directory.$application->dockerfile.$application->dockerfile_location.$application->custom_labels.$application->custom_docker_run_options.$application->dockerfile_target_build.$application->redirect.$application->custom_nginx_configuration.$application->settings?->use_build_secrets.$application->settings?->inject_build_args_to_dockerfile.$application->settings?->include_source_commit_in_build);
+    $hash .= json_encode($application->environment_variables()->get(['value', 'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->sort());
+
+    return md5($hash);
+}
+
+it('does not report pending changes for a hash stored before the recipe changed', function () {
+    $application = makeApplicationWithEnv();
+
+    $application->forceFill(['config_hash' => preValuesConfigurationHash($application)])->save();
+
+    expect($application->hasPendingDeploymentConfigurationChanges())->toBeFalse();
+});
+
+it('still reports pending changes when the configuration really changed', function () {
+    $application = makeApplicationWithEnv();
+
+    $application->forceFill(['config_hash' => preValuesConfigurationHash($application)])->save();
+    $application->forceFill(['ports_exposes' => '4000'])->save();
+
+    expect($application->refresh()->hasPendingDeploymentConfigurationChanges())->toBeTrue();
+});
+
+it('still reports pending changes when no hash was ever stored', function () {
+    $application = makeApplicationWithEnv();
+
+    $application->forceFill(['config_hash' => null])->save();
+
+    expect($application->refresh()->hasPendingDeploymentConfigurationChanges())->toBeTrue();
+});


### PR DESCRIPTION
## Changes

After an upgrade, applications deployed before it show the rebuild-required toast and report every field as pending, though nothing was touched.

The legacy hash recipe changed twice without a data migration: environment variable values were folded in on 2026-07-07, noindex domains on 2026-08-10. A resource deployed before either change still carries a hash in the older format, and with no stored deployment snapshot the mismatch is treated as a diff against an empty configuration — so the whole current config shows up as new.

This makes the no-snapshot comparison accept any of the three recipes that have existed, not only the current one. A hash matching none of them, or no hash at all, still reports pending changes as before.

## Issues

- Fixes #11101

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: tracing the two commits that changed the recipe, and running the tests below.

## Testing

Added ApplicationLegacyConfigurationHashTest with three cases: a pre-2026-07-07 hash must not report changes; a real config change must still report changes; a missing hash must still report changes. The old recipe is spelled out in the test rather than reused from the code it guards.

Verified as a real guard: with the fix reverted the first case fails, the other two still pass.

Note: ApplicationConfigurationChangedTest already has one case failing on a clean main, unrelated to this change — same result on upstream main and on this branch.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
>
> Last box: covered by the tests above, but not exercised on a local instance across a real upgrade, so left unchecked rather than overstated.
