### PR TITLE
fix(ui): stop the new token heading from looking like a copy button

### DIFF
--- a/resources/views/livewire/security/api-tokens.blade.php
+++ b/resources/views/livewire/security/api-tokens.blade.php
@@ -107,7 +107,7 @@
             @endcan
 
             @if (session()->has('token'))
-                <x-application.settings-section title="Copy your token"
+                <x-application.settings-section title="Your new token"
                     description="This value will not be shown again after you leave this page.">
                     <x-forms.copy-button :text="session('token')" />
                 </x-application.settings-section>

--- a/tests/Feature/ApiTokenNewTokenSectionTest.php
+++ b/tests/Feature/ApiTokenNewTokenSectionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Livewire\Security\ApiTokens;
+use App\Models\InstanceSettings;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
+    $team = Team::factory()->create();
+    $owner = User::factory()->create();
+    $team->members()->attach($owner->id, ['role' => 'owner']);
+
+    $this->actingAs($owner);
+    session(['currentTeam' => $team]);
+});
+
+test('the freshly created token is announced with a non-imperative heading', function () {
+    Livewire::test(ApiTokens::class)
+        ->set('description', 'ci-token')
+        ->set('permissions', ['read'])
+        ->call('addNewToken')
+        ->assertSee('Your new token')
+        ->assertDontSee('Copy your token')
+        ->assertSee('This value will not be shown again after you leave this page.');
+});


### PR DESCRIPTION
## Changes

After you create an API token, the box showing the new token had the heading "Copy your token". That heading is underlined and it is clickable, and the wording sounds like a button, so the obvious thing to do is click it. Clicking it does not copy anything. It just opens the small help tooltip. The only thing that actually copies is the icon inside the input box, which is easy to miss.

That matters more than a normal styling issue because Sanctum only stores the hash of the token. If you think you copied it and move to another page, the token is gone for good and you have to create a new one.

The underline comes from `x-application.settings-section`, which turns the title into a tooltip trigger whenever a description is passed. That is fine everywhere else, because every other section title in the app is a plain noun like "Backup schedule" or "Issued tokens". This one was the only title written as a command, so the wording was the part that was wrong, not the component.

So this changes the title to "Your new token" and leaves everything else alone. The shared component is untouched, so no other screen is affected.

One note on naming. The issue suggested either "Your new token" or "New API token". I used the first one because the create token form right above it already uses "New API token" as its heading, and having the same heading twice on one page would be confusing.

## Issues

- Fixes #11567

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

I could not get a screenshot of this. See the note in the Testing section below.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

I added `tests/Feature/ApiTokenNewTokenSectionTest.php`. It creates a token through `addNewToken()` and then checks three things on the rendered component: that "Your new token" is shown, that "Copy your token" is no longer there, and that the description text still renders so the help tooltip did not get dropped by accident.

I ran it before making the change and it failed on the missing heading, then ran it again after the change and it passed.

I also ran the other API token tests to check nothing broke: `ApiTokenPermissionsLayoutTest`, `ApiTokenLivewireAuthorizationTest` and `ApiTokenPolicyTest`. That is 37 tests passing, 49 assertions. `vendor/bin/pint --dirty` is clean.

One thing I want to be upfront about. I could not open this page in a browser to look at it. On current `main`, every page that requires login returns a 500 from `resources/views/layouts/app.blade.php`. The `@parent` placeholder that Blade writes into the section buffer, `##parent-placeholder-<hash>##`, ends up inside the output of the `layout-popups` component that is mounted on the next line, and that trips Livewire's multiple root element check. It has nothing to do with this change and I can open a separate issue for it if that is useful. The test renders the same Blade output that the page does, so the change itself is still covered.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
