### PR TITLE
fix(ui): point port mismatch warning at the editable field

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1395,8 +1395,13 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->build_pack !== 'dockercompose') {
                 $detectedPort = $this->application->detectPortFromEnvironment(false);
                 if ($detectedPort && ! empty($ports) && ! in_array($detectedPort, $ports)) {
+                    // With readonly labels disabled the Ports Exposes field is not editable,
+                    // so pointing the user at it would be a dead end.
+                    $where = $this->application->settings->is_container_label_readonly_enabled === false
+                        ? 'Readonly labels are disabled, so set the port in the labels section.'
+                        : 'Check the "General" page to fix it.';
                     $this->application_deployment_queue->addLogEntry(
-                        "Warning: PORT environment variable ({$detectedPort}) does not match configured ports_exposes: ".implode(',', $ports).'. It could case "bad gateway" or "no server" errors. Check the "General" page to fix it.',
+                        "Warning: PORT environment variable ({$detectedPort}) does not match configured ports_exposes: ".implode(',', $ports).'. It could case "bad gateway" or "no server" errors. '.$where,
                         'stderr'
                     );
                 }

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -429,11 +429,20 @@
                             </svg>
                             <div>
                                 <span class="font-semibold">PORT mismatch detected</span>
-                                <p class="mt-1">Your PORT environment variable is set to
-                                    <strong>{{ $this->detectedPortInfo['port'] }}</strong>, but it's not in your Ports
-                                    Exposes
-                                    configuration. Ensure they match for proper proxy routing.
-                                </p>
+                                @if ($application->settings->is_container_label_readonly_enabled === false)
+                                    <p class="mt-1">Your PORT environment variable is set to
+                                        <strong>{{ $this->detectedPortInfo['port'] }}</strong>, but it's not in your
+                                        Ports Exposes configuration. Readonly labels are disabled, so the Ports Exposes
+                                        field cannot be edited here — set the port in the labels section instead.
+                                    </p>
+                                @else
+                                    <p class="mt-1">Your PORT environment variable is set to
+                                        <strong>{{ $this->detectedPortInfo['port'] }}</strong>, but it's not in your
+                                        Ports
+                                        Exposes
+                                        configuration. Ensure they match for proper proxy routing.
+                                    </p>
+                                @endif
                             </div>
                         </div>
                     @else

--- a/tests/Feature/ApplicationPortMismatchWarningTest.php
+++ b/tests/Feature/ApplicationPortMismatchWarningTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Livewire\Project\Application\General;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::updateOrCreate(['id' => 0], []));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $project->id]);
+    $privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    $server = Server::factory()->create(['team_id' => $this->team->id, 'private_key_id' => $privateKey->id]);
+    $this->destination = StandaloneDocker::factory()->create(['server_id' => $server->id, 'network' => 'coolify-test']);
+});
+
+function applicationWithPortMismatch(bool $readonlyLabels): Application
+{
+    $application = Application::factory()->create([
+        'environment_id' => test()->environment->id,
+        'destination_id' => test()->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'dockerimage',
+        'base_directory' => '/',
+        'redirect' => 'no',
+        'ports_exposes' => '80',
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'PORT',
+        'value' => '3000',
+        'is_preview' => false,
+        'resourceable_id' => $application->id,
+        'resourceable_type' => $application->getMorphClass(),
+    ]);
+
+    $application->settings->update(['is_container_label_readonly_enabled' => $readonlyLabels]);
+
+    return $application->refresh();
+}
+
+it('points at the labels section when the ports field cannot be edited', function () {
+    $application = applicationWithPortMismatch(readonlyLabels: false);
+
+    Livewire::test(General::class, ['application' => $application])
+        ->assertSuccessful()
+        ->assertSee('PORT mismatch detected')
+        ->assertSee('set the port in the labels section instead')
+        ->assertDontSee('Ensure they match for proper proxy routing');
+});
+
+it('keeps the original advice when the ports field is editable', function () {
+    $application = applicationWithPortMismatch(readonlyLabels: true);
+
+    Livewire::test(General::class, ['application' => $application])
+        ->assertSuccessful()
+        ->assertSee('PORT mismatch detected')
+        ->assertSee('Ensure they match for proper proxy routing')
+        ->assertDontSee('set the port in the labels section instead');
+});


### PR DESCRIPTION
## Changes

When readonly labels are disabled, the Ports Exposes field is rendered read-only — its own helper says to set the ports in the labels section instead. But the PORT mismatch warning above it, and the matching warning in the deployment log, both tell the user to fix it on the General page. That is a dead end: the field they are sent to cannot be edited.

Both messages now point at the labels section in that mode, and keep their original wording when the field is editable.

## Issues

- Fixes #10941

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Text-only change to an existing warning, no layout change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: locating the two messages and the read-only condition, and running the tests below.

## Testing

Added ApplicationPortMismatchWarningTest with both modes: with readonly labels disabled the warning must point at the labels section and must not show the old advice; with them enabled the original wording must remain.

Verified as a real guard: with the change reverted the first case fails and the second still passes, as it should.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
>
> Last box: covered by the Livewire tests above, which render the real component, but I did not click through a local instance — left unchecked rather than overstated.
