### PR TITLE
Add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,73 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: WordPress running behind OpenLiteSpeed with persistent MariaDB storage.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME:-wordpress}
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_TABLE_PREFIX=${WORDPRESS_TABLE_PREFIX:-wp_}
+      - TZ=${TZ:-UTC}
+    command: ["bash", "/usr/local/bin/coolify-wordpress-init.sh"]
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+      - type: bind
+        source: ./coolify-wordpress-init.sh
+        target: /usr/local/bin/coolify-wordpress-init.sh
+        content: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          cd /var/www/vhosts/localhost/html
+
+          until mysqladmin ping -h"${WORDPRESS_DB_HOST}" -u"${WORDPRESS_DB_USER}" -p"${WORDPRESS_DB_PASSWORD}" --silent; do
+            echo "Waiting for MariaDB..."
+            sleep 2
+          done
+
+          if [ ! -f index.php ]; then
+            wp core download --allow-root
+          fi
+
+          if [ ! -f wp-config.php ]; then
+            wp config create \
+              --allow-root \
+              --dbname="${WORDPRESS_DB_NAME}" \
+              --dbuser="${WORDPRESS_DB_USER}" \
+              --dbpass="${WORDPRESS_DB_PASSWORD}" \
+              --dbhost="${WORDPRESS_DB_HOST}" \
+              --dbprefix="${WORDPRESS_TABLE_PREFIX}"
+          fi
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=${WORDPRESS_DB_NAME:-wordpress}
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -219,7 +219,7 @@
     },
     "autobase": {
         "documentation": "https://autobase.tech/docs/?utm_source=coolify.io",
-        "slogan": "Autobase for PostgreSQL\u00ae is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
+        "slogan": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
         "compose": "c2VydmljZXM6CiAgYXV0b2Jhc2U6CiAgICBpbWFnZTogJ2F1dG9iYXNlL2NvbnNvbGVfdWk6Mi41LjInCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9BVVRPQkFTRV84MAogICAgICAtICdQR19DT05TT0xFX0FVVEhPUklaQVRJT05fVE9LRU49JHtTRVJWSUNFX1BBU1NXT1JEX1VJfScKICAgICAgLSBQR19DT05TT0xFX0FQSV9IT1NUPWF1dG9iYXNlLWFwaQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwLycKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgICBkZXBlbmRzX29uOgogICAgICBhdXRvYmFzZS1hcGk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICBhdXRvYmFzZS1kYjoKICAgIGltYWdlOiAnYXV0b2Jhc2UvY29uc29sZV9kYjoyLjUuMicKICAgIHBsYXRmb3JtOiBsaW51eC9hbWQ2NAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICB2b2x1bWVzOgogICAgICAtICdhdXRvYmFzZS1kYi1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgcG9zdGdyZXMnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAogIGF1dG9iYXNlLWFwaToKICAgIGltYWdlOiAnYXV0b2Jhc2UvY29uc29sZV9hcGk6Mi41LjInCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFBHX0NPTlNPTEVfREJfSE9TVD1hdXRvYmFzZS1kYgogICAgICAtICdQR19DT05TT0xFX0RCX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICAgIC0gJ1BHX0NPTlNPTEVfQVVUSE9SSVpBVElPTl9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfVUl9JwogICAgICAtICdQR19DT05TT0xFX0VOQ1JZUFRJT05LRVk9JHtTRVJWSUNFX0JBU0U2NF9FTkNSWVBUSU9OS0VZfScKICAgICAgLSAnUEdfQ09OU09MRV9MT0dHRVJfTEVWRUw9JHtQR19DT05TT0xFX0xPR0dFUl9MRVZFTDotaW5mb30nCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgICAgLSAnL3RtcC9hbnNpYmxlOi90bXAvYW5zaWJsZScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWZzUycKICAgICAgICAtICctSCcKICAgICAgICAtICdhY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24nCiAgICAgICAgLSAnLUgnCiAgICAgICAgLSAnQXV0aG9yaXphdGlvbjogQmVhcmVyICR7U0VSVklDRV9QQVNTV09SRF9VSX0nCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4MDgwL2FwaS92MS92ZXJzaW9uJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDUKICAgIGRlcGVuZHNfb246CiAgICAgIGF1dG9iYXNlLWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5Cg==",
         "tags": [
             "database",
@@ -266,22 +266,6 @@
         "template_last_updated_at": "2026-02-03T22:27:36+01:00",
         "port": "8080"
     },
-    "beszel-agent": {
-        "documentation": "https://www.beszel.dev/guide/agent-installation?utm_source=coolify.io",
-        "slogan": "Monitoring agent for Beszel",
-        "compose": "c2VydmljZXM6CiAgYmVzemVsLWFnZW50OgogICAgaW1hZ2U6ICdoZW5yeWdkL2Jlc3plbC1hZ2VudDowLjE4LjcnCiAgICBuZXR3b3JrX21vZGU6IGhvc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIExJU1RFTj0vYmVzemVsX3NvY2tldC9iZXN6ZWwuc29jawogICAgICAtIEhVQl9VUkw9JFNFUlZJQ0VfVVJMX0JFU1pFTAogICAgICAtICdUT0tFTj0ke1RPS0VOfScKICAgICAgLSAnS0VZPSR7S0VZfScKICAgICAgLSAnRElTQUJMRV9TU0g9JHtESVNBQkxFX1NTSDotZmFsc2V9JwogICAgICAtICdMT0dfTEVWRUw9JHtMT0dfTEVWRUw6LXdhcm59JwogICAgICAtICdTS0lQX0dQVT0ke1NLSVBfR1BVOi1mYWxzZX0nCiAgICAgIC0gJ1NZU1RFTV9OQU1FPSR7U1lTVEVNX05BTUV9JwogICAgdm9sdW1lczoKICAgICAgLSAnYmVzemVsX2FnZW50X2RhdGE6L3Zhci9saWIvYmVzemVsLWFnZW50JwogICAgICAtICdiZXN6ZWxfc29ja2V0Oi9iZXN6ZWxfc29ja2V0JwogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jazpybycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvYWdlbnQKICAgICAgICAtIGhlYWx0aAogICAgICBpbnRlcnZhbDogNjBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgICBzdGFydF9wZXJpb2Q6IDVzCg==",
-        "tags": [
-            "beszel",
-            "monitoring",
-            "server",
-            "stats",
-            "alerts"
-        ],
-        "category": "monitoring",
-        "logo": "svgs/beszel.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-24T02:22:08+05:30"
-    },
     "beszel": {
         "documentation": "https://github.com/henrygd/beszel?tab=readme-ov-file#getting-started?utm_source=coolify.io",
         "slogan": "A lightweight server resource monitoring hub with historical data, docker stats, and alerts.",
@@ -298,6 +282,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-24T02:21:33+05:30",
         "port": "8090"
+    },
+    "beszel-agent": {
+        "documentation": "https://www.beszel.dev/guide/agent-installation?utm_source=coolify.io",
+        "slogan": "Monitoring agent for Beszel",
+        "compose": "c2VydmljZXM6CiAgYmVzemVsLWFnZW50OgogICAgaW1hZ2U6ICdoZW5yeWdkL2Jlc3plbC1hZ2VudDowLjE4LjcnCiAgICBuZXR3b3JrX21vZGU6IGhvc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIExJU1RFTj0vYmVzemVsX3NvY2tldC9iZXN6ZWwuc29jawogICAgICAtIEhVQl9VUkw9JFNFUlZJQ0VfVVJMX0JFU1pFTAogICAgICAtICdUT0tFTj0ke1RPS0VOfScKICAgICAgLSAnS0VZPSR7S0VZfScKICAgICAgLSAnRElTQUJMRV9TU0g9JHtESVNBQkxFX1NTSDotZmFsc2V9JwogICAgICAtICdMT0dfTEVWRUw9JHtMT0dfTEVWRUw6LXdhcm59JwogICAgICAtICdTS0lQX0dQVT0ke1NLSVBfR1BVOi1mYWxzZX0nCiAgICAgIC0gJ1NZU1RFTV9OQU1FPSR7U1lTVEVNX05BTUV9JwogICAgdm9sdW1lczoKICAgICAgLSAnYmVzemVsX2FnZW50X2RhdGE6L3Zhci9saWIvYmVzemVsLWFnZW50JwogICAgICAtICdiZXN6ZWxfc29ja2V0Oi9iZXN6ZWxfc29ja2V0JwogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jazpybycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvYWdlbnQKICAgICAgICAtIGhlYWx0aAogICAgICBpbnRlcnZhbDogNjBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgICBzdGFydF9wZXJpb2Q6IDVzCg==",
+        "tags": [
+            "beszel",
+            "monitoring",
+            "server",
+            "stats",
+            "alerts"
+        ],
+        "category": "monitoring",
+        "logo": "svgs/beszel.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-24T02:22:08+05:30"
     },
     "bitcoin-core": {
         "documentation": "https://hub.docker.com/r/ruimarinho/bitcoin-core/?utm_source=coolify.io",
@@ -438,6 +438,27 @@
         "template_last_updated_at": null,
         "port": "3000"
     },
+    "calibre-web": {
+        "documentation": "https://github.com/linuxserver/docker-calibre-web?utm_source=coolify.io",
+        "slogan": "Calibre-web is a web app providing a clean interface for browsing, reading and downloading eBooks.",
+        "compose": "c2VydmljZXM6CiAgY2FsaWJyZS13ZWI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvY2FsaWJyZS13ZWI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfQ0FMSUJSRV84MDgzCiAgICAgIC0gUFVJRD0xMDAwCiAgICAgIC0gUEdJRD0xMDAwCiAgICAgIC0gJ1RaPSR7VFo6LUV0Yy9VVEN9JwogICAgICAtICdET0NLRVJfTU9EUz0ke0RPQ0tFUl9NT0RTOi1saW51eHNlcnZlci9tb2RzOnVuaXZlcnNhbC1jYWxpYnJlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2NhbGlicmVfd2ViX2RhdGE6L2NvbmZpZycKICAgICAgLSAnY2FsaWJyZV9saWJyYXJ5Oi9ib29rcycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgzJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "calibre",
+            "calibre-web",
+            "ebook",
+            "library",
+            "epub",
+            "ereader",
+            "kindle",
+            "book",
+            "reader"
+        ],
+        "category": "media",
+        "logo": "svgs/calibre-web.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8083"
+    },
     "calibre-web-automated-book-downloader": {
         "documentation": "https://github.com/calibrain/calibre-web-automated-book-downloader?utm_source=coolify.io",
         "slogan": "An intuitive web interface for searching and requesting book downloads, designed to work seamlessly with Calibre-Web-Automated.",
@@ -461,43 +482,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "8083"
     },
-    "calibre-web": {
-        "documentation": "https://github.com/linuxserver/docker-calibre-web?utm_source=coolify.io",
-        "slogan": "Calibre-web is a web app providing a clean interface for browsing, reading and downloading eBooks.",
-        "compose": "c2VydmljZXM6CiAgY2FsaWJyZS13ZWI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvY2FsaWJyZS13ZWI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfQ0FMSUJSRV84MDgzCiAgICAgIC0gUFVJRD0xMDAwCiAgICAgIC0gUEdJRD0xMDAwCiAgICAgIC0gJ1RaPSR7VFo6LUV0Yy9VVEN9JwogICAgICAtICdET0NLRVJfTU9EUz0ke0RPQ0tFUl9NT0RTOi1saW51eHNlcnZlci9tb2RzOnVuaXZlcnNhbC1jYWxpYnJlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2NhbGlicmVfd2ViX2RhdGE6L2NvbmZpZycKICAgICAgLSAnY2FsaWJyZV9saWJyYXJ5Oi9ib29rcycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgzJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
-        "tags": [
-            "calibre",
-            "calibre-web",
-            "ebook",
-            "library",
-            "epub",
-            "ereader",
-            "kindle",
-            "book",
-            "reader"
-        ],
-        "category": "media",
-        "logo": "svgs/calibre-web.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8083"
-    },
-    "cap-captcha": {
-        "documentation": "https://capjs.js.org/guide/?utm_source=coolify.io",
-        "slogan": "The self-hosted CAPTCHA for the modern web.",
-        "compose": "c2VydmljZXM6CiAgY2FwOgogICAgaW1hZ2U6ICd0aWFnbzIvY2FwOjMuMC40JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfQ0FQXzMwMDAKICAgICAgLSBBRE1JTl9LRVk9JFNFUlZJQ0VfUEFTU1dPUkRfQURNSU4KICAgICAgLSAnUkVESVNfVVJMPXJlZGlzOi8vdmFsa2V5OjYzNzknCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gYnVuCiAgICAgICAgLSAnLWUnCiAgICAgICAgLSAiZmV0Y2goJ2h0dHA6Ly9sb2NhbGhvc3Q6MzAwMCcpLnRoZW4ociA9PiB7IGlmICghci5vaykgcHJvY2Vzcy5leGl0KDEpIH0pLmNhdGNoKCgpID0+IHByb2Nlc3MuZXhpdCgxKSkiCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwogICAgICBzdGFydF9wZXJpb2Q6IDVzCiAgICBkZXBlbmRzX29uOgogICAgICB2YWxrZXk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICB2YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OS1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICd2YWxrZXktZGF0YTovZGF0YScKICAgIGNvbW1hbmQ6ICd2YWxrZXktc2VydmVyIC0tc2F2ZSA2MCAxIC0tbG9nbGV2ZWwgd2FybmluZyAtLW1heG1lbW9yeS1wb2xpY3kgbm9ldmljdGlvbicKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB2YWxrZXktY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1Cg==",
-        "tags": [
-            "captcha",
-            "security",
-            "privacy",
-            "proof-of-work"
-        ],
-        "category": "security",
-        "logo": "svgs/cap-captcha.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-23T01:07:14+05:30",
-        "port": "3000"
-    },
     "cap": {
         "documentation": "https://cap.so?utm_source=coolify.io",
         "slogan": "Cap is the open source alternative to Loom. Lightweight, powerful, and cross-platform. Record and share in seconds.",
@@ -515,6 +499,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "5679"
+    },
+    "cap-captcha": {
+        "documentation": "https://capjs.js.org/guide/?utm_source=coolify.io",
+        "slogan": "The self-hosted CAPTCHA for the modern web.",
+        "compose": "c2VydmljZXM6CiAgY2FwOgogICAgaW1hZ2U6ICd0aWFnbzIvY2FwOjMuMC40JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfQ0FQXzMwMDAKICAgICAgLSBBRE1JTl9LRVk9JFNFUlZJQ0VfUEFTU1dPUkRfQURNSU4KICAgICAgLSAnUkVESVNfVVJMPXJlZGlzOi8vdmFsa2V5OjYzNzknCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gYnVuCiAgICAgICAgLSAnLWUnCiAgICAgICAgLSAiZmV0Y2goJ2h0dHA6Ly9sb2NhbGhvc3Q6MzAwMCcpLnRoZW4ociA9PiB7IGlmICghci5vaykgcHJvY2Vzcy5leGl0KDEpIH0pLmNhdGNoKCgpID0+IHByb2Nlc3MuZXhpdCgxKSkiCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwogICAgICBzdGFydF9wZXJpb2Q6IDVzCiAgICBkZXBlbmRzX29uOgogICAgICB2YWxrZXk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICB2YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OS1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICd2YWxrZXktZGF0YTovZGF0YScKICAgIGNvbW1hbmQ6ICd2YWxrZXktc2VydmVyIC0tc2F2ZSA2MCAxIC0tbG9nbGV2ZWwgd2FybmluZyAtLW1heG1lbW9yeS1wb2xpY3kgbm9ldmljdGlvbicKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB2YWxrZXktY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1Cg==",
+        "tags": [
+            "captcha",
+            "security",
+            "privacy",
+            "proof-of-work"
+        ],
+        "category": "security",
+        "logo": "svgs/cap-captcha.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-23T01:07:14+05:30",
+        "port": "3000"
     },
     "castopod": {
         "documentation": "https://docs.castopod.org/main/en/?utm_source=coolify.io",
@@ -823,6 +823,23 @@
         "template_last_updated_at": "2025-11-03T21:29:53+08:00",
         "port": "3000"
     },
+    "convertx": {
+        "documentation": "https://github.com/C4illin/ConvertX?utm_source=coolify.io",
+        "slogan": "A self-hosted online file converter. Supports over a thousand different formats.",
+        "compose": "c2VydmljZXM6CiAgY29udmVydHg6CiAgICBpbWFnZTogJ2doY3IuaW8vYzRpbGxpbi9jb252ZXJ0eDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9DT05WRVJUWAogICAgICAtICdBQ0NPVU5UX1JFR0lTVFJBVElPTj0ke0FDQ09VTlRfUkVHSVNUUkFUSU9OOi1mYWxzZX0nCiAgICAgIC0gJ0hUVFBfQUxMT1dFRD0ke0hUVFBfQUxMT1dFRDotdHJ1ZX0nCiAgICAgIC0gJ0FMTE9XX1VOQVVUSEVOVElDQVRFRD0ke0FMTE9XX1VOQVVUSEVOVElDQVRFRDotZmFsc2V9JwogICAgICAtICdBVVRPX0RFTEVURV9FVkVSWV9OX0hPVVJTPSR7QVVUT19ERUxFVEVfRVZFUllfTl9IT1VSUzotMjR9JwogICAgICAtICdKV1RfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9DT05WRVJUWEpXVFNFQ1JFVH0nCiAgICB2b2x1bWVzOgogICAgICAtICdjb252ZXJ0eF9kYXRhOi9hcHAvZGF0YScK",
+        "tags": [
+            "converter",
+            "file",
+            "documents",
+            "files",
+            "directories"
+        ],
+        "category": "backend",
+        "logo": "svgs/convertx.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3000"
+    },
     "convex": {
         "documentation": "https://github.com/get-convex/convex-backend/blob/main/self-hosted/README.md?utm_source=coolify.io",
         "slogan": "Convex is the open-source reactive database for app developers.",
@@ -929,22 +946,6 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "4512"
     },
-    "directus-with-postgresql": {
-        "documentation": "https://directus.io?utm_source=coolify.io",
-        "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
-        "compose": "c2VydmljZXM6CiAgZGlyZWN0dXM6CiAgICBpbWFnZTogJ2RpcmVjdHVzL2RpcmVjdHVzOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtdXBsb2FkczovZGlyZWN0dXMvdXBsb2FkcycKICAgICAgLSAnZGlyZWN0dXMtZXh0ZW5zaW9uczovZGlyZWN0dXMvZXh0ZW5zaW9ucycKICAgICAgLSAnZGlyZWN0dXMtdGVtcGxhdGVzOi9kaXJlY3R1cy90ZW1wbGF0ZXMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9ESVJFQ1RVU184MDU1CiAgICAgIC0gS0VZPSRTRVJWSUNFX0JBU0U2NF82NF9LRVkKICAgICAgLSBTRUNSRVQ9JFNFUlZJQ0VfQkFTRTY0XzY0X1NFQ1JFVAogICAgICAtICdBRE1JTl9FTUFJTD0ke0FETUlOX0VNQUlMOi1hZG1pbkBleGFtcGxlLmNvbX0nCiAgICAgIC0gQURNSU5fUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfQURNSU4KICAgICAgLSBEQl9DTElFTlQ9cG9zdGdyZXMKICAgICAgLSBEQl9IT1NUPXBvc3RncmVzcWwKICAgICAgLSBEQl9QT1JUPTU0MzIKICAgICAgLSAnREJfREFUQUJBU0U9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1kaXJlY3R1c30nCiAgICAgIC0gREJfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTUUwKICAgICAgLSBEQl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMCiAgICAgIC0gUkVESVNfSE9TVD1yZWRpcwogICAgICAtIFJFRElTX1BPUlQ9NjM3OQogICAgICAtIFdFQlNPQ0tFVFNfRU5BQkxFRD10cnVlCiAgICAgIC0gJ0NPUlNfRU5BQkxFRD0ke0NPUlNfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0NPUlNfT1JJR0lOPSR7Q09SU19PUklHSU59JwogICAgICAtICdDT1JTX01FVEhPRFM9JHtDT1JTX01FVEhPRFM6LUdFVCxQT1NULFBBVENILERFTEVURSxPUFRJT05TfScKICAgICAgLSAnQ09SU19BTExPV0VEX0hFQURFUlM9JHtDT1JTX0FMTE9XRURfSEVBREVSUzotQ29udGVudC1UeXBlLEF1dGhvcml6YXRpb259JwogICAgICAtICdDT1JTX0NSRURFTlRJQUxTPSR7Q09SU19DUkVERU5USUFMUzotdHJ1ZX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA1NS9hZG1pbi9sb2dpbicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXNxbDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RnaXMvcG9zdGdpczoxNi0zLjQtYWxwaW5lJwogICAgcGxhdGZvcm06IGxpbnV4L2FtZDY0CiAgICB2b2x1bWVzOgogICAgICAtICdkaXJlY3R1cy1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1kaXJlY3R1c30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgY29tbWFuZDogJ3JlZGlzLXNlcnZlciAtLWFwcGVuZG9ubHkgeWVzJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtcmVkaXMtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
-        "tags": [
-            "directus",
-            "cms",
-            "database",
-            "sql"
-        ],
-        "category": "cms",
-        "logo": "svgs/directus.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-03T19:25:51+05:30",
-        "port": "8055"
-    },
     "directus": {
         "documentation": "https://directus.io?utm_source=coolify.io",
         "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
@@ -959,6 +960,22 @@
         "logo": "svgs/directus.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-03T19:26:06+05:30",
+        "port": "8055"
+    },
+    "directus-with-postgresql": {
+        "documentation": "https://directus.io?utm_source=coolify.io",
+        "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
+        "compose": "c2VydmljZXM6CiAgZGlyZWN0dXM6CiAgICBpbWFnZTogJ2RpcmVjdHVzL2RpcmVjdHVzOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtdXBsb2FkczovZGlyZWN0dXMvdXBsb2FkcycKICAgICAgLSAnZGlyZWN0dXMtZXh0ZW5zaW9uczovZGlyZWN0dXMvZXh0ZW5zaW9ucycKICAgICAgLSAnZGlyZWN0dXMtdGVtcGxhdGVzOi9kaXJlY3R1cy90ZW1wbGF0ZXMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9ESVJFQ1RVU184MDU1CiAgICAgIC0gS0VZPSRTRVJWSUNFX0JBU0U2NF82NF9LRVkKICAgICAgLSBTRUNSRVQ9JFNFUlZJQ0VfQkFTRTY0XzY0X1NFQ1JFVAogICAgICAtICdBRE1JTl9FTUFJTD0ke0FETUlOX0VNQUlMOi1hZG1pbkBleGFtcGxlLmNvbX0nCiAgICAgIC0gQURNSU5fUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfQURNSU4KICAgICAgLSBEQl9DTElFTlQ9cG9zdGdyZXMKICAgICAgLSBEQl9IT1NUPXBvc3RncmVzcWwKICAgICAgLSBEQl9QT1JUPTU0MzIKICAgICAgLSAnREJfREFUQUJBU0U9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1kaXJlY3R1c30nCiAgICAgIC0gREJfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTUUwKICAgICAgLSBEQl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMCiAgICAgIC0gUkVESVNfSE9TVD1yZWRpcwogICAgICAtIFJFRElTX1BPUlQ9NjM3OQogICAgICAtIFdFQlNPQ0tFVFNfRU5BQkxFRD10cnVlCiAgICAgIC0gJ0NPUlNfRU5BQkxFRD0ke0NPUlNfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0NPUlNfT1JJR0lOPSR7Q09SU19PUklHSU59JwogICAgICAtICdDT1JTX01FVEhPRFM9JHtDT1JTX01FVEhPRFM6LUdFVCxQT1NULFBBVENILERFTEVURSxPUFRJT05TfScKICAgICAgLSAnQ09SU19BTExPV0VEX0hFQURFUlM9JHtDT1JTX0FMTE9XRURfSEVBREVSUzotQ29udGVudC1UeXBlLEF1dGhvcml6YXRpb259JwogICAgICAtICdDT1JTX0NSRURFTlRJQUxTPSR7Q09SU19DUkVERU5USUFMUzotdHJ1ZX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA1NS9hZG1pbi9sb2dpbicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXNxbDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RnaXMvcG9zdGdpczoxNi0zLjQtYWxwaW5lJwogICAgcGxhdGZvcm06IGxpbnV4L2FtZDY0CiAgICB2b2x1bWVzOgogICAgICAtICdkaXJlY3R1cy1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1kaXJlY3R1c30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgY29tbWFuZDogJ3JlZGlzLXNlcnZlciAtLWFwcGVuZG9ubHkgeWVzJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtcmVkaXMtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "directus",
+            "cms",
+            "database",
+            "sql"
+        ],
+        "category": "cms",
+        "logo": "svgs/directus.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-03T19:25:51+05:30",
         "port": "8055"
     },
     "diun": {
@@ -1031,10 +1048,10 @@
         "template_last_updated_at": "2025-11-07T17:08:01+05:30",
         "port": "3000"
     },
-    "docuseal-with-postgres": {
+    "docuseal": {
         "documentation": "https://www.docuseal.co/?utm_source=coolify.io",
         "slogan": "Document Signing for Everyone free forever for individuals, extensible for businesses and developers. Open Source Alternative to DocuSign, PandaDoc and more.",
-        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPQ1VTRUFMXzMwMDAKICAgICAgLSAnSE9TVD0ke1NFUlZJQ0VfVVJMX0RPQ1VTRUFMfScKICAgICAgLSAnREFUQUJBU0VfVVJMPXBvc3RncmVzcWw6Ly8kU0VSVklDRV9VU0VSX1BPU1RHUkVTOiRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTQHBvc3RncmVzcWw6NTQzMi8ke1BPU1RHUkVTX0RCfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RvY3VzZWFsLWRhdGE6L2RhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3Jlc3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19VU0VSPSRTRVJWSUNFX1VTRVJfUE9TVEdSRVMKICAgICAgLSBQT1NUR1JFU19QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFUwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1kb2N1c2VhbH0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPQ1VTRUFMXzMwMDAKICAgICAgLSAnSE9TVD0ke1NFUlZJQ0VfVVJMX0RPQ1VTRUFMfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RvY3VzZWFsLWRhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "documentation"
         ],
@@ -1044,10 +1061,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "docuseal": {
+    "docuseal-with-postgres": {
         "documentation": "https://www.docuseal.co/?utm_source=coolify.io",
         "slogan": "Document Signing for Everyone free forever for individuals, extensible for businesses and developers. Open Source Alternative to DocuSign, PandaDoc and more.",
-        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPQ1VTRUFMXzMwMDAKICAgICAgLSAnSE9TVD0ke1NFUlZJQ0VfVVJMX0RPQ1VTRUFMfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RvY3VzZWFsLWRhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPQ1VTRUFMXzMwMDAKICAgICAgLSAnSE9TVD0ke1NFUlZJQ0VfVVJMX0RPQ1VTRUFMfScKICAgICAgLSAnREFUQUJBU0VfVVJMPXBvc3RncmVzcWw6Ly8kU0VSVklDRV9VU0VSX1BPU1RHUkVTOiRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTQHBvc3RncmVzcWw6NTQzMi8ke1BPU1RHUkVTX0RCfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RvY3VzZWFsLWRhdGE6L2RhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3Jlc3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19VU0VSPSRTRVJWSUNFX1VTRVJfUE9TVEdSRVMKICAgICAgLSBQT1NUR1JFU19QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFUwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1kb2N1c2VhbH0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "documentation"
         ],
@@ -1086,10 +1103,10 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "dozzle-with-auth": {
-        "documentation": "https://dozzle.dev/?utm_source=coolify.io",
+    "dozzle": {
+        "documentation": "https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io",
         "slogan": "Dozzle is a simple and lightweight web UI for Docker logs.",
-        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPWlpMRV84MDgwCiAgICAgIC0gRE9aWkxFX0FVVEhfUFJPVklERVI9c2ltcGxlCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgICAgLQogICAgICAgIHR5cGU6IGJpbmQKICAgICAgICBzb3VyY2U6IC4vZGF0YS91c2Vycy55bWwKICAgICAgICB0YXJnZXQ6ICcvZGF0YS91c2Vycy55bWw6cm8nCiAgICAgICAgY29udGVudDogInVzZXJzOlxuICAjIFwiYWRtaW5cIiBpcyB0aGUgdXNlcm5hbWVcbiAgYWRtaW46XG4gICAgZW1haWw6IHRlc3RAZW1haWwuY29tXG4gICAgbmFtZTogQWRtaW5cbiAgICAjIEEgc2hhLTI1NiBoYXNoIG9mIHRoZSBwYXNzd29yZCB5b3Ugd2FudCB0byB1c2UuIENhbiBiZSBjb21wdXRlZCB3aXRoIFwiZWNobyAtbiBwYXNzd29yZCB8IHNoYXN1bSAtYSAyNTZcIi4gRGVmYXVsdCBwYXNzd29yZCBpcyBcIlRlc3RcIi5cbiAgICBwYXNzd29yZDogJDJhJDExJHZpdWNDdkZMbEhXdkJOT09JNnV5cHVWVS5EMDlVV2IuenN3UnhFZzBNa0RQaTFxL2JLYmRHXG4iCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2RvenpsZQogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDNzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiA1Cg==",
+        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPWlpMRV84MDgwCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvZG96emxlCiAgICAgICAgLSBoZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogM3MKICAgICAgdGltZW91dDogMzBzCiAgICAgIHJldHJpZXM6IDUKICAgICAgc3RhcnRfcGVyaW9kOiAzMHMK",
         "tags": [
             "dozzle",
             "docker",
@@ -1102,10 +1119,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
-    "dozzle": {
-        "documentation": "https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io",
+    "dozzle-with-auth": {
+        "documentation": "https://dozzle.dev/?utm_source=coolify.io",
         "slogan": "Dozzle is a simple and lightweight web UI for Docker logs.",
-        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPWlpMRV84MDgwCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvZG96emxlCiAgICAgICAgLSBoZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogM3MKICAgICAgdGltZW91dDogMzBzCiAgICAgIHJldHJpZXM6IDUKICAgICAgc3RhcnRfcGVyaW9kOiAzMHMK",
+        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0RPWlpMRV84MDgwCiAgICAgIC0gRE9aWkxFX0FVVEhfUFJPVklERVI9c2ltcGxlCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgICAgLQogICAgICAgIHR5cGU6IGJpbmQKICAgICAgICBzb3VyY2U6IC4vZGF0YS91c2Vycy55bWwKICAgICAgICB0YXJnZXQ6ICcvZGF0YS91c2Vycy55bWw6cm8nCiAgICAgICAgY29udGVudDogInVzZXJzOlxuICAjIFwiYWRtaW5cIiBpcyB0aGUgdXNlcm5hbWVcbiAgYWRtaW46XG4gICAgZW1haWw6IHRlc3RAZW1haWwuY29tXG4gICAgbmFtZTogQWRtaW5cbiAgICAjIEEgc2hhLTI1NiBoYXNoIG9mIHRoZSBwYXNzd29yZCB5b3Ugd2FudCB0byB1c2UuIENhbiBiZSBjb21wdXRlZCB3aXRoIFwiZWNobyAtbiBwYXNzd29yZCB8IHNoYXN1bSAtYSAyNTZcIi4gRGVmYXVsdCBwYXNzd29yZCBpcyBcIlRlc3RcIi5cbiAgICBwYXNzd29yZDogJDJhJDExJHZpdWNDdkZMbEhXdkJOT09JNnV5cHVWVS5EMDlVV2IuenN3UnhFZzBNa0RQaTFxL2JLYmRHXG4iCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2RvenpsZQogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDNzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiA1Cg==",
         "tags": [
             "dozzle",
             "docker",
@@ -1180,6 +1197,24 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
+    "elasticsearch": {
+        "documentation": "https://www.elastic.co/products/elasticsearch?utm_source=coolify.io",
+        "slogan": "Elasticsearch is free and Open Source, Distributed, RESTful Search Engine.",
+        "compose": "c2VydmljZXM6CiAgZWxhc3RpY3NlYXJjaDoKICAgIGltYWdlOiAnZG9ja2VyLmVsYXN0aWMuY28vZWxhc3RpY3NlYXJjaC9lbGFzdGljc2VhcmNoLXdvbGZpOjguMTkuMCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0VMQVNUSUNTRUFSQ0hfOTIwMAogICAgICAtICdFTEFTVElDX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9FTEFTVElDU0VBUkNIfScKICAgICAgLSAnRVNfSkFWQV9PUFRTPS1YbXM1MTJtIC1YbXg1MTJtJwogICAgICAtIGRpc2NvdmVyeS50eXBlPXNpbmdsZS1ub2RlCiAgICAgIC0gYm9vdHN0cmFwLm1lbW9yeV9sb2NrPXRydWUKICAgICAgLSB4cGFjay5zZWN1cml0eS5odHRwLnNzbC5lbmFibGVkPWZhbHNlCiAgICB2b2x1bWVzOgogICAgICAtICdlbGFzdGljc2VhcmNoLWRhdGE6L3Vzci9zaGFyZS9lbGFzdGljc2VhcmNoL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ2N1cmwgLS11c2VyIGVsYXN0aWM6JHtTRVJWSUNFX1BBU1NXT1JEX0VMQVNUSUNTRUFSQ0h9IC0tc2lsZW50IC0tZmFpbCBodHRwOi8vbG9jYWxob3N0OjkyMDAvX2NsdXN0ZXIvaGVhbHRoJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAyNAo=",
+        "tags": [
+            "search",
+            "engine",
+            "fulltext",
+            "full",
+            "text",
+            "elasticsearch"
+        ],
+        "category": "search",
+        "logo": "svgs/elasticsearch.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-18T18:30:06+02:00",
+        "port": "9200"
+    },
     "elasticsearch-with-kibana": {
         "documentation": "https://www.elastic.co/docs/deploy-manage/deploy/self-managed/install-kibana-with-docker?utm_source=coolify.io",
         "slogan": "Elastic + Kibana is a Free and Open Source Search, Monitoring, and Visualization Stack",
@@ -1202,24 +1237,6 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-09T00:43:59-05:00",
         "port": "5601"
-    },
-    "elasticsearch": {
-        "documentation": "https://www.elastic.co/products/elasticsearch?utm_source=coolify.io",
-        "slogan": "Elasticsearch is free and Open Source, Distributed, RESTful Search Engine.",
-        "compose": "c2VydmljZXM6CiAgZWxhc3RpY3NlYXJjaDoKICAgIGltYWdlOiAnZG9ja2VyLmVsYXN0aWMuY28vZWxhc3RpY3NlYXJjaC9lbGFzdGljc2VhcmNoLXdvbGZpOjguMTkuMCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0VMQVNUSUNTRUFSQ0hfOTIwMAogICAgICAtICdFTEFTVElDX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9FTEFTVElDU0VBUkNIfScKICAgICAgLSAnRVNfSkFWQV9PUFRTPS1YbXM1MTJtIC1YbXg1MTJtJwogICAgICAtIGRpc2NvdmVyeS50eXBlPXNpbmdsZS1ub2RlCiAgICAgIC0gYm9vdHN0cmFwLm1lbW9yeV9sb2NrPXRydWUKICAgICAgLSB4cGFjay5zZWN1cml0eS5odHRwLnNzbC5lbmFibGVkPWZhbHNlCiAgICB2b2x1bWVzOgogICAgICAtICdlbGFzdGljc2VhcmNoLWRhdGE6L3Vzci9zaGFyZS9lbGFzdGljc2VhcmNoL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ2N1cmwgLS11c2VyIGVsYXN0aWM6JHtTRVJWSUNFX1BBU1NXT1JEX0VMQVNUSUNTRUFSQ0h9IC0tc2lsZW50IC0tZmFpbCBodHRwOi8vbG9jYWxob3N0OjkyMDAvX2NsdXN0ZXIvaGVhbHRoJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAyNAo=",
-        "tags": [
-            "search",
-            "engine",
-            "fulltext",
-            "full",
-            "text",
-            "elasticsearch"
-        ],
-        "category": "search",
-        "logo": "svgs/elasticsearch.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-18T18:30:06+02:00",
-        "port": "9200"
     },
     "electricsql": {
         "documentation": "https://electric-sql.com/docs/guides/deployment?utm_source=coolify.io",
@@ -1290,26 +1307,6 @@
         "template_last_updated_at": "2026-04-27T09:25:48+03:00",
         "port": "18083"
     },
-    "ente-photos-with-s3": {
-        "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
-        "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
-        "compose": "c2VydmljZXM6CiAgbXVzZXVtOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vc2VydmVyOjYxM2M2YTk2MzkwZDdhNjI0Y2YzMGI5NDY5NTU3MDVkNjMyNDIzY2MnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9NVVNFVU1fODA4MAogICAgICAtIEVOVEVfREJfSE9TVD1wb3N0Z3JlcwogICAgICAtIEVOVEVfREJfUE9SVD01NDMyCiAgICAgIC0gJ0VOVEVfREJfTkFNRT0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgLSAnRU5URV9EQl9VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnRU5URV9EQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdFTlRFX0hUVFBfVVNFX1RMUz0ke0VOVEVfSFRUUF9VU0VfVExTOi1mYWxzZX0nCiAgICAgIC0gRU5URV9TM19BUkVfTE9DQUxfQlVDS0VUUz1mYWxzZQogICAgICAtIEVOVEVfUzNfVVNFX1BBVEhfU1RZTEVfVVJMUz10cnVlCiAgICAgIC0gJ0VOVEVfUzNfQjJfRVVfQ0VOX0tFWT0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ0VOVEVfUzNfQjJfRVVfQ0VOX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9FTkRQT0lOVD0ke1NFUlZJQ0VfRlFETl9NSU5JT185MDAwfScKICAgICAgLSBFTlRFX1MzX0IyX0VVX0NFTl9SRUdJT049ZXUtY2VudHJhbC0yCiAgICAgIC0gRU5URV9TM19CMl9FVV9DRU5fQlVDS0VUPWIyLWV1LWNlbgogICAgICAtICdFTlRFX0tFWV9FTkNSWVBUSU9OPSR7U0VSVklDRV9SRUFMQkFTRTY0X0VOQ1JZUFRJT059JwogICAgICAtICdFTlRFX0tFWV9IQVNIPSR7U0VSVklDRV9SRUFMQkFTRTY0XzY0X0hBU0h9JwogICAgICAtICdFTlRFX0pXVF9TRUNSRVQ9JHtTRVJWSUNFX1JFQUxCQVNFNjRfSldUfScKICAgICAgLSAnRU5URV9JTlRFUk5BTF9BRE1JTj0ke0VOVEVfSU5URVJOQUxfQURNSU46LTE1ODA1NTk5NjIzODY0Mzh9JwogICAgICAtICdFTlRFX0lOVEVSTkFMX0RJU0FCTEVfUkVHSVNUUkFUSU9OPSR7RU5URV9JTlRFUk5BTF9ESVNBQkxFX1JFR0lTVFJBVElPTjotZmFsc2V9JwogICAgICAtICdFTlRFX1NNVFBfSE9TVD0ke0VOVEVfU01UUF9IT1NUOi1zbXRwLmdtYWlsLmNvbX0nCiAgICAgIC0gJ0VOVEVfU01UUF9QT1JUPSR7RU5URV9TTVRQX1BPUlQ6LTU4N30nCiAgICAgIC0gJ0VOVEVfU01UUF9VU0VSTkFNRT0ke0VOVEVfU01UUF9VU0VSTkFNRX0nCiAgICAgIC0gJ0VOVEVfU01UUF9QQVNTV09SRD0ke0VOVEVfU01UUF9QQVNTV09SRH0nCiAgICAgIC0gJ0VOVEVfU01UUF9FTUFJTD0ke0VOVEVfU01UUF9FTUFJTH0nCiAgICAgIC0gJ0VOVEVfU01UUF9TRU5ERVJfTkFNRT0ke0VOVEVfU01UUF9TRU5ERVJfTkFNRX0nCiAgICAgIC0gJ0VOVEVfU01UUF9FTkNSWVBUSU9OPSR7RU5URV9TTVRQX0VOQ1JZUFRJT046LXRsc30nCiAgICB2b2x1bWVzOgogICAgICAtICdtdXNldW0tZGF0YTovZGF0YScKICAgICAgLSAnbXVzZXVtLWNvbmZpZzovY29uZmlnJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgwL3BpbmcnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICB3ZWI6CiAgICBpbWFnZTogJ2doY3IuaW8vZW50ZS1pby93ZWI6Y2EwMzE2NWY1ZTdmMmE1MDEwNWU2ZTQwMDE5YzE3YWU2Y2RkOTM0ZicKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1dFQl8zMDAwCiAgICAgIC0gJ0VOVEVfQVBJX09SSUdJTj0ke1NFUlZJQ0VfVVJMX01VU0VVTX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy0tZmFpbCcKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjMwMDAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTUtYWxwaW5lJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfSAtZCAke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgbWluaW86CiAgICBpbWFnZTogJ2doY3IuaW8vY29vbGxhYnNpby9taW5pbzpSRUxFQVNFLjIwMjUtMTAtMTVUMTctMjktNTVaJwogICAgY29tbWFuZDogJ3NlcnZlciAvZGF0YSAtLWNvbnNvbGUtYWRkcmVzcyAiOjkwMDEiJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTUlOSU9fU0VSVkVSX1VSTD0kTUlOSU9fU0VSVkVSX1VSTAogICAgICAtIE1JTklPX0JST1dTRVJfUkVESVJFQ1RfVVJMPSRNSU5JT19CUk9XU0VSX1JFRElSRUNUX1VSTAogICAgICAtIE1JTklPX1JPT1RfVVNFUj0kU0VSVklDRV9VU0VSX01JTklPCiAgICAgIC0gTUlOSU9fUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NSU5JTwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpSRUxFQVNFLjIwMjUtMDgtMTNUMDgtMzUtNDFaJwogICAgZGVwZW5kc19vbjoKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIHJlc3RhcnQ6IG9uLWZhaWx1cmUKICAgIGV4Y2x1ZGVfZnJvbV9oYzogdHJ1ZQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ01JTklPX1JPT1RfVVNFUj0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ01JTklPX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnTUlOSU9fQ09SU19VUkxTPSRTRVJWSUNFX1VSTF9NVVNFVU0sJFNFUlZJQ0VfVVJMX1dFQicKICAgIGVudHJ5cG9pbnQ6ICIvYmluL3NoIC1jIFwiXG4gIGVjaG8gXFxcIk1JTklPX0NPUlNfVVJMUzogXFwkJHtNSU5JT19DT1JTX1VSTFN9XFxcIjtcbiAgc2xlZXAgNTtcbiAgdW50aWwgbWMgYWxpYXMgc2V0IG1pbmlvIGh0dHA6Ly9taW5pbzo5MDAwIFxcJCR7TUlOSU9fUk9PVF9VU0VSfSBcXCQke01JTklPX1JPT1RfUEFTU1dPUkR9OyBkb1xuICAgIGVjaG8gJ1dhaXRpbmcgZm9yIE1pbklPLi4uJztcbiAgICBzbGVlcCAyO1xuICBkb25lO1xuICBtYyBhZG1pbiBjb25maWcgc2V0IG1pbmlvIGFwaSBjb3JzX2FsbG93X29yaWdpbj0nJE1JTklPX0NPUlNfVVJMUycgfHwgdHJ1ZTtcbiAgbWMgbWIgbWluaW8vYjItZXUtY2VuIC0taWdub3JlLWV4aXN0aW5nO1xuICBtYyBtYiBtaW5pby93YXNhYmktZXUtY2VudHJhbC0yLXYzIC0taWdub3JlLWV4aXN0aW5nO1xuICBtYyBtYiBtaW5pby9zY3ctZXUtZnItdjMgLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIGVjaG8gJ01pbklPIGJ1Y2tldHMgYW5kIENPUlMgY29uZmlndXJlZCc7XG5cIiIK",
-        "tags": [
-            "photos",
-            "gallery",
-            "backup",
-            "encryption",
-            "privacy",
-            "self-hosted",
-            "google-photos",
-            "alternative"
-        ],
-        "category": "media",
-        "logo": "svgs/ente-photos.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-10-22T16:05:17+02:00",
-        "port": "8080"
-    },
     "ente-photos": {
         "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
         "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
@@ -1328,6 +1325,26 @@
         "logo": "svgs/ente-photos.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-03-02T12:00:19+01:00",
+        "port": "8080"
+    },
+    "ente-photos-with-s3": {
+        "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
+        "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
+        "compose": "c2VydmljZXM6CiAgbXVzZXVtOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vc2VydmVyOjYxM2M2YTk2MzkwZDdhNjI0Y2YzMGI5NDY5NTU3MDVkNjMyNDIzY2MnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9NVVNFVU1fODA4MAogICAgICAtIEVOVEVfREJfSE9TVD1wb3N0Z3JlcwogICAgICAtIEVOVEVfREJfUE9SVD01NDMyCiAgICAgIC0gJ0VOVEVfREJfTkFNRT0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgLSAnRU5URV9EQl9VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnRU5URV9EQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdFTlRFX0hUVFBfVVNFX1RMUz0ke0VOVEVfSFRUUF9VU0VfVExTOi1mYWxzZX0nCiAgICAgIC0gRU5URV9TM19BUkVfTE9DQUxfQlVDS0VUUz1mYWxzZQogICAgICAtIEVOVEVfUzNfVVNFX1BBVEhfU1RZTEVfVVJMUz10cnVlCiAgICAgIC0gJ0VOVEVfUzNfQjJfRVVfQ0VOX0tFWT0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ0VOVEVfUzNfQjJfRVVfQ0VOX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9FTkRQT0lOVD0ke1NFUlZJQ0VfRlFETl9NSU5JT185MDAwfScKICAgICAgLSBFTlRFX1MzX0IyX0VVX0NFTl9SRUdJT049ZXUtY2VudHJhbC0yCiAgICAgIC0gRU5URV9TM19CMl9FVV9DRU5fQlVDS0VUPWIyLWV1LWNlbgogICAgICAtICdFTlRFX0tFWV9FTkNSWVBUSU9OPSR7U0VSVklDRV9SRUFMQkFTRTY0X0VOQ1JZUFRJT059JwogICAgICAtICdFTlRFX0tFWV9IQVNIPSR7U0VSVklDRV9SRUFMQkFTRTY0XzY0X0hBU0h9JwogICAgICAtICdFTlRFX0pXVF9TRUNSRVQ9JHtTRVJWSUNFX1JFQUxCQVNFNjRfSldUfScKICAgICAgLSAnRU5URV9JTlRFUk5BTF9BRE1JTj0ke0VOVEVfSU5URVJOQUxfQURNSU46LTE1ODA1NTk5NjIzODY0Mzh9JwogICAgICAtICdFTlRFX0lOVEVSTkFMX0RJU0FCTEVfUkVHSVNUUkFUSU9OPSR7RU5URV9JTlRFUk5BTF9ESVNBQkxFX1JFR0lTVFJBVElPTjotZmFsc2V9JwogICAgICAtICdFTlRFX1NNVFBfSE9TVD0ke0VOVEVfU01UUF9IT1NUOi1zbXRwLmdtYWlsLmNvbX0nCiAgICAgIC0gJ0VOVEVfU01UUF9QT1JUPSR7RU5URV9TTVRQX1BPUlQ6LTU4N30nCiAgICAgIC0gJ0VOVEVfU01UUF9VU0VSTkFNRT0ke0VOVEVfU01UUF9VU0VSTkFNRX0nCiAgICAgIC0gJ0VOVEVfU01UUF9QQVNTV09SRD0ke0VOVEVfU01UUF9QQVNTV09SRH0nCiAgICAgIC0gJ0VOVEVfU01UUF9FTUFJTD0ke0VOVEVfU01UUF9FTUFJTH0nCiAgICAgIC0gJ0VOVEVfU01UUF9TRU5ERVJfTkFNRT0ke0VOVEVfU01UUF9TRU5ERVJfTkFNRX0nCiAgICAgIC0gJ0VOVEVfU01UUF9FTkNSWVBUSU9OPSR7RU5URV9TTVRQX0VOQ1JZUFRJT046LXRsc30nCiAgICB2b2x1bWVzOgogICAgICAtICdtdXNldW0tZGF0YTovZGF0YScKICAgICAgLSAnbXVzZXVtLWNvbmZpZzovY29uZmlnJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgwL3BpbmcnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICB3ZWI6CiAgICBpbWFnZTogJ2doY3IuaW8vZW50ZS1pby93ZWI6Y2EwMzE2NWY1ZTdmMmE1MDEwNWU2ZTQwMDE5YzE3YWU2Y2RkOTM0ZicKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1dFQl8zMDAwCiAgICAgIC0gJ0VOVEVfQVBJX09SSUdJTj0ke1NFUlZJQ0VfVVJMX01VU0VVTX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy0tZmFpbCcKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjMwMDAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTUtYWxwaW5lJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfSAtZCAke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgbWluaW86CiAgICBpbWFnZTogJ2doY3IuaW8vY29vbGxhYnNpby9taW5pbzpSRUxFQVNFLjIwMjUtMTAtMTVUMTctMjktNTVaJwogICAgY29tbWFuZDogJ3NlcnZlciAvZGF0YSAtLWNvbnNvbGUtYWRkcmVzcyAiOjkwMDEiJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTUlOSU9fU0VSVkVSX1VSTD0kTUlOSU9fU0VSVkVSX1VSTAogICAgICAtIE1JTklPX0JST1dTRVJfUkVESVJFQ1RfVVJMPSRNSU5JT19CUk9XU0VSX1JFRElSRUNUX1VSTAogICAgICAtIE1JTklPX1JPT1RfVVNFUj0kU0VSVklDRV9VU0VSX01JTklPCiAgICAgIC0gTUlOSU9fUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NSU5JTwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpSRUxFQVNFLjIwMjUtMDgtMTNUMDgtMzUtNDFaJwogICAgZGVwZW5kc19vbjoKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIHJlc3RhcnQ6IG9uLWZhaWx1cmUKICAgIGV4Y2x1ZGVfZnJvbV9oYzogdHJ1ZQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ01JTklPX1JPT1RfVVNFUj0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ01JTklPX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnTUlOSU9fQ09SU19VUkxTPSRTRVJWSUNFX1VSTF9NVVNFVU0sJFNFUlZJQ0VfVVJMX1dFQicKICAgIGVudHJ5cG9pbnQ6ICIvYmluL3NoIC1jIFwiXG4gIGVjaG8gXFxcIk1JTklPX0NPUlNfVVJMUzogXFwkJHtNSU5JT19DT1JTX1VSTFN9XFxcIjtcbiAgc2xlZXAgNTtcbiAgdW50aWwgbWMgYWxpYXMgc2V0IG1pbmlvIGh0dHA6Ly9taW5pbzo5MDAwIFxcJCR7TUlOSU9fUk9PVF9VU0VSfSBcXCQke01JTklPX1JPT1RfUEFTU1dPUkR9OyBkb1xuICAgIGVjaG8gJ1dhaXRpbmcgZm9yIE1pbklPLi4uJztcbiAgICBzbGVlcCAyO1xuICBkb25lO1xuICBtYyBhZG1pbiBjb25maWcgc2V0IG1pbmlvIGFwaSBjb3JzX2FsbG93X29yaWdpbj0nJE1JTklPX0NPUlNfVVJMUycgfHwgdHJ1ZTtcbiAgbWMgbWIgbWluaW8vYjItZXUtY2VuIC0taWdub3JlLWV4aXN0aW5nO1xuICBtYyBtYiBtaW5pby93YXNhYmktZXUtY2VudHJhbC0yLXYzIC0taWdub3JlLWV4aXN0aW5nO1xuICBtYyBtYiBtaW5pby9zY3ctZXUtZnItdjMgLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIGVjaG8gJ01pbklPIGJ1Y2tldHMgYW5kIENPUlMgY29uZmlndXJlZCc7XG5cIiIK",
+        "tags": [
+            "photos",
+            "gallery",
+            "backup",
+            "encryption",
+            "privacy",
+            "self-hosted",
+            "google-photos",
+            "alternative"
+        ],
+        "category": "media",
+        "logo": "svgs/ente-photos.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-10-22T16:05:17+02:00",
         "port": "8080"
     },
     "esphome": {
@@ -1546,6 +1563,32 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
+    "flowise": {
+        "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
+        "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents.",
+        "compose": "c2VydmljZXM6CiAgZmxvd2lzZToKICAgIGltYWdlOiAnZmxvd2lzZWFpL2Zsb3dpc2U6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfRkxPV0lTRV8zMDAxCiAgICAgIC0gJ0RFQlVHPSR7REVCVUc6LWZhbHNlfScKICAgICAgLSAnRElTQUJMRV9GTE9XSVNFX1RFTEVNRVRSWT0ke0RJU0FCTEVfRkxPV0lTRV9URUxFTUVUUlk6LXRydWV9JwogICAgICAtICdQT1JUPSR7UE9SVDotMzAwMX0nCiAgICAgIC0gREFUQUJBU0VfUEFUSD0vcm9vdC8uZmxvd2lzZQogICAgICAtIEFQSUtFWV9QQVRIPS9yb290Ly5mbG93aXNlCiAgICAgIC0gU0VDUkVUS0VZX1BBVEg9L3Jvb3QvLmZsb3dpc2UKICAgICAgLSBMT0dfUEFUSD0vcm9vdC8uZmxvd2lzZS9sb2dzCiAgICAgIC0gQkxPQl9TVE9SQUdFX1BBVEg9L3Jvb3QvLmZsb3dpc2Uvc3RvcmFnZQogICAgICAtICdGTE9XSVNFX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0ZMT1dJU0V9JwogICAgICAtICdGTE9XSVNFX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9GTE9XSVNFfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2Zsb3dpc2UtZGF0YTovcm9vdC8uZmxvd2lzZScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnd2dldCAtcU8tIGh0dHA6Ly8xMjcuMC4wLjE6MzAwMSB8fCBleGl0IDEnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
+        "tags": [
+            "lowcode",
+            "nocode",
+            "ai",
+            "llm",
+            "openai",
+            "anthropic",
+            "machine-learning",
+            "rag",
+            "agents",
+            "chatbot",
+            "api",
+            "team",
+            "bot",
+            "flows"
+        ],
+        "category": "ai",
+        "logo": "svgs/flowise.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3001"
+    },
     "flowise-with-databases": {
         "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
         "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents. Also deploys Redis, Postgres and other services.",
@@ -1572,31 +1615,22 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3001"
     },
-    "flowise": {
-        "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
-        "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents.",
-        "compose": "c2VydmljZXM6CiAgZmxvd2lzZToKICAgIGltYWdlOiAnZmxvd2lzZWFpL2Zsb3dpc2U6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfRkxPV0lTRV8zMDAxCiAgICAgIC0gJ0RFQlVHPSR7REVCVUc6LWZhbHNlfScKICAgICAgLSAnRElTQUJMRV9GTE9XSVNFX1RFTEVNRVRSWT0ke0RJU0FCTEVfRkxPV0lTRV9URUxFTUVUUlk6LXRydWV9JwogICAgICAtICdQT1JUPSR7UE9SVDotMzAwMX0nCiAgICAgIC0gREFUQUJBU0VfUEFUSD0vcm9vdC8uZmxvd2lzZQogICAgICAtIEFQSUtFWV9QQVRIPS9yb290Ly5mbG93aXNlCiAgICAgIC0gU0VDUkVUS0VZX1BBVEg9L3Jvb3QvLmZsb3dpc2UKICAgICAgLSBMT0dfUEFUSD0vcm9vdC8uZmxvd2lzZS9sb2dzCiAgICAgIC0gQkxPQl9TVE9SQUdFX1BBVEg9L3Jvb3QvLmZsb3dpc2Uvc3RvcmFnZQogICAgICAtICdGTE9XSVNFX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0ZMT1dJU0V9JwogICAgICAtICdGTE9XSVNFX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9GTE9XSVNFfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2Zsb3dpc2UtZGF0YTovcm9vdC8uZmxvd2lzZScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnd2dldCAtcU8tIGh0dHA6Ly8xMjcuMC4wLjE6MzAwMSB8fCBleGl0IDEnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
+    "forgejo": {
+        "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
+        "slogan": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
+        "compose": "c2VydmljZXM6CiAgZm9yZ2VqbzoKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2Zvcmdlam8vZm9yZ2VqbzoxNScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZPUkdFSk9fMzAwMAogICAgICAtICdGT1JHRUpPX19zZXJ2ZXJfX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfRk9SR0VKT30nCiAgICAgIC0gJ0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XRURfRE9NQUlOUz0ke0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XRURfRE9NQUlOU30nCiAgICAgIC0gJ0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XX0xPQ0FMTkVUV09SS1M9JHtGT1JHRUpPX19taWdyYXRpb25zX19BTExPV19MT0NBTE5FVFdPUktTLWZhbHNlfScKICAgICAgLSBVU0VSX1VJRD0xMDAwCiAgICAgIC0gVVNFUl9HSUQ9MTAwMAogICAgcG9ydHM6CiAgICAgIC0gJzIyMjIyOjIyJwogICAgdm9sdW1lczoKICAgICAgLSAnZm9yZ2Vqby1kYXRhOi9kYXRhJwogICAgICAtICdmb3JnZWpvLXRpbWV6b25lOi9ldGMvdGltZXpvbmU6cm8nCiAgICAgIC0gJ2Zvcmdlam8tbG9jYWx0aW1lOi9ldGMvbG9jYWx0aW1lOnJvJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
         "tags": [
-            "lowcode",
-            "nocode",
-            "ai",
-            "llm",
-            "openai",
-            "anthropic",
-            "machine-learning",
-            "rag",
-            "agents",
-            "chatbot",
-            "api",
-            "team",
-            "bot",
-            "flows"
+            "version control",
+            "collaboration",
+            "code",
+            "hosting",
+            "lightweight"
         ],
-        "category": "ai",
-        "logo": "svgs/flowise.png",
+        "category": "git",
+        "logo": "svgs/forgejo.svg",
         "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3001"
+        "template_last_updated_at": "2026-08-10T11:35:20+02:00",
+        "port": "3000"
     },
     "forgejo-with-mariadb": {
         "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
@@ -1645,23 +1679,6 @@
             "hosting",
             "lightweight",
             "postgresql"
-        ],
-        "category": "git",
-        "logo": "svgs/forgejo.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-08-10T11:35:20+02:00",
-        "port": "3000"
-    },
-    "forgejo": {
-        "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
-        "slogan": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
-        "compose": "c2VydmljZXM6CiAgZm9yZ2VqbzoKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2Zvcmdlam8vZm9yZ2VqbzoxNScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZPUkdFSk9fMzAwMAogICAgICAtICdGT1JHRUpPX19zZXJ2ZXJfX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfRk9SR0VKT30nCiAgICAgIC0gJ0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XRURfRE9NQUlOUz0ke0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XRURfRE9NQUlOU30nCiAgICAgIC0gJ0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XX0xPQ0FMTkVUV09SS1M9JHtGT1JHRUpPX19taWdyYXRpb25zX19BTExPV19MT0NBTE5FVFdPUktTLWZhbHNlfScKICAgICAgLSBVU0VSX1VJRD0xMDAwCiAgICAgIC0gVVNFUl9HSUQ9MTAwMAogICAgcG9ydHM6CiAgICAgIC0gJzIyMjIyOjIyJwogICAgdm9sdW1lczoKICAgICAgLSAnZm9yZ2Vqby1kYXRhOi9kYXRhJwogICAgICAtICdmb3JnZWpvLXRpbWV6b25lOi9ldGMvdGltZXpvbmU6cm8nCiAgICAgIC0gJ2Zvcmdlam8tbG9jYWx0aW1lOi9ldGMvbG9jYWx0aW1lOnJvJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
-        "tags": [
-            "version control",
-            "collaboration",
-            "code",
-            "hosting",
-            "lightweight"
         ],
         "category": "git",
         "logo": "svgs/forgejo.svg",
@@ -1718,6 +1735,20 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
+    "freshrss": {
+        "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
+        "slogan": "A free, self-hostable feed aggregator.",
+        "compose": "c2VydmljZXM6CiAgZnJlc2hyc3M6CiAgICBpbWFnZTogJ2ZyZXNocnNzL2ZyZXNocnNzOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZSRVNIUlNTXzgwCiAgICAgIC0gJ0NST05fTUlOPSR7Q1JPTl9NSU46LTEsMzF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZnJlc2hyc3MtZGF0YTovdmFyL3d3dy9GcmVzaFJTUy9kYXRhJwogICAgICAtICdmcmVzaHJzcy1leHRlbnNpb25zOi92YXIvd3d3L0ZyZXNoUlNTL2V4dGVuc2lvbnMnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS84MCcgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDMK",
+        "tags": [
+            "rss",
+            "feed"
+        ],
+        "category": "RSS",
+        "logo": "svgs/freshrss.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "80"
+    },
     "freshrss-with-mariadb": {
         "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
         "slogan": "A free, self-hostable feed aggregator.",
@@ -1760,20 +1791,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "freshrss": {
-        "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
-        "slogan": "A free, self-hostable feed aggregator.",
-        "compose": "c2VydmljZXM6CiAgZnJlc2hyc3M6CiAgICBpbWFnZTogJ2ZyZXNocnNzL2ZyZXNocnNzOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZSRVNIUlNTXzgwCiAgICAgIC0gJ0NST05fTUlOPSR7Q1JPTl9NSU46LTEsMzF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZnJlc2hyc3MtZGF0YTovdmFyL3d3dy9GcmVzaFJTUy9kYXRhJwogICAgICAtICdmcmVzaHJzcy1leHRlbnNpb25zOi92YXIvd3d3L0ZyZXNoUlNTL2V4dGVuc2lvbnMnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS84MCcgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDMK",
-        "tags": [
-            "rss",
-            "feed"
-        ],
-        "category": "RSS",
-        "logo": "svgs/freshrss.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "80"
-    },
     "garage": {
         "documentation": "https://garagehq.deuxfleurs.fr/documentation/?utm_source=coolify.io",
         "slogan": "Garage is an S3-compatible distributed object storage service designed for self-hosting.",
@@ -1794,7 +1811,7 @@
     },
     "getoutline": {
         "documentation": "https://docs.getoutline.com/s/hosting/doc/hosting-outline-nipGaCRBDu?utm_source=coolify.io",
-        "slogan": "Your team\u2019s knowledge base",
+        "slogan": "Your team’s knowledge base",
         "compose": "c2VydmljZXM6CiAgb3V0bGluZToKICAgIGltYWdlOiAnZG9ja2VyLmdldG91dGxpbmUuY29tL291dGxpbmV3aWtpL291dGxpbmU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc3RvcmFnZS1kYXRhOi92YXIvbGliL291dGxpbmUvZGF0YScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIHJlZGlzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9PVVRMSU5FXzMwMDAKICAgICAgLSBOT0RFX0VOVj1wcm9kdWN0aW9uCiAgICAgIC0gJ1NFQ1JFVF9LRVk9JHtTRVJWSUNFX0hFWF82NF9PVVRMSU5FfScKICAgICAgLSAnVVRJTFNfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF82NF9PVVRMSU5FfScKICAgICAgLSAnREFUQUJBU0VfVVJMPXBvc3RncmVzOi8vJHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9OiR7U0VSVklDRV9QQVNTV09SRF82NF9QT1NUR1JFU31AcG9zdGdyZXM6NTQzMi8ke1BPU1RHUkVTX0RBVEFCQVNFOi1vdXRsaW5lfScKICAgICAgLSAnUkVESVNfVVJMPXJlZGlzOi8vOiR7U0VSVklDRV9QQVNTV09SRF82NF9SRURJU31AcmVkaXM6NjM3OScKICAgICAgLSAnVVJMPSR7U0VSVklDRV9VUkxfT1VUTElORX0nCiAgICAgIC0gJ1BPUlQ9JHtPVVRMSU5FX1BPUlQ6LTMwMDB9JwogICAgICAtICdGSUxFX1NUT1JBR0U9JHtGSUxFX1NUT1JBR0U6LWxvY2FsfScKICAgICAgLSAnRklMRV9TVE9SQUdFX0xPQ0FMX1JPT1RfRElSPSR7RklMRV9TVE9SQUdFX0xPQ0FMX1JPT1RfRElSOi0vdmFyL2xpYi9vdXRsaW5lL2RhdGF9JwogICAgICAtICdGSUxFX1NUT1JBR0VfVVBMT0FEX01BWF9TSVpFPSR7RklMRV9TVE9SQUdFX1VQTE9BRF9NQVhfU0laRTotMjAwMH0nCiAgICAgIC0gJ0ZJTEVfU1RPUkFHRV9JTVBPUlRfTUFYX1NJWkU9JHtGSUxFX1NUT1JBR0VfSU1QT1JUX01BWF9TSVpFOi0xMDB9JwogICAgICAtICdGSUxFX1NUT1JBR0VfV09SS1NQQUNFX0lNUE9SVF9NQVhfU0laRT0ke0ZJTEVfU1RPUkFHRV9XT1JLU1BBQ0VfSU1QT1JUX01BWF9TSVpFfScKICAgICAgLSAnQVdTX0FDQ0VTU19LRVlfSUQ9JHtBV1NfQUNDRVNTX0tFWV9JRH0nCiAgICAgIC0gJ0FXU19TRUNSRVRfQUNDRVNTX0tFWT0ke0FXU19TRUNSRVRfQUNDRVNTX0tFWX0nCiAgICAgIC0gJ0FXU19SRUdJT049JHtBV1NfUkVHSU9OfScKICAgICAgLSAnQVdTX1MzX0FDQ0VMRVJBVEVfVVJMPSR7QVdTX1MzX0FDQ0VMRVJBVEVfVVJMfScKICAgICAgLSAnQVdTX1MzX1VQTE9BRF9CVUNLRVRfVVJMPSR7QVdTX1MzX1VQTE9BRF9CVUNLRVRfVVJMfScKICAgICAgLSAnQVdTX1MzX1VQTE9BRF9CVUNLRVRfTkFNRT0ke0FXU19TM19VUExPQURfQlVDS0VUX05BTUV9JwogICAgICAtICdBV1NfUzNfRk9SQ0VfUEFUSF9TVFlMRT0ke0FXU19TM19GT1JDRV9QQVRIX1NUWUxFOi10cnVlfScKICAgICAgLSAnQVdTX1MzX0FDTD0ke0FXU19TM19BQ0w6LXByaXZhdGV9JwogICAgICAtICdTTEFDS19DTElFTlRfSUQ9JHtTTEFDS19DTElFTlRfSUR9JwogICAgICAtICdTTEFDS19DTElFTlRfU0VDUkVUPSR7U0xBQ0tfQ0xJRU5UX1NFQ1JFVH0nCiAgICAgIC0gJ0dPT0dMRV9DTElFTlRfSUQ9JHtHT09HTEVfQ0xJRU5UX0lEfScKICAgICAgLSAnR09PR0xFX0NMSUVOVF9TRUNSRVQ9JHtHT09HTEVfQ0xJRU5UX1NFQ1JFVH0nCiAgICAgIC0gJ0FaVVJFX0NMSUVOVF9JRD0ke0FaVVJFX0NMSUVOVF9JRH0nCiAgICAgIC0gJ0FaVVJFX0NMSUVOVF9TRUNSRVQ9JHtBWlVSRV9DTElFTlRfU0VDUkVUfScKICAgICAgLSAnQVpVUkVfUkVTT1VSQ0VfQVBQX0lEPSR7QVpVUkVfUkVTT1VSQ0VfQVBQX0lEfScKICAgICAgLSAnT0lEQ19DTElFTlRfSUQ9JHtPSURDX0NMSUVOVF9JRH0nCiAgICAgIC0gJ09JRENfQ0xJRU5UX1NFQ1JFVD0ke09JRENfQ0xJRU5UX1NFQ1JFVH0nCiAgICAgIC0gJ09JRENfQVVUSF9VUkk9JHtPSURDX0FVVEhfVVJJfScKICAgICAgLSAnT0lEQ19UT0tFTl9VUkk9JHtPSURDX1RPS0VOX1VSSX0nCiAgICAgIC0gJ09JRENfVVNFUklORk9fVVJJPSR7T0lEQ19VU0VSSU5GT19VUkl9JwogICAgICAtICdPSURDX0xPR09VVF9VUkk9JHtPSURDX0xPR09VVF9VUkl9JwogICAgICAtICdPSURDX1VTRVJOQU1FX0NMQUlNPSR7T0lEQ19VU0VSTkFNRV9DTEFJTX0nCiAgICAgIC0gJ09JRENfRElTUExBWV9OQU1FPSR7T0lEQ19ESVNQTEFZX05BTUV9JwogICAgICAtICdPSURDX1NDT1BFUz0ke09JRENfU0NPUEVTfScKICAgICAgLSAnR0lUSFVCX0NMSUVOVF9JRD0ke0dJVEhVQl9DTElFTlRfSUR9JwogICAgICAtICdHSVRIVUJfQ0xJRU5UX1NFQ1JFVD0ke0dJVEhVQl9DTElFTlRfU0VDUkVUfScKICAgICAgLSAnR0lUSFVCX0FQUF9OQU1FPSR7R0lUSFVCX0FQUF9OQU1FfScKICAgICAgLSAnR0lUSFVCX0FQUF9JRD0ke0dJVEhVQl9BUFBfSUR9JwogICAgICAtICdHSVRIVUJfQVBQX1BSSVZBVEVfS0VZPSR7R0lUSFVCX0FQUF9QUklWQVRFX0tFWX0nCiAgICAgIC0gJ0RJU0NPUkRfQ0xJRU5UX0lEPSR7RElTQ09SRF9DTElFTlRfSUR9JwogICAgICAtICdESVNDT1JEX0NMSUVOVF9TRUNSRVQ9JHtESVNDT1JEX0NMSUVOVF9TRUNSRVR9JwogICAgICAtICdESVNDT1JEX1NFUlZFUl9JRD0ke0RJU0NPUkRfU0VSVkVSX0lEfScKICAgICAgLSAnRElTQ09SRF9TRVJWRVJfUk9MRVM9JHtESVNDT1JEX1NFUlZFUl9ST0xFU30nCiAgICAgIC0gJ1BHU1NMTU9ERT0ke1BHU1NMTU9ERTotZGlzYWJsZX0nCiAgICAgIC0gJ0ZPUkNFX0hUVFBTPSR7Rk9SQ0VfSFRUUFM6LXRydWV9JwogICAgICAtICdTTVRQX0hPU1Q9JHtTTVRQX0hPU1R9JwogICAgICAtICdTTVRQX1BPUlQ9JHtTTVRQX1BPUlR9JwogICAgICAtICdTTVRQX1VTRVJOQU1FPSR7U01UUF9VU0VSTkFNRX0nCiAgICAgIC0gJ1NNVFBfUEFTU1dPUkQ9JHtTTVRQX1BBU1NXT1JEfScKICAgICAgLSAnU01UUF9GUk9NX0VNQUlMPSR7U01UUF9GUk9NX0VNQUlMfScKICAgICAgLSAnU01UUF9SRVBMWV9FTUFJTD0ke1NNVFBfUkVQTFlfRU1BSUx9JwogICAgICAtICdTTVRQX1RMU19DSVBIRVJTPSR7U01UUF9UTFNfQ0lQSEVSU30nCiAgICAgIC0gJ1NNVFBfU0VDVVJFPSR7U01UUF9TRUNVUkV9JwogICAgICAtICdTTVRQX05BTUU9JHtTTVRQX05BTUV9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIGRpc2FibGU6IHRydWUKICByZWRpczoKICAgIGltYWdlOiAncmVkaXM6YWxwaW5lJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1JFRElTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9SRURJU30nCiAgICBjb21tYW5kOgogICAgICAtIHJlZGlzLXNlcnZlcgogICAgICAtICctLXJlcXVpcmVwYXNzJwogICAgICAtICcke1NFUlZJQ0VfUEFTU1dPUkRfNjRfUkVESVN9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHJlZGlzLWNsaQogICAgICAgIC0gJy1hJwogICAgICAgIC0gJyR7U0VSVklDRV9QQVNTV09SRF82NF9SRURJU30nCiAgICAgICAgLSBQSU5HCiAgICAgIGludGVydmFsOiAxMHMKICAgICAgdGltZW91dDogMzBzCiAgICAgIHJldHJpZXM6IDMKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTItYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAnZGF0YWJhc2UtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUE9TVEdSRVNfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9QT1NUR1JFU30nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREFUQUJBU0U6LW91dGxpbmV9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHBnX2lzcmVhZHkKICAgICAgICAtICctVScKICAgICAgICAtICcke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgICAgLSAnLWQnCiAgICAgICAgLSAnJHtQT1NUR1JFU19EQVRBQkFTRTotb3V0bGluZX0nCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDMK",
         "tags": [
             "knowledge base",
@@ -1822,6 +1839,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-11-14T23:33:47+05:30",
         "port": "2368"
+    },
+    "gitea": {
+        "documentation": "https://docs.gitea.com?utm_source=coolify.io",
+        "slogan": "Gitea is a self-hosted, lightweight Git service, offering version control, collaboration, and code hosting.",
+        "compose": "c2VydmljZXM6CiAgZ2l0ZWE6CiAgICBpbWFnZTogJ2dpdGVhL2dpdGVhOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0dJVEVBXzMwMDAKICAgICAgLSBVU0VSX1VJRD0xMDAwCiAgICAgIC0gVVNFUl9HSUQ9MTAwMAogICAgcG9ydHM6CiAgICAgIC0gJzIyMjIyOjIyJwogICAgdm9sdW1lczoKICAgICAgLSAnZ2l0ZWEtZGF0YTovZGF0YScKICAgICAgLSAnZ2l0ZWEtdGltZXpvbmU6L2V0Yy90aW1lem9uZTpybycKICAgICAgLSAnZ2l0ZWEtbG9jYWx0aW1lOi9ldGMvbG9jYWx0aW1lOnJvJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
+        "tags": [
+            "version control",
+            "collaboration",
+            "code",
+            "hosting",
+            "lightweight"
+        ],
+        "category": "git",
+        "logo": "svgs/gitea.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
     "gitea-runner": {
         "documentation": "https://github.com/go-gitea/gitea?utm_source=coolify.io",
@@ -1883,22 +1916,6 @@
             "hosting",
             "lightweight",
             "postgresql"
-        ],
-        "category": "git",
-        "logo": "svgs/gitea.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00"
-    },
-    "gitea": {
-        "documentation": "https://docs.gitea.com?utm_source=coolify.io",
-        "slogan": "Gitea is a self-hosted, lightweight Git service, offering version control, collaboration, and code hosting.",
-        "compose": "c2VydmljZXM6CiAgZ2l0ZWE6CiAgICBpbWFnZTogJ2dpdGVhL2dpdGVhOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0dJVEVBXzMwMDAKICAgICAgLSBVU0VSX1VJRD0xMDAwCiAgICAgIC0gVVNFUl9HSUQ9MTAwMAogICAgcG9ydHM6CiAgICAgIC0gJzIyMjIyOjIyJwogICAgdm9sdW1lczoKICAgICAgLSAnZ2l0ZWEtZGF0YTovZGF0YScKICAgICAgLSAnZ2l0ZWEtdGltZXpvbmU6L2V0Yy90aW1lem9uZTpybycKICAgICAgLSAnZ2l0ZWEtbG9jYWx0aW1lOi9ldGMvbG9jYWx0aW1lOnJvJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
-        "tags": [
-            "version control",
-            "collaboration",
-            "code",
-            "hosting",
-            "lightweight"
         ],
         "category": "git",
         "logo": "svgs/gitea.svg",
@@ -2077,10 +2094,10 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "3000"
     },
-    "grafana-with-postgresql": {
+    "grafana": {
         "documentation": "https://grafana.com?utm_source=coolify.io",
         "slogan": "Grafana is the open source analytics & monitoring solution for every database.",
-        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9HUkFGQU5BXzMwMDAKICAgICAgLSAnR0ZfU0VSVkVSX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFUlZFUl9ET01BSU49JHtTRVJWSUNFX0ZRRE5fR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFQ1VSSVRZX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9HUkFGQU5BfScKICAgICAgLSBHRl9EQVRBQkFTRV9UWVBFPXBvc3RncmVzCiAgICAgIC0gR0ZfREFUQUJBU0VfSE9TVD1wb3N0Z3Jlc3FsCiAgICAgIC0gR0ZfREFUQUJBU0VfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gR0ZfREFUQUJBU0VfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVMKICAgICAgLSAnR0ZfREFUQUJBU0VfTkFNRT0ke1BPU1RHUkVTX0RCOi1ncmFmYW5hfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dyYWZhbmEtZGF0YTovdmFyL2xpYi9ncmFmYW5hJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYXBpL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgZGVwZW5kc19vbjoKICAgICAgLSBwb3N0Z3Jlc3FsCiAgcG9zdGdyZXNxbDoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAncG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFBPU1RHUkVTX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFUwogICAgICAtIFBPU1RHUkVTX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREI6LWdyYWZhbmF9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9HUkFGQU5BXzMwMDAKICAgICAgLSAnR0ZfU0VSVkVSX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFUlZFUl9ET01BSU49JHtTRVJWSUNFX0ZRRE5fR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFQ1VSSVRZX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9HUkFGQU5BfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dyYWZhbmEtZGF0YTovdmFyL2xpYi9ncmFmYW5hJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYXBpL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "grafana",
             "analytics",
@@ -2093,10 +2110,10 @@
         "template_last_updated_at": "2026-03-22T22:04:22+07:00",
         "port": "3000"
     },
-    "grafana": {
+    "grafana-with-postgresql": {
         "documentation": "https://grafana.com?utm_source=coolify.io",
         "slogan": "Grafana is the open source analytics & monitoring solution for every database.",
-        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9HUkFGQU5BXzMwMDAKICAgICAgLSAnR0ZfU0VSVkVSX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFUlZFUl9ET01BSU49JHtTRVJWSUNFX0ZRRE5fR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFQ1VSSVRZX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9HUkFGQU5BfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dyYWZhbmEtZGF0YTovdmFyL2xpYi9ncmFmYW5hJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYXBpL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9HUkFGQU5BXzMwMDAKICAgICAgLSAnR0ZfU0VSVkVSX1JPT1RfVVJMPSR7U0VSVklDRV9VUkxfR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFUlZFUl9ET01BSU49JHtTRVJWSUNFX0ZRRE5fR1JBRkFOQX0nCiAgICAgIC0gJ0dGX1NFQ1VSSVRZX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9HUkFGQU5BfScKICAgICAgLSBHRl9EQVRBQkFTRV9UWVBFPXBvc3RncmVzCiAgICAgIC0gR0ZfREFUQUJBU0VfSE9TVD1wb3N0Z3Jlc3FsCiAgICAgIC0gR0ZfREFUQUJBU0VfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gR0ZfREFUQUJBU0VfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVMKICAgICAgLSAnR0ZfREFUQUJBU0VfTkFNRT0ke1BPU1RHUkVTX0RCOi1ncmFmYW5hfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dyYWZhbmEtZGF0YTovdmFyL2xpYi9ncmFmYW5hJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYXBpL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogICAgZGVwZW5kc19vbjoKICAgICAgLSBwb3N0Z3Jlc3FsCiAgcG9zdGdyZXNxbDoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAncG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFBPU1RHUkVTX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFUwogICAgICAtIFBPU1RHUkVTX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREI6LWdyYWZhbmF9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "grafana",
             "analytics",
@@ -2225,7 +2242,7 @@
     },
     "hermes-agent-with-webui": {
         "documentation": "https://github.com/nesquena/hermes-webui?utm_source=coolify.io",
-        "slogan": "Hermes Agent \u2014 autonomous AI agent with persistent memory, scheduling, and a self-hosted web chat UI.",
+        "slogan": "Hermes Agent — autonomous AI agent with persistent memory, scheduling, and a self-hosted web chat UI.",
         "compose": "c2VydmljZXM6CiAgaGVybWVzLWFnZW50OgogICAgaW1hZ2U6ICdub3VzcmVzZWFyY2gvaGVybWVzLWFnZW50QHNoYTI1NjoyZjFmMmYxNzI1ZTVkYzlhNjFjZjZhMmRlYTVhY2E1MmE3NzZlYzRkMDIyY2IyOTY3OWU2YWEzZmYzMDNlNzdhJwogICAgY29tbWFuZDogJ2dhdGV3YXkgcnVuJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gSEVSTUVTX0hPTUU9L2hvbWUvaGVybWVzLy5oZXJtZXMKICAgICAgLSBIRVJNRVNfVUlEPTEwMDAKICAgICAgLSBIRVJNRVNfR0lEPTEwMDAKICAgICAgLSAnT1BFTlJPVVRFUl9BUElfS0VZPSR7T1BFTlJPVVRFUl9BUElfS0VZfScKICAgICAgLSAnQU5USFJPUElDX0FQSV9LRVk9JHtBTlRIUk9QSUNfQVBJX0tFWX0nCiAgICAgIC0gJ09QRU5BSV9BUElfS0VZPSR7T1BFTkFJX0FQSV9LRVl9JwogICAgICAtICdHT09HTEVfQVBJX0tFWT0ke0dPT0dMRV9BUElfS0VZfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2hlcm1lcy1ob21lOi9ob21lL2hlcm1lcy8uaGVybWVzJwogICAgICAtICdoZXJtZXMtYWdlbnQtc3JjOi9vcHQvaGVybWVzJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd0ZXN0IC1kIC9ob21lL2hlcm1lcy8uaGVybWVzIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgaGVybWVzLXdlYnVpOgogICAgaW1hZ2U6ICdnaGNyLmlvL25lc3F1ZW5hL2hlcm1lcy13ZWJ1aTowLjUxLjkyJwogICAgZGVwZW5kc19vbjoKICAgICAgLSBoZXJtZXMtYWdlbnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0hFUk1FU1dFQlVJXzg3ODcKICAgICAgLSBIRVJNRVNfV0VCVUlfSE9TVD0wLjAuMC4wCiAgICAgIC0gSEVSTUVTX1dFQlVJX1BPUlQ9ODc4NwogICAgICAtIEhFUk1FU19XRUJVSV9TVEFURV9ESVI9L2hvbWUvaGVybWVzd2VidWkvLmhlcm1lcy93ZWJ1aQogICAgICAtIFdBTlRFRF9VSUQ9MTAwMAogICAgICAtIFdBTlRFRF9HSUQ9MTAwMAogICAgICAtICdIRVJNRVNfV0VCVUlfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0hFUk1FU1dFQlVJfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2hlcm1lcy1ob21lOi9ob21lL2hlcm1lc3dlYnVpLy5oZXJtZXMnCiAgICAgIC0gJ2hlcm1lcy1hZ2VudC1zcmM6L2hvbWUvaGVybWVzd2VidWkvLmhlcm1lcy9oZXJtZXMtYWdlbnQ6cm8nCiAgICAgIC0gJ2hlcm1lcy13b3Jrc3BhY2U6L3dvcmtzcGFjZScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4Nzg3L2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDMwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
         "tags": [
             "ai",
@@ -2524,7 +2541,7 @@
     },
     "jitsi": {
         "documentation": "https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/?utm_source=coolify.io",
-        "slogan": "Self-hosted Jitsi Meet \u2014 open-source video conferencing platform",
+        "slogan": "Self-hosted Jitsi Meet — open-source video conferencing platform",
         "compose": "c2VydmljZXM6CiAgaml0c2ktd2ViOgogICAgaW1hZ2U6ICdqaXRzaS93ZWI6c3RhYmxlLTEwODg4JwogICAgcmVzdGFydDogdW5sZXNzLXN0b3BwZWQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0pJVFNJCiAgICAgIC0gUFVCTElDX1VSTD0kU0VSVklDRV9VUkxfSklUU0kKICAgICAgLSBFTkFCTEVfQVVUSD0wCiAgICAgIC0gRU5BQkxFX0dVRVNUUz0xCiAgICAgIC0gRU5BQkxFX0xFVFNFTkNSWVBUPTAKICAgICAgLSBFTkFCTEVfSFRUUF9SRURJUkVDVD0wCiAgICAgIC0gRElTQUJMRV9IVFRQUz0xCiAgICAgIC0gWE1QUF9ET01BSU49bWVldC5qaXRzaQogICAgICAtIFhNUFBfQVVUSF9ET01BSU49YXV0aC5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9HVUVTVF9ET01BSU49Z3Vlc3QubWVldC5qaXRzaQogICAgICAtIFhNUFBfTVVDX0RPTUFJTj1jb25mZXJlbmNlLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX0lOVEVSTkFMX01VQ19ET01BSU49aW50ZXJuYWwuYXV0aC5tZWV0LmppdHNpCiAgICAgIC0gJ1hNUFBfQk9TSF9VUkxfQkFTRT1odHRwOi8vcHJvc29keTo1MjgwJwogICAgICAtIEpWQl9CUkVXRVJZX01VQz1qdmJicmV3ZXJ5CiAgICAgIC0gJ0pJQ09GT19DT01QT05FTlRfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9KSUNPRk99JwogICAgICAtICdKSUNPRk9fQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfSklDT0ZPfScKICAgICAgLSAnSlZCX0FVVEhfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pWQn0nCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICBkZXBlbmRzX29uOgogICAgICAtIHByb3NvZHkKICAgICAgLSBqaWNvZm8KICAgICAgLSBqdmIKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ppdHNpLXdlYjovY29uZmlnJwogICAgbmV0d29ya3M6CiAgICAgIG1lZXQuaml0c2k6CiAgICAgICAgYWxpYXNlczoKICAgICAgICAgIC0gbWVldC5qaXRzaQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1CiAgcHJvc29keToKICAgIGltYWdlOiAnaml0c2kvcHJvc29keTpzdGFibGUtMTA4ODgnCiAgICByZXN0YXJ0OiB1bmxlc3Mtc3RvcHBlZAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gQVVUSF9UWVBFPWludGVybmFsCiAgICAgIC0gRU5BQkxFX0FVVEg9MAogICAgICAtIEVOQUJMRV9HVUVTVFM9MQogICAgICAtIFhNUFBfRE9NQUlOPW1lZXQuaml0c2kKICAgICAgLSBYTVBQX0FVVEhfRE9NQUlOPWF1dGgubWVldC5qaXRzaQogICAgICAtIFhNUFBfR1VFU1RfRE9NQUlOPWd1ZXN0Lm1lZXQuaml0c2kKICAgICAgLSBYTVBQX01VQ19ET01BSU49Y29uZmVyZW5jZS5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9JTlRFUk5BTF9NVUNfRE9NQUlOPWludGVybmFsLmF1dGgubWVldC5qaXRzaQogICAgICAtICdKSUNPRk9fQ09NUE9ORU5UX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfSklDT0ZPfScKICAgICAgLSAnSklDT0ZPX0FVVEhfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pJQ09GT30nCiAgICAgIC0gJ0pWQl9BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9KVkJ9JwogICAgICAtIFBVQkxJQ19VUkw9JFNFUlZJQ0VfVVJMX0pJVFNJCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICAgIC0gJ0xPR19MRVZFTD0ke0xPR19MRVZFTDotaW5mb30nCiAgICB2b2x1bWVzOgogICAgICAtICdqaXRzaS1wcm9zb2R5Oi9jb25maWcnCiAgICBuZXR3b3JrczoKICAgICAgbWVldC5qaXRzaToKICAgICAgICBhbGlhc2VzOgogICAgICAgICAgLSB4bXBwLm1lZXQuaml0c2kKICAgICAgICAgIC0gYXV0aC5tZWV0LmppdHNpCiAgICAgICAgICAtIGd1ZXN0Lm1lZXQuaml0c2kKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo1MjgwL2h0dHAtYmluZCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIGppY29mbzoKICAgIGltYWdlOiAnaml0c2kvamljb2ZvOnN0YWJsZS0xMDg4OCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBBVVRIX1RZUEU9aW50ZXJuYWwKICAgICAgLSBFTkFCTEVfQVVUSD0wCiAgICAgIC0gWE1QUF9ET01BSU49bWVldC5qaXRzaQogICAgICAtIFhNUFBfQVVUSF9ET01BSU49YXV0aC5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9JTlRFUk5BTF9NVUNfRE9NQUlOPWludGVybmFsLmF1dGgubWVldC5qaXRzaQogICAgICAtIFhNUFBfTVVDX0RPTUFJTj1jb25mZXJlbmNlLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX1NFUlZFUj1wcm9zb2R5CiAgICAgIC0gJ0pJQ09GT19DT01QT05FTlRfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9KSUNPRk99JwogICAgICAtICdKSUNPRk9fQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfSklDT0ZPfScKICAgICAgLSBKVkJfQlJFV0VSWV9NVUM9anZiYnJld2VyeQogICAgICAtIEpJQ09GT19FTkFCTEVfSEVBTFRIX0NIRUNLUz0xCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICBkZXBlbmRzX29uOgogICAgICAtIHByb3NvZHkKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ppdHNpLWppY29mbzovY29uZmlnJwogICAgbmV0d29ya3M6CiAgICAgIG1lZXQuaml0c2k6IG51bGwKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4ODg4L2Fib3V0L2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIGp2YjoKICAgIGltYWdlOiAnaml0c2kvanZiOnN0YWJsZS0xMDg4OCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBwb3J0czoKICAgICAgLSAnMTAwMDA6MTAwMDAvdWRwJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gWE1QUF9TRVJWRVI9cHJvc29keQogICAgICAtIFhNUFBfRE9NQUlOPW1lZXQuaml0c2kKICAgICAgLSBYTVBQX0FVVEhfRE9NQUlOPWF1dGgubWVldC5qaXRzaQogICAgICAtIFhNUFBfSU5URVJOQUxfTVVDX0RPTUFJTj1pbnRlcm5hbC5hdXRoLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX01VQ19ET01BSU49Y29uZmVyZW5jZS5tZWV0LmppdHNpCiAgICAgIC0gSlZCX0FVVEhfVVNFUj1qdmIKICAgICAgLSAnSlZCX0FVVEhfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pWQn0nCiAgICAgIC0gSlZCX0JSRVdFUllfTVVDPWp2YmJyZXdlcnkKICAgICAgLSBKVkJfUE9SVD0xMDAwMAogICAgICAtICdKVkJfQURWRVJUSVNFX0lQUz0ke0pWQl9BRFZFUlRJU0VfSVBTOi19JwogICAgICAtICdKVkJfU1RVTl9TRVJWRVJTPSR7SlZCX1NUVU5fU0VSVkVSUzotc3R1bi5sLmdvb2dsZS5jb206MTkzMDJ9JwogICAgICAtIFBVQkxJQ19VUkw9JFNFUlZJQ0VfVVJMX0pJVFNJCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICBkZXBlbmRzX29uOgogICAgICAtIHByb3NvZHkKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ppdHNpLWp2YjovY29uZmlnJwogICAgbmV0d29ya3M6CiAgICAgIG1lZXQuaml0c2k6IG51bGwKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4MDgwL2Fib3V0L2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQpuZXR3b3JrczoKICBtZWV0LmppdHNpOiBudWxsCg==",
         "tags": [
             "jitsi",
@@ -2603,10 +2620,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "keycloak-with-postgres": {
+    "keycloak": {
         "documentation": "https://www.keycloak.org?utm_source=coolify.io",
         "slogan": "Keycloak is an open-source Identity and Access Management tool.",
-        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0tFWUNMT0FLXzgwODAKICAgICAgLSAnVFo9JHtUSU1FWk9ORTotVVRDfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0FETUlOfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9BRE1JTn0nCiAgICAgIC0gS0NfREI9cG9zdGdyZXMKICAgICAgLSAnS0NfREJfVVNFUk5BTUU9JHtTRVJWSUNFX1VTRVJfREFUQUJBU0V9JwogICAgICAtICdLQ19EQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfREFUQUJBU0V9JwogICAgICAtIEtDX0RCX1VSTF9QT1JUPTU0MzIKICAgICAgLSAnS0NfREJfVVJMPWpkYmM6cG9zdGdyZXNxbDovL3Bvc3RncmVzLyR7UE9TVEdSRVNRTF9EQVRBQkFTRTota2V5Y2xvYWt9JwogICAgICAtICdLQ19IT1NUTkFNRT0ke1NFUlZJQ0VfVVJMX0tFWUNMT0FLfScKICAgICAgLSAnS0NfSFRUUF9FTkFCTEVEPSR7S0NfSFRUUF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfSEVBTFRIX0VOQUJMRUQ9JHtLQ19IRUFMVEhfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0tDX1BST1hZX0hFQURFUlM9JHtLQ19QUk9YWV9IRUFERVJTOi14Zm9yd2FyZGVkfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2tleWNsb2FrLWRhdGE6L29wdC9rZXljbG9hay9kYXRhJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiZXhlYyAzPD4vZGV2L3RjcC8xMjcuMC4wLjEvOTAwMDsgZWNobyAtZSAnR0VUIC9oZWFsdGgvcmVhZHkgSFRUUC8xLjFcclxuSG9zdDogbG9jYWxob3N0OjkwMDBcclxuQ29ubmVjdGlvbjogY2xvc2VcclxuXHJcbicgPiYzO2NhdCA8JjMgfCBncmVwIC1xICdcInN0YXR1c1wiOiBcIlVQXCInICYmIGV4aXQgMCB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX0RBVEFCQVNFfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X0RBVEFCQVNFfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1rZXljbG9ha30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0tFWUNMT0FLXzgwODAKICAgICAgLSAnVFo9JHtUSU1FWk9ORTotVVRDfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0FETUlOfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9BRE1JTn0nCiAgICAgIC0gJ0tDX0hPU1ROQU1FPSR7U0VSVklDRV9VUkxfS0VZQ0xPQUt9JwogICAgICAtICdLQ19IVFRQX0VOQUJMRUQ9JHtLQ19IVFRQX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19IRUFMVEhfRU5BQkxFRD0ke0tDX0hFQUxUSF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfUFJPWFlfSEVBREVSUz0ke0tDX1BST1hZX0hFQURFUlM6LXhmb3J3YXJkZWR9JwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstZGF0YTovb3B0L2tleWNsb2FrL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImV4ZWMgMzw+L2Rldi90Y3AvMTI3LjAuMC4xLzkwMDA7IGVjaG8gLWUgJ0dFVCAvaGVhbHRoL3JlYWR5IEhUVFAvMS4xXHJcbkhvc3Q6IGxvY2FsaG9zdDo5MDAwXHJcbkNvbm5lY3Rpb246IGNsb3NlXHJcblxyXG4nID4mMztjYXQgPCYzIHwgZ3JlcCAtcSAnXCJzdGF0dXNcIjogXCJVUFwiJyAmJiBleGl0IDAgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "keycloak",
             "identity",
@@ -2632,10 +2649,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
-    "keycloak": {
+    "keycloak-with-postgres": {
         "documentation": "https://www.keycloak.org?utm_source=coolify.io",
         "slogan": "Keycloak is an open-source Identity and Access Management tool.",
-        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0tFWUNMT0FLXzgwODAKICAgICAgLSAnVFo9JHtUSU1FWk9ORTotVVRDfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0FETUlOfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9BRE1JTn0nCiAgICAgIC0gJ0tDX0hPU1ROQU1FPSR7U0VSVklDRV9VUkxfS0VZQ0xPQUt9JwogICAgICAtICdLQ19IVFRQX0VOQUJMRUQ9JHtLQ19IVFRQX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19IRUFMVEhfRU5BQkxFRD0ke0tDX0hFQUxUSF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfUFJPWFlfSEVBREVSUz0ke0tDX1BST1hZX0hFQURFUlM6LXhmb3J3YXJkZWR9JwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstZGF0YTovb3B0L2tleWNsb2FrL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImV4ZWMgMzw+L2Rldi90Y3AvMTI3LjAuMC4xLzkwMDA7IGVjaG8gLWUgJ0dFVCAvaGVhbHRoL3JlYWR5IEhUVFAvMS4xXHJcbkhvc3Q6IGxvY2FsaG9zdDo5MDAwXHJcbkNvbm5lY3Rpb246IGNsb3NlXHJcblxyXG4nID4mMztjYXQgPCYzIHwgZ3JlcCAtcSAnXCJzdGF0dXNcIjogXCJVUFwiJyAmJiBleGl0IDAgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0tFWUNMT0FLXzgwODAKICAgICAgLSAnVFo9JHtUSU1FWk9ORTotVVRDfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0FETUlOfScKICAgICAgLSAnS0NfQk9PVFNUUkFQX0FETUlOX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9BRE1JTn0nCiAgICAgIC0gS0NfREI9cG9zdGdyZXMKICAgICAgLSAnS0NfREJfVVNFUk5BTUU9JHtTRVJWSUNFX1VTRVJfREFUQUJBU0V9JwogICAgICAtICdLQ19EQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfREFUQUJBU0V9JwogICAgICAtIEtDX0RCX1VSTF9QT1JUPTU0MzIKICAgICAgLSAnS0NfREJfVVJMPWpkYmM6cG9zdGdyZXNxbDovL3Bvc3RncmVzLyR7UE9TVEdSRVNRTF9EQVRBQkFTRTota2V5Y2xvYWt9JwogICAgICAtICdLQ19IT1NUTkFNRT0ke1NFUlZJQ0VfVVJMX0tFWUNMT0FLfScKICAgICAgLSAnS0NfSFRUUF9FTkFCTEVEPSR7S0NfSFRUUF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfSEVBTFRIX0VOQUJMRUQ9JHtLQ19IRUFMVEhfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0tDX1BST1hZX0hFQURFUlM9JHtLQ19QUk9YWV9IRUFERVJTOi14Zm9yd2FyZGVkfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2tleWNsb2FrLWRhdGE6L29wdC9rZXljbG9hay9kYXRhJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiZXhlYyAzPD4vZGV2L3RjcC8xMjcuMC4wLjEvOTAwMDsgZWNobyAtZSAnR0VUIC9oZWFsdGgvcmVhZHkgSFRUUC8xLjFcclxuSG9zdDogbG9jYWxob3N0OjkwMDBcclxuQ29ubmVjdGlvbjogY2xvc2VcclxuXHJcbicgPiYzO2NhdCA8JjMgfCBncmVwIC1xICdcInN0YXR1c1wiOiBcIlVQXCInICYmIGV4aXQgMCB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX0RBVEFCQVNFfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X0RBVEFCQVNFfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1rZXljbG9ha30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "keycloak",
             "identity",
@@ -2871,10 +2888,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
-    "linkding-plus": {
+    "linkding": {
         "documentation": "https://linkding.link/?utm_source=coolify.io",
-        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up. (Includes feature for archiving websites as HTML snapshots)",
-        "compose": "c2VydmljZXM6CiAgbGlua2RpbmctcGx1czoKICAgIGltYWdlOiAnc2lzc2JydWVja2VyL2xpbmtkaW5nOmxhdGVzdC1wbHVzJwogICAgdm9sdW1lczoKICAgICAgLSAnbGlua2RpbmdfZGF0YTovZXRjL2xpbmtkaW5nL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9MSU5LRElOR185MDkwCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9OQU1FPSR7U0VSVklDRV9VU0VSX0xJTktESU5HfScKICAgICAgLSAnTERfU1VQRVJVU0VSX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9MSU5LRElOR30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS85MDkwJyB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwo=",
+        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up.",
+        "compose": "c2VydmljZXM6CiAgbGlua2Rpbmc6CiAgICBpbWFnZTogJ3Npc3NicnVlY2tlci9saW5rZGluZzpsYXRlc3QnCiAgICB2b2x1bWVzOgogICAgICAtICdsaW5rZGluZ19kYXRhOi9ldGMvbGlua2RpbmcvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0xJTktESU5HXzkwOTAKICAgICAgLSAnTERfU1VQRVJVU0VSX05BTUU9JHtTRVJWSUNFX1VTRVJfTElOS0RJTkd9JwogICAgICAtICdMRF9TVVBFUlVTRVJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0xJTktESU5HfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiYmFzaCAtYyAnOj4gL2Rldi90Y3AvMTI3LjAuMC4xLzkwOTAnIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDVzCg==",
         "tags": [
             "rss",
             "feed"
@@ -2885,10 +2902,10 @@
         "template_last_updated_at": "2026-01-13T00:05:43+01:00",
         "port": "9090"
     },
-    "linkding": {
+    "linkding-plus": {
         "documentation": "https://linkding.link/?utm_source=coolify.io",
-        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up.",
-        "compose": "c2VydmljZXM6CiAgbGlua2Rpbmc6CiAgICBpbWFnZTogJ3Npc3NicnVlY2tlci9saW5rZGluZzpsYXRlc3QnCiAgICB2b2x1bWVzOgogICAgICAtICdsaW5rZGluZ19kYXRhOi9ldGMvbGlua2RpbmcvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0xJTktESU5HXzkwOTAKICAgICAgLSAnTERfU1VQRVJVU0VSX05BTUU9JHtTRVJWSUNFX1VTRVJfTElOS0RJTkd9JwogICAgICAtICdMRF9TVVBFUlVTRVJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0xJTktESU5HfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiYmFzaCAtYyAnOj4gL2Rldi90Y3AvMTI3LjAuMC4xLzkwOTAnIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDVzCg==",
+        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up. (Includes feature for archiving websites as HTML snapshots)",
+        "compose": "c2VydmljZXM6CiAgbGlua2RpbmctcGx1czoKICAgIGltYWdlOiAnc2lzc2JydWVja2VyL2xpbmtkaW5nOmxhdGVzdC1wbHVzJwogICAgdm9sdW1lczoKICAgICAgLSAnbGlua2RpbmdfZGF0YTovZXRjL2xpbmtkaW5nL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9MSU5LRElOR185MDkwCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9OQU1FPSR7U0VSVklDRV9VU0VSX0xJTktESU5HfScKICAgICAgLSAnTERfU1VQRVJVU0VSX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9MSU5LRElOR30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS85MDkwJyB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwo=",
         "tags": [
             "rss",
             "feed"
@@ -3029,6 +3046,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8025"
+    },
+    "marimo": {
+        "documentation": "https://marimo.io/?utm_source=coolify.io",
+        "slogan": "An open-source reactive notebook for Python — reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.",
+        "compose": "c2VydmljZXM6CiAgbWFyaW1vOgogICAgaW1hZ2U6ICdnaGNyLmlvL21hcmltby10ZWFtL21hcmltbzpsYXRlc3Qtc3FsJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfTUFSSU1PXzgwODAKICAgICAgLSBUT0tFTl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NQVJJTU8KICAgIHZvbHVtZXM6CiAgICAgIC0gJ21hcmltbzovYXBwJwogICAgY29tbWFuZDoKICAgICAgLSBtYXJpbW8KICAgICAgLSBlZGl0CiAgICAgIC0gJy0tdG9rZW4tcGFzc3dvcmQnCiAgICAgIC0gJyR7U0VSVklDRV9QQVNTV09SRF9NQVJJTU99JwogICAgICAtICctLXBvcnQnCiAgICAgIC0gJzgwODAnCiAgICAgIC0gJy0taG9zdCcKICAgICAgLSAwLjAuMC4wCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gdXZ4CiAgICAgICAgLSAnLS13aXRoJwogICAgICAgIC0gJ2h0dHB4W2NsaV0nCiAgICAgICAgLSBodHRweAogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9oZWFsdGgnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
+        "tags": [
+            "notebook",
+            "python",
+            "data",
+            "analysis"
+        ],
+        "category": "devtools",
+        "logo": "svgs/marimo.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8080"
     },
     "martin": {
         "documentation": "https://maplibre.org/martin/introduction.html/?utm_source=coolify.io",
@@ -3283,7 +3316,7 @@
     },
     "moodle": {
         "documentation": "https://moodle.org?utm_source=coolify.io",
-        "slogan": "Moodle is the world\u2019s most customisable and trusted eLearning solution that empowers educators to improve our world.",
+        "slogan": "Moodle is the world’s most customisable and trusted eLearning solution that empowers educators to improve our world.",
         "compose": "c2VydmljZXM6CiAgbWFyaWFkYjoKICAgIGltYWdlOiAnbWFyaWFkYjoxMS4xJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gQUxMT1dfRU1QVFlfUEFTU1dPUkQ9bm8KICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgICAgLSBNWVNRTF9EQVRBQkFTRT1iaXRuYW1pX21vb2RsZQogICAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9NQVJJQURCCiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfTUFSSUFEQgogICAgICAtIE1BUklBREJfQ0hBUkFDVEVSX1NFVD11dGY4bWI0CiAgICAgIC0gTUFSSUFEQl9DT0xMQVRFPXV0ZjhtYjRfdW5pY29kZV9jaQogICAgdm9sdW1lczoKICAgICAgLSAnbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc8L2Rldi90Y3AvbG9jYWxob3N0LzMzMDYnIgogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDUKICBtb29kbGU6CiAgICBpbWFnZTogJ2RvY2tlci5pby9iaXRuYW1pbGVnYWN5L21vb2RsZTo0LjMnCiAgICBkZXBlbmRzX29uOgogICAgICAtIG1hcmlhZGIKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX01PT0RMRV84MDgwCiAgICAgIC0gTU9PRExFX0RBVEFCQVNFX0hPU1Q9bWFyaWFkYgogICAgICAtIE1PT0RMRV9EQVRBQkFTRV9QT1JUX05VTUJFUj0zMzA2CiAgICAgIC0gTU9PRExFX0RBVEFCQVNFX1VTRVI9JFNFUlZJQ0VfVVNFUl9NQVJJQURCCiAgICAgIC0gTU9PRExFX0RBVEFCQVNFX05BTUU9Yml0bmFtaV9tb29kbGUKICAgICAgLSBNT09ETEVfREFUQUJBU0VfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfTUFSSUFEQgogICAgICAtIEFMTE9XX0VNUFRZX1BBU1NXT1JEPW5vCiAgICAgIC0gJ01PT0RMRV9VU0VSTkFNRT0ke01PT0RMRV9VU0VSTkFNRTotdXNlcn0nCiAgICAgIC0gTU9PRExFX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX01PT0RMRQogICAgICAtIE1PT0RMRV9FTUFJTD11c2VyQGV4YW1wbGUuY29tCiAgICAgIC0gJ01PT0RMRV9TSVRFX05BTUU9JHtNT09ETEVfU0lURV9OQU1FOi1OZXcgU2l0ZX0nCiAgICB2b2x1bWVzOgogICAgICAtICdtb29kbGUtZGF0YTovYml0bmFtaS9tb29kbGUnCiAgICAgIC0gJ21vb2RsZWRhdGEtZGF0YTovYml0bmFtaS9tb29kbGVkYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHBocAogICAgICAgIC0gJy1yJwogICAgICAgIC0gImV4aXQoZmlsZV9leGlzdHMoJy9vcHQvYml0bmFtaS9tb29kbGUvY29uZmlnLnBocCcpID8gMCA6IDEpOyIKICAgICAgaW50ZXJ2YWw6IDIwcwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogNQo=",
         "tags": [
             "moodle",
@@ -3317,6 +3350,25 @@
         "template_last_updated_at": "2026-01-05T18:25:15+01:00",
         "port": "1883"
     },
+    "n8n": {
+        "documentation": "https://n8n.io?utm_source=coolify.io",
+        "slogan": "n8n is an extendable workflow automation tool.",
+        "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfTjhOXzU2NzgKICAgICAgLSAnTjhOX0VESVRPUl9CQVNFX1VSTD0ke1NFUlZJQ0VfVVJMX044Tn0nCiAgICAgIC0gJ1dFQkhPT0tfVVJMPSR7U0VSVklDRV9VUkxfTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX1BST1RPQ09MPSR7TjhOX1BST1RPQ09MOi1odHRwc30nCiAgICAgIC0gJ0dFTkVSSUNfVElNRVpPTkU9JHtHRU5FUklDX1RJTUVaT05FOi1VVEN9JwogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdEQl9TUUxJVEVfUE9PTF9TSVpFPSR7REJfU1FMSVRFX1BPT0xfU0laRTotMn0nCiAgICAgIC0gTjhOX1JVTk5FUlNfRU5BQkxFRD10cnVlCiAgICAgIC0gTjhOX1JVTk5FUlNfTU9ERT1leHRlcm5hbAogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M9JHtOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M6LTAuMC4wLjB9JwogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfUE9SVD0ke044Tl9SVU5ORVJTX0JST0tFUl9QT1JUOi01Njc5fScKICAgICAgLSAnTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfTjhOfScKICAgICAgLSAnTjhOX05BVElWRV9QWVRIT05fUlVOTkVSPSR7TjhOX05BVElWRV9QWVRIT05fUlVOTkVSOi10cnVlfScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgICAgLSAnTjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERT0ke044Tl9CTE9DS19FTlZfQUNDRVNTX0lOX05PREU6LXRydWV9JwogICAgICAtICdOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TPSR7TjhOX0dJVF9OT0RFX0RJU0FCTEVfQkFSRV9SRVBPUzotdHJ1ZX0nCiAgICAgIC0gJ044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM9JHtOOE5fRU5GT1JDRV9TRVRUSU5HU19GSUxFX1BFUk1JU1NJT05TOi10cnVlfScKICAgICAgLSAnTjhOX1BST1hZX0hPUFM9JHtOOE5fUFJPWFlfSE9QUzotMX0nCiAgICAgIC0gJ044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s9JHtOOE5fU0tJUF9BVVRIX09OX09BVVRIX0NBTExCQUNLOi1mYWxzZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduOG4tZGF0YTovaG9tZS9ub2RlLy5uOG4nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2NzgvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHRhc2stcnVubmVyczoKICAgIGltYWdlOiAnbjhuaW8vcnVubmVyczoyLjEwLjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJPSR7TjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJOi1odHRwOi8vbjhuOjU2Nzl9JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRIX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9OOE59JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ9JHtOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ6LTE1fScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgIGRlcGVuZHNfb246CiAgICAgIC0gbjhuCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2ODAvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "n8n",
+            "workflow",
+            "automation",
+            "open",
+            "source",
+            "low",
+            "code"
+        ],
+        "category": "automation",
+        "logo": "svgs/n8n.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-03-30T20:40:07+02:00",
+        "port": "5678"
+    },
     "n8n-with-postgres-and-worker": {
         "documentation": "https://n8n.io?utm_source=coolify.io",
         "slogan": "n8n is an extendable workflow automation tool with queue mode and workers.",
@@ -3343,25 +3395,6 @@
         "documentation": "https://n8n.io?utm_source=coolify.io",
         "slogan": "n8n is an extendable workflow automation tool.",
         "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfTjhOXzU2NzgKICAgICAgLSAnTjhOX0VESVRPUl9CQVNFX1VSTD0ke1NFUlZJQ0VfVVJMX044Tn0nCiAgICAgIC0gJ1dFQkhPT0tfVVJMPSR7U0VSVklDRV9VUkxfTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX1VSTF9OOE59JwogICAgICAtICdOOE5fUFJPVE9DT0w9JHtOOE5fUFJPVE9DT0w6LWh0dHBzfScKICAgICAgLSAnR0VORVJJQ19USU1FWk9ORT0ke0dFTkVSSUNfVElNRVpPTkU6LVVUQ30nCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICAgIC0gREJfVFlQRT1wb3N0Z3Jlc2RiCiAgICAgIC0gJ0RCX1BPU1RHUkVTREJfREFUQUJBU0U9JHtQT1NUR1JFU19EQjotbjhufScKICAgICAgLSBEQl9QT1NUR1JFU0RCX0hPU1Q9cG9zdGdyZXNxbAogICAgICAtIERCX1BPU1RHUkVTREJfUE9SVD01NDMyCiAgICAgIC0gREJfUE9TVEdSRVNEQl9VU0VSPSRTRVJWSUNFX1VTRVJfUE9TVEdSRVMKICAgICAgLSBEQl9QT1NUR1JFU0RCX1NDSEVNQT1wdWJsaWMKICAgICAgLSBEQl9QT1NUR1JFU0RCX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gTjhOX1JVTk5FUlNfRU5BQkxFRD10cnVlCiAgICAgIC0gTjhOX1JVTk5FUlNfTU9ERT1leHRlcm5hbAogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M9JHtOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M6LTAuMC4wLjB9JwogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfUE9SVD0ke044Tl9SVU5ORVJTX0JST0tFUl9QT1JUOi01Njc5fScKICAgICAgLSBOOE5fUlVOTkVSU19BVVRIX1RPS0VOPSRTRVJWSUNFX1BBU1NXT1JEX044TgogICAgICAtICdOOE5fTkFUSVZFX1BZVEhPTl9SVU5ORVI9JHtOOE5fTkFUSVZFX1BZVEhPTl9SVU5ORVI6LXRydWV9JwogICAgICAtICdOOE5fUlVOTkVSU19NQVhfQ09OQ1VSUkVOQ1k9JHtOOE5fUlVOTkVSU19NQVhfQ09OQ1VSUkVOQ1k6LTV9JwogICAgICAtICdOOE5fQkxPQ0tfRU5WX0FDQ0VTU19JTl9OT0RFPSR7TjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERTotdHJ1ZX0nCiAgICAgIC0gJ044Tl9HSVRfTk9ERV9ESVNBQkxFX0JBUkVfUkVQT1M9JHtOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TOi10cnVlfScKICAgICAgLSAnTjhOX0VORk9SQ0VfU0VUVElOR1NfRklMRV9QRVJNSVNTSU9OUz0ke044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM6LXRydWV9JwogICAgICAtICdOOE5fUFJPWFlfSE9QUz0ke044Tl9QUk9YWV9IT1BTOi0xfScKICAgICAgLSAnTjhOX1NLSVBfQVVUSF9PTl9PQVVUSF9DQUxMQkFDSz0ke044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s6LWZhbHNlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ244bi1kYXRhOi9ob21lL25vZGUvLm44bicKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnd2dldCAtcU8tIGh0dHA6Ly8xMjcuMC4wLjE6NTY3OC9oZWFsdGh6JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgdGFzay1ydW5uZXJzOgogICAgaW1hZ2U6ICduOG5pby9ydW5uZXJzOjIuMTAuMicKICAgIGVudmlyb25tZW50OgogICAgICAtICdOOE5fUlVOTkVSU19UQVNLX0JST0tFUl9VUkk9JHtOOE5fUlVOTkVSU19UQVNLX0JST0tFUl9VUkk6LWh0dHA6Ly9uOG46NTY3OX0nCiAgICAgIC0gTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0kU0VSVklDRV9QQVNTV09SRF9OOE4KICAgICAgLSAnTjhOX1JVTk5FUlNfQVVUT19TSFVURE9XTl9USU1FT1VUPSR7TjhOX1JVTk5FUlNfQVVUT19TSFVURE9XTl9USU1FT1VUOi0xNX0nCiAgICAgIC0gJ044Tl9SVU5ORVJTX01BWF9DT05DVVJSRU5DWT0ke044Tl9SVU5ORVJTX01BWF9DT05DVVJSRU5DWTotNX0nCiAgICBkZXBlbmRzX29uOgogICAgICAtIG44bgogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd3Z2V0IC1xTy0gaHR0cDovLzEyNy4wLjAuMTo1NjgwL2hlYWx0aHonCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdwb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gUE9TVEdSRVNfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gUE9TVEdSRVNfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVMKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU19EQjotbjhufScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
-        "tags": [
-            "n8n",
-            "workflow",
-            "automation",
-            "open",
-            "source",
-            "low",
-            "code"
-        ],
-        "category": "automation",
-        "logo": "svgs/n8n.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-03-30T20:40:07+02:00",
-        "port": "5678"
-    },
-    "n8n": {
-        "documentation": "https://n8n.io?utm_source=coolify.io",
-        "slogan": "n8n is an extendable workflow automation tool.",
-        "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfTjhOXzU2NzgKICAgICAgLSAnTjhOX0VESVRPUl9CQVNFX1VSTD0ke1NFUlZJQ0VfVVJMX044Tn0nCiAgICAgIC0gJ1dFQkhPT0tfVVJMPSR7U0VSVklDRV9VUkxfTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX1BST1RPQ09MPSR7TjhOX1BST1RPQ09MOi1odHRwc30nCiAgICAgIC0gJ0dFTkVSSUNfVElNRVpPTkU9JHtHRU5FUklDX1RJTUVaT05FOi1VVEN9JwogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdEQl9TUUxJVEVfUE9PTF9TSVpFPSR7REJfU1FMSVRFX1BPT0xfU0laRTotMn0nCiAgICAgIC0gTjhOX1JVTk5FUlNfRU5BQkxFRD10cnVlCiAgICAgIC0gTjhOX1JVTk5FUlNfTU9ERT1leHRlcm5hbAogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M9JHtOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M6LTAuMC4wLjB9JwogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfUE9SVD0ke044Tl9SVU5ORVJTX0JST0tFUl9QT1JUOi01Njc5fScKICAgICAgLSAnTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfTjhOfScKICAgICAgLSAnTjhOX05BVElWRV9QWVRIT05fUlVOTkVSPSR7TjhOX05BVElWRV9QWVRIT05fUlVOTkVSOi10cnVlfScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgICAgLSAnTjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERT0ke044Tl9CTE9DS19FTlZfQUNDRVNTX0lOX05PREU6LXRydWV9JwogICAgICAtICdOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TPSR7TjhOX0dJVF9OT0RFX0RJU0FCTEVfQkFSRV9SRVBPUzotdHJ1ZX0nCiAgICAgIC0gJ044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM9JHtOOE5fRU5GT1JDRV9TRVRUSU5HU19GSUxFX1BFUk1JU1NJT05TOi10cnVlfScKICAgICAgLSAnTjhOX1BST1hZX0hPUFM9JHtOOE5fUFJPWFlfSE9QUzotMX0nCiAgICAgIC0gJ044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s9JHtOOE5fU0tJUF9BVVRIX09OX09BVVRIX0NBTExCQUNLOi1mYWxzZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduOG4tZGF0YTovaG9tZS9ub2RlLy5uOG4nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2NzgvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHRhc2stcnVubmVyczoKICAgIGltYWdlOiAnbjhuaW8vcnVubmVyczoyLjEwLjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJPSR7TjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJOi1odHRwOi8vbjhuOjU2Nzl9JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRIX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9OOE59JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ9JHtOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ6LTE1fScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgIGRlcGVuZHNfb246CiAgICAgIC0gbjhuCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2ODAvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "n8n",
             "workflow",
@@ -3410,7 +3443,7 @@
     },
     "netbird-client": {
         "documentation": "https://docs.netbird.io/how-to/examples#net-bird-client-in-docker?utm_source=coolify.io",
-        "slogan": "Connect your devices into a secure WireGuard\u00ae-based overlay network with SSO, MFA and granular access controls.",
+        "slogan": "Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.",
         "compose": "c2VydmljZXM6CiAgbmV0YmlyZC1jbGllbnQ6CiAgICBpbWFnZTogJ25ldGJpcmRpby9uZXRiaXJkOmxhdGVzdCcKICAgIG5ldHdvcmtfbW9kZTogaG9zdAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ05CX1NFVFVQX0tFWT0ke05CX1NFVFVQX0tFWX0nCiAgICAgIC0gJ05CX0VOQUJMRV9ST1NFTlBBU1M9JHtOQl9FTkFCTEVfUk9TRU5QQVNTOi1mYWxzZX0nCiAgICAgIC0gJ05CX0VOQUJMRV9FWFBFUklNRU5UQUxfTEFaWV9DT05OPSR7TkJfRU5BQkxFX0VYUEVSSU1FTlRBTF9MQVpZX0NPTk46LWZhbHNlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25ldGJpcmQtY2xpZW50Oi92YXIvbGliL25ldGJpcmQnCiAgICBjYXBfYWRkOgogICAgICAtIE5FVF9BRE1JTgogICAgICAtIFNZU19BRE1JTgogICAgICAtIFNZU19SRVNPVVJDRQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIG5ldGJpcmQKICAgICAgICAtIHZlcnNpb24KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "wireguard",
@@ -3472,6 +3505,23 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
+    "nextcloud": {
+        "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
+        "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
+        "compose": "c2VydmljZXM6CiAgbmV4dGNsb3VkOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL25leHRjbG91ZDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9ORVhUQ0xPVURfODAKICAgICAgLSBQVUlEPTEwMDAKICAgICAgLSBQR0lEPTEwMDAKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL01hZHJpZH0nCiAgICB2b2x1bWVzOgogICAgICAtICduZXh0Y2xvdWQtY29uZmlnOi9jb25maWcnCiAgICAgIC0gJ25leHRjbG91ZC1kYXRhOi9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwL3N0YXR1cy5waHAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
+        "tags": [
+            "cloud",
+            "collaboration",
+            "communication",
+            "filestorage",
+            "data"
+        ],
+        "category": "storage",
+        "logo": "svgs/nextcloud.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-07T23:32:57+05:30",
+        "port": "80"
+    },
     "nextcloud-with-mariadb": {
         "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
         "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
@@ -3523,22 +3573,24 @@
         "template_last_updated_at": "2026-04-07T23:32:57+05:30",
         "port": "80"
     },
-    "nextcloud": {
-        "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
-        "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
-        "compose": "c2VydmljZXM6CiAgbmV4dGNsb3VkOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL25leHRjbG91ZDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9ORVhUQ0xPVURfODAKICAgICAgLSBQVUlEPTEwMDAKICAgICAgLSBQR0lEPTEwMDAKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL01hZHJpZH0nCiAgICB2b2x1bWVzOgogICAgICAtICduZXh0Y2xvdWQtY29uZmlnOi9jb25maWcnCiAgICAgIC0gJ25leHRjbG91ZC1kYXRhOi9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwL3N0YXR1cy5waHAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
+    "nexus": {
+        "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
+        "slogan": "Open source Universal Repository Manager (x86_64 version, official), default credentials: admin/admin123",
+        "compose": "c2VydmljZXM6CiAgbmV4dXM6CiAgICBpbWFnZTogc29uYXR5cGUvbmV4dXMzCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05FWFVTXzgwODEKICAgICAgLSAnTkVYVVNfU0VDVVJJVFlfUkFORE9NUEFTU1dPUkQ9JHtORVhVU19TRUNVUklUWV9SQU5ET01QQVNTV09SRDotZmFsc2V9JwogICAgICAtICdJTlNUQUxMNEpfQUREX1ZNX1BBUkFNUz0tWG1zMjcwM20gLVhteDI3MDNtIC1YWDpNYXhEaXJlY3RNZW1vcnlTaXplPTI3MDNtIC1EamF2YS51dGlsLnByZWZzLnVzZXJSb290PS9uZXh1cy1kYXRhL2phdmFwcmVmcycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25leHVzX2RhdGE6L25leHVzLWRhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6ODA4MS9zZXJ2aWNlL3Jlc3QvdjEvc3RhdHVzJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAzCiAgICAgIHN0YXJ0X3BlcmlvZDogNjBzCg==",
         "tags": [
-            "cloud",
-            "collaboration",
-            "communication",
-            "filestorage",
-            "data"
+            "repository",
+            "manager",
+            "open source",
+            "docker",
+            "docker",
+            "registry",
+            "container"
         ],
-        "category": "storage",
-        "logo": "svgs/nextcloud.svg",
+        "category": "devtools",
+        "logo": "svgs/nexus.png",
         "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-07T23:32:57+05:30",
-        "port": "80"
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8081"
     },
     "nexus-arm": {
         "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
@@ -3559,29 +3611,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8081"
     },
-    "nexus": {
-        "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
-        "slogan": "Open source Universal Repository Manager (x86_64 version, official), default credentials: admin/admin123",
-        "compose": "c2VydmljZXM6CiAgbmV4dXM6CiAgICBpbWFnZTogc29uYXR5cGUvbmV4dXMzCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05FWFVTXzgwODEKICAgICAgLSAnTkVYVVNfU0VDVVJJVFlfUkFORE9NUEFTU1dPUkQ9JHtORVhVU19TRUNVUklUWV9SQU5ET01QQVNTV09SRDotZmFsc2V9JwogICAgICAtICdJTlNUQUxMNEpfQUREX1ZNX1BBUkFNUz0tWG1zMjcwM20gLVhteDI3MDNtIC1YWDpNYXhEaXJlY3RNZW1vcnlTaXplPTI3MDNtIC1EamF2YS51dGlsLnByZWZzLnVzZXJSb290PS9uZXh1cy1kYXRhL2phdmFwcmVmcycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25leHVzX2RhdGE6L25leHVzLWRhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6ODA4MS9zZXJ2aWNlL3Jlc3QvdjEvc3RhdHVzJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAzCiAgICAgIHN0YXJ0X3BlcmlvZDogNjBzCg==",
-        "tags": [
-            "repository",
-            "manager",
-            "open source",
-            "docker",
-            "docker",
-            "registry",
-            "container"
-        ],
-        "category": "devtools",
-        "logo": "svgs/nexus.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8081"
-    },
-    "nitropage-with-postgresql": {
+    "nitropage": {
         "documentation": "https://nitropage.org?utm_source=coolify.io",
         "slogan": "Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.",
-        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6IG5pdHJvcGFnZS9uaXRyb3BhZ2UKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05JVFJPUEFHRV8zMDAwCiAgICAgIC0gJ05QX0FVVEhfU0FMVD0ke1NFUlZJQ0VfQkFTRTY0X1NBTFR9JwogICAgICAtICdOUF9BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9TRVNTSU9OfScKICAgICAgLSAnREFUQUJBU0VfVVJMPXBvc3RncmVzcWw6Ly8ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfToke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH1AcG9zdGdyZXNxbDo1NDMyLyR7UE9TVEdSRVNRTF9EQVRBQkFTRTotbml0cm9wYWdlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1kYXRhOi9hcHAvLmRhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3Jlc3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hZG1pbicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1uaXRyb3BhZ2V9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6ICduaXRyb3BhZ2Uvbml0cm9wYWdlOnNxbGl0ZScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05JVFJPUEFHRV8zMDAwCiAgICAgIC0gJ05QX0FVVEhfU0FMVD0ke1NFUlZJQ0VfQkFTRTY0X1NBTFR9JwogICAgICAtICdOUF9BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9TRVNTSU9OfScKICAgICAgLSAnREFUQUJBU0VfVVJMPWZpbGU6Li4vLmRhdGEvZGV2LmRiJwogICAgdm9sdW1lczoKICAgICAgLSAnbml0cm9wYWdlLWRhdGE6L2FwcC8uZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwL2FkbWluJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
         "tags": [
             "nitropage",
             "builder",
@@ -3597,10 +3630,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "nitropage": {
+    "nitropage-with-postgresql": {
         "documentation": "https://nitropage.org?utm_source=coolify.io",
         "slogan": "Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.",
-        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6ICduaXRyb3BhZ2Uvbml0cm9wYWdlOnNxbGl0ZScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05JVFJPUEFHRV8zMDAwCiAgICAgIC0gJ05QX0FVVEhfU0FMVD0ke1NFUlZJQ0VfQkFTRTY0X1NBTFR9JwogICAgICAtICdOUF9BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9TRVNTSU9OfScKICAgICAgLSAnREFUQUJBU0VfVVJMPWZpbGU6Li4vLmRhdGEvZGV2LmRiJwogICAgdm9sdW1lczoKICAgICAgLSAnbml0cm9wYWdlLWRhdGE6L2FwcC8uZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwL2FkbWluJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
+        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6IG5pdHJvcGFnZS9uaXRyb3BhZ2UKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX05JVFJPUEFHRV8zMDAwCiAgICAgIC0gJ05QX0FVVEhfU0FMVD0ke1NFUlZJQ0VfQkFTRTY0X1NBTFR9JwogICAgICAtICdOUF9BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF82NF9TRVNTSU9OfScKICAgICAgLSAnREFUQUJBU0VfVVJMPXBvc3RncmVzcWw6Ly8ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfToke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH1AcG9zdGdyZXNxbDo1NDMyLyR7UE9TVEdSRVNRTF9EQVRBQkFTRTotbml0cm9wYWdlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1kYXRhOi9hcHAvLmRhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3Jlc3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hZG1pbicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIHBvc3RncmVzcWw6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU1FMX0RBVEFCQVNFOi1uaXRyb3BhZ2V9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "nitropage",
             "builder",
@@ -3847,7 +3880,7 @@
     },
     "openobserve": {
         "documentation": "https://openobserve.ai/docs/?utm_source=coolify.io",
-        "slogan": "Cloud-native observability platform for logs, metrics, traces, RUM, errors and session replays \u2014 a 140x cheaper alternative to Elasticsearch, Splunk and Datadog.",
+        "slogan": "Cloud-native observability platform for logs, metrics, traces, RUM, errors and session replays — a 140x cheaper alternative to Elasticsearch, Splunk and Datadog.",
         "compose": "c2VydmljZXM6CiAgb3Blbm9ic2VydmU6CiAgICBpbWFnZTogJ3B1YmxpYy5lY3IuYXdzL3ppbmNsYWJzL29wZW5vYnNlcnZlOnYwLjkwLjAnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9PUEVOT0JTRVJWRV81MDgwCiAgICAgIC0gWk9fREFUQV9ESVI9L2RhdGEKICAgICAgLSAnWk9fUk9PVF9VU0VSX0VNQUlMPSR7Wk9fUk9PVF9VU0VSX0VNQUlMOi1yb290QGV4YW1wbGUuY29tfScKICAgICAgLSAnWk9fUk9PVF9VU0VSX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9PUEVOT0JTRVJWRX0nCiAgICAgIC0gJ1pPX1RFTEVNRVRSWT0ke1pPX1RFTEVNRVRSWTotZmFsc2V9JwogICAgICAtICdaT19DT09LSUVfU0VDVVJFX09OTFk9JHtaT19DT09LSUVfU0VDVVJFX09OTFk6LXRydWV9JwogICAgdm9sdW1lczoKICAgICAgLSAnb3Blbm9ic2VydmUtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvb3Blbm9ic2VydmUKICAgICAgICAtIG5vZGUKICAgICAgICAtIHN0YXR1cwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDUKICAgICAgc3RhcnRfcGVyaW9kOiA2MHMK",
         "tags": [
             "logs",
@@ -4056,24 +4089,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "penpot-with-s3": {
-        "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
-        "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
-        "compose": "c2VydmljZXM6CiAgZnJvbnRlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9mcm9udGVuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwZW5wb3QtYmFja2VuZDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtZXhwb3J0ZXI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZST05URU5EXzgwODAKICAgICAgLSAnUEVOUE9UX0ZMQUdTPSR7UEVOUE9UX0JBQ0tFTkRfRkxBR1M6LWVuYWJsZS1sb2dpbi13aXRoLXBhc3N3b3JkfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgwJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1CiAgcGVucG90LWJhY2tlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9iYWNrZW5kOjIuMTEuMScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIHBlbnBvdC12YWxrZXk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgbWluaW8taW5pdDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfY29tcGxldGVkX3N1Y2Nlc3NmdWxseQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BFTlBPVF9GTEFHUz0ke1BFTlBPVF9CQUNLRU5EX0ZMQUdTOi1lbmFibGUtbG9naW4td2l0aC1wYXNzd29yZH0nCiAgICAgIC0gUEVOUE9UX0hUVFBfU0VSVkVSX1BPUlQ9NjA2MAogICAgICAtICdQRU5QT1RfU0VDUkVUX0tFWT0ke1NFUlZJQ0VfUkVBTEJBU0U2NF82NF9QRU5QT1R9JwogICAgICAtICdQRU5QT1RfUFVCTElDX1VSST0ke1NFUlZJQ0VfVVJMX0ZST05URU5EXzgwODB9JwogICAgICAtICdQRU5QT1RfQkFDS0VORF9VUkk9aHR0cDovL3BlbnBvdC1iYWNrZW5kJwogICAgICAtICdQRU5QT1RfRVhQT1JURVJfVVJJPWh0dHA6Ly9wZW5wb3QtZXhwb3J0ZXInCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9VUkk9cG9zdGdyZXNxbDovL3Bvc3RncmVzLyR7UE9TVEdSRVNfREI6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQRU5QT1RfUkVESVNfVVJJPXJlZGlzOi8vcGVucG90LXZhbGtleS8wJwogICAgICAtICdQRU5QT1RfVEVMRU1FVFJZX0VOQUJMRUQ9JHtQRU5QT1RfVEVMRU1FVFJZX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX0JBQ0tFTkQ9czMKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX1JFR0lPTj11cy1lYXN0LTEKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX0JVQ0tFVD1wZW5wb3QKICAgICAgLSAnUEVOUE9UX09CSkVDVFNfU1RPUkFHRV9TM19FTkRQT0lOVD1odHRwOi8vbWluaW86OTAwMCcKICAgICAgLSAnQVdTX0FDQ0VTU19LRVlfSUQ9JHtTRVJWSUNFX1VTRVJfTUlOSU99JwogICAgICAtICdBV1NfU0VDUkVUX0FDQ0VTU19LRVk9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnUEVOUE9UX1NNVFBfREVGQVVMVF9GUk9NPSR7UEVOUE9UX1NNVFBfREVGQVVMVF9GUk9NOi1uby1yZXBseUBleGFtcGxlLmNvbX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX0RFRkFVTFRfUkVQTFlfVE89JHtQRU5QT1RfU01UUF9ERUZBVUxUX1JFUExZX1RPOi1uby1yZXBseUBleGFtcGxlLmNvbX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX0hPU1Q9JHtQRU5QT1RfU01UUF9IT1NUOi1tYWlscGl0fScKICAgICAgLSAnUEVOUE9UX1NNVFBfUE9SVD0ke1BFTlBPVF9TTVRQX1BPUlQ6LTEwMjV9JwogICAgICAtICdQRU5QT1RfU01UUF9VU0VSTkFNRT0ke1BFTlBPVF9TTVRQX1VTRVJOQU1FOi1wZW5wb3R9JwogICAgICAtICdQRU5QT1RfU01UUF9QQVNTV09SRD0ke1BFTlBPVF9TTVRQX1BBU1NXT1JEOi1wZW5wb3R9JwogICAgICAtICdQRU5QT1RfU01UUF9UTFM9JHtQRU5QT1RfU01UUF9UTFM6LWZhbHNlfScKICAgICAgLSAnUEVOUE9UX1NNVFBfU1NMPSR7UEVOUE9UX1NNVFBfU1NMOi1mYWxzZX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gbm9kZQogICAgICAgIC0gJy1lJwogICAgICAgIC0gInJlcXVpcmUoJ2h0dHAnKS5nZXQoe2hvc3Q6JzEyNy4wLjAuMScsIHBvcnQ6NjA2MCwgcGF0aDonL3JlYWR5eid9LCByZXMgPT4gcHJvY2Vzcy5leGl0KHJlcy5zdGF0dXNDb2RlPT09MjAwID8gMCA6IDEpKS5vbignZXJyb3InLCAoKSA9PiBwcm9jZXNzLmV4aXQoMSkpOyIKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAzMHMKICAgICAgcmV0cmllczogMTUKICBwZW5wb3QtZXhwb3J0ZXI6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9leHBvcnRlcjoyLjExLjEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUEVOUE9UX1BVQkxJQ19VUkk9JHtTRVJWSUNFX1VSTF9GUk9OVEVORF84MDgwfScKICAgICAgLSAnUEVOUE9UX1JFRElTX1VSST1yZWRpczovL3BlbnBvdC12YWxrZXkvMCcKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo2MDYxL3JlYWR5eicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIG1pbmlvOgogICAgaW1hZ2U6ICdnaGNyLmlvL2Nvb2xsYWJzaW8vbWluaW86UkVMRUFTRS4yMDI1LTEwLTE1VDE3LTI5LTU1WicKICAgIGNvbW1hbmQ6ICdzZXJ2ZXIgL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTUlOSU9fUk9PVF9VU0VSPSR7U0VSVklDRV9VU0VSX01JTklPfScKICAgICAgLSAnTUlOSU9fUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpsYXRlc3QnCiAgICBkZXBlbmRzX29uOgogICAgICBtaW5pbzoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgZW50cnlwb2ludDogInNoIC1jIFwiXG4gIG1jIGFsaWFzIHNldCBsb2NhbCBodHRwOi8vbWluaW86OTAwMCAke1NFUlZJQ0VfVVNFUl9NSU5JT30gJHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfSAmJlxuICBtYyBtYiAtcCBsb2NhbC9wZW5wb3QgfHwgdHJ1ZSAmJlxuICBtYyBhbm9ueW1vdXMgc2V0IHByaXZhdGUgbG9jYWwvcGVucG90XG5cIlxuIgogICAgcmVzdGFydDogJ25vJwogICAgZXhjbHVkZV9mcm9tX2hjOiB0cnVlCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE1JwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXBvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19JTklUREJfQVJHUz0tLWRhdGEtY2hlY2tzdW1zCiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1wZW5wb3R9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBlbnBvdC12YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OC4xJwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXZhbGtleS1kYXRhOi9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1ZBTEtFWV9FWFRSQV9GTEFHUz0tLW1heG1lbW9yeSAxMjhtYiAtLW1heG1lbW9yeS1wb2xpY3kgdm9sYXRpbGUtbGZ1JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd2YWxrZXktY2xpIHBpbmcgfCBncmVwIFBPTkcnCiAgICAgIGludGVydmFsOiAxcwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogM3MKICBtYWlscGl0OgogICAgaW1hZ2U6ICdheGxsZW50L21haWxwaXQ6djEuMjgnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9NQUlMUElUXzgwMjUKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvbWFpbHBpdAogICAgICAgIC0gcmVhZHl6CiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
-        "tags": [
-            "penpot",
-            "design",
-            "prototyping",
-            "figma",
-            "open",
-            "source"
-        ],
-        "category": "productivity",
-        "logo": "svgs/penpot.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-11-29T15:56:03+05:30",
-        "port": "8080"
-    },
     "penpot": {
         "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
         "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
@@ -4090,6 +4105,24 @@
         "logo": "svgs/penpot.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-11-29T17:45:19+05:30",
+        "port": "8080"
+    },
+    "penpot-with-s3": {
+        "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
+        "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
+        "compose": "c2VydmljZXM6CiAgZnJvbnRlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9mcm9udGVuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwZW5wb3QtYmFja2VuZDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtZXhwb3J0ZXI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0ZST05URU5EXzgwODAKICAgICAgLSAnUEVOUE9UX0ZMQUdTPSR7UEVOUE9UX0JBQ0tFTkRfRkxBR1M6LWVuYWJsZS1sb2dpbi13aXRoLXBhc3N3b3JkfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgwJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1CiAgcGVucG90LWJhY2tlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9iYWNrZW5kOjIuMTEuMScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIHBlbnBvdC12YWxrZXk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgbWluaW8taW5pdDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfY29tcGxldGVkX3N1Y2Nlc3NmdWxseQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BFTlBPVF9GTEFHUz0ke1BFTlBPVF9CQUNLRU5EX0ZMQUdTOi1lbmFibGUtbG9naW4td2l0aC1wYXNzd29yZH0nCiAgICAgIC0gUEVOUE9UX0hUVFBfU0VSVkVSX1BPUlQ9NjA2MAogICAgICAtICdQRU5QT1RfU0VDUkVUX0tFWT0ke1NFUlZJQ0VfUkVBTEJBU0U2NF82NF9QRU5QT1R9JwogICAgICAtICdQRU5QT1RfUFVCTElDX1VSST0ke1NFUlZJQ0VfVVJMX0ZST05URU5EXzgwODB9JwogICAgICAtICdQRU5QT1RfQkFDS0VORF9VUkk9aHR0cDovL3BlbnBvdC1iYWNrZW5kJwogICAgICAtICdQRU5QT1RfRVhQT1JURVJfVVJJPWh0dHA6Ly9wZW5wb3QtZXhwb3J0ZXInCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9VUkk9cG9zdGdyZXNxbDovL3Bvc3RncmVzLyR7UE9TVEdSRVNfREI6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgIC0gJ1BFTlBPVF9EQVRBQkFTRV9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQRU5QT1RfUkVESVNfVVJJPXJlZGlzOi8vcGVucG90LXZhbGtleS8wJwogICAgICAtICdQRU5QT1RfVEVMRU1FVFJZX0VOQUJMRUQ9JHtQRU5QT1RfVEVMRU1FVFJZX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX0JBQ0tFTkQ9czMKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX1JFR0lPTj11cy1lYXN0LTEKICAgICAgLSBQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX0JVQ0tFVD1wZW5wb3QKICAgICAgLSAnUEVOUE9UX09CSkVDVFNfU1RPUkFHRV9TM19FTkRQT0lOVD1odHRwOi8vbWluaW86OTAwMCcKICAgICAgLSAnQVdTX0FDQ0VTU19LRVlfSUQ9JHtTRVJWSUNFX1VTRVJfTUlOSU99JwogICAgICAtICdBV1NfU0VDUkVUX0FDQ0VTU19LRVk9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnUEVOUE9UX1NNVFBfREVGQVVMVF9GUk9NPSR7UEVOUE9UX1NNVFBfREVGQVVMVF9GUk9NOi1uby1yZXBseUBleGFtcGxlLmNvbX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX0RFRkFVTFRfUkVQTFlfVE89JHtQRU5QT1RfU01UUF9ERUZBVUxUX1JFUExZX1RPOi1uby1yZXBseUBleGFtcGxlLmNvbX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX0hPU1Q9JHtQRU5QT1RfU01UUF9IT1NUOi1tYWlscGl0fScKICAgICAgLSAnUEVOUE9UX1NNVFBfUE9SVD0ke1BFTlBPVF9TTVRQX1BPUlQ6LTEwMjV9JwogICAgICAtICdQRU5QT1RfU01UUF9VU0VSTkFNRT0ke1BFTlBPVF9TTVRQX1VTRVJOQU1FOi1wZW5wb3R9JwogICAgICAtICdQRU5QT1RfU01UUF9QQVNTV09SRD0ke1BFTlBPVF9TTVRQX1BBU1NXT1JEOi1wZW5wb3R9JwogICAgICAtICdQRU5QT1RfU01UUF9UTFM9JHtQRU5QT1RfU01UUF9UTFM6LWZhbHNlfScKICAgICAgLSAnUEVOUE9UX1NNVFBfU1NMPSR7UEVOUE9UX1NNVFBfU1NMOi1mYWxzZX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gbm9kZQogICAgICAgIC0gJy1lJwogICAgICAgIC0gInJlcXVpcmUoJ2h0dHAnKS5nZXQoe2hvc3Q6JzEyNy4wLjAuMScsIHBvcnQ6NjA2MCwgcGF0aDonL3JlYWR5eid9LCByZXMgPT4gcHJvY2Vzcy5leGl0KHJlcy5zdGF0dXNDb2RlPT09MjAwID8gMCA6IDEpKS5vbignZXJyb3InLCAoKSA9PiBwcm9jZXNzLmV4aXQoMSkpOyIKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAzMHMKICAgICAgcmV0cmllczogMTUKICBwZW5wb3QtZXhwb3J0ZXI6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9leHBvcnRlcjoyLjExLjEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUEVOUE9UX1BVQkxJQ19VUkk9JHtTRVJWSUNFX1VSTF9GUk9OVEVORF84MDgwfScKICAgICAgLSAnUEVOUE9UX1JFRElTX1VSST1yZWRpczovL3BlbnBvdC12YWxrZXkvMCcKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo2MDYxL3JlYWR5eicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIG1pbmlvOgogICAgaW1hZ2U6ICdnaGNyLmlvL2Nvb2xsYWJzaW8vbWluaW86UkVMRUFTRS4yMDI1LTEwLTE1VDE3LTI5LTU1WicKICAgIGNvbW1hbmQ6ICdzZXJ2ZXIgL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTUlOSU9fUk9PVF9VU0VSPSR7U0VSVklDRV9VU0VSX01JTklPfScKICAgICAgLSAnTUlOSU9fUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpsYXRlc3QnCiAgICBkZXBlbmRzX29uOgogICAgICBtaW5pbzoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgZW50cnlwb2ludDogInNoIC1jIFwiXG4gIG1jIGFsaWFzIHNldCBsb2NhbCBodHRwOi8vbWluaW86OTAwMCAke1NFUlZJQ0VfVVNFUl9NSU5JT30gJHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfSAmJlxuICBtYyBtYiAtcCBsb2NhbC9wZW5wb3QgfHwgdHJ1ZSAmJlxuICBtYyBhbm9ueW1vdXMgc2V0IHByaXZhdGUgbG9jYWwvcGVucG90XG5cIlxuIgogICAgcmVzdGFydDogJ25vJwogICAgZXhjbHVkZV9mcm9tX2hjOiB0cnVlCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE1JwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXBvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19JTklUREJfQVJHUz0tLWRhdGEtY2hlY2tzdW1zCiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1wZW5wb3R9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBlbnBvdC12YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OC4xJwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXZhbGtleS1kYXRhOi9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1ZBTEtFWV9FWFRSQV9GTEFHUz0tLW1heG1lbW9yeSAxMjhtYiAtLW1heG1lbW9yeS1wb2xpY3kgdm9sYXRpbGUtbGZ1JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd2YWxrZXktY2xpIHBpbmcgfCBncmVwIFBPTkcnCiAgICAgIGludGVydmFsOiAxcwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogM3MKICBtYWlscGl0OgogICAgaW1hZ2U6ICdheGxsZW50L21haWxwaXQ6djEuMjgnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9NQUlMUElUXzgwMjUKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvbWFpbHBpdAogICAgICAgIC0gcmVhZHl6CiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "penpot",
+            "design",
+            "prototyping",
+            "figma",
+            "open",
+            "source"
+        ],
+        "category": "productivity",
+        "logo": "svgs/penpot.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-11-29T15:56:03+05:30",
         "port": "8080"
     },
     "pgadmin": {
@@ -4205,6 +4238,26 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "3000"
     },
+    "pocket-id": {
+        "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
+        "slogan": "A simple and secure OIDC provider with passkey authentication",
+        "compose": "c2VydmljZXM6CiAgcG9ja2V0LWlkOgogICAgaW1hZ2U6ICdnaGNyLmlvL3BvY2tldC1pZC9wb2NrZXQtaWQ6djEuMTMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9QT0NLRVRJRF8xNDExCiAgICAgIC0gJ0FQUF9VUkw9JHtTRVJWSUNFX1VSTF9QT0NLRVRJRH0nCiAgICAgIC0gJ1RSVVNUX1BST1hZPSR7VFJVU1RfUFJPWFk6LXRydWV9JwogICAgICAtICdNQVhNSU5EX0xJQ0VOU0VfS0VZPSR7TUFYTUlORF9MSUNFTlNFX0tFWX0nCiAgICAgIC0gJ1NNVFBfSE9TVD0ke1NNVFBfSE9TVH0nCiAgICAgIC0gJ1NNVFBfUE9SVD0ke1NNVFBfUE9SVDotNTg3fScKICAgICAgLSAnU01UUF9GUk9NPSR7U01UUF9GUk9NfScKICAgICAgLSAnU01UUF9VU0VSPSR7U01UUF9VU0VSfScKICAgICAgLSAnU01UUF9QQVNTV09SRD0ke1NNVFBfUEFTU1dPUkR9JwogICAgICAtICdTTVRQX1RMUz0ke1NNVFBfVExTOi1zdGFydHRsc30nCiAgICAgIC0gJ1NNVFBfU0tJUF9DRVJUX1ZFUklGWT0ke1NNVFBfU0tJUF9DRVJUX1ZFUklGWTotZmFsc2V9JwogICAgICAtICdFTUFJTF9MT0dJTl9OT1RJRklDQVRJT05fRU5BQkxFRD0ke0VNQUlMX0xPR0lOX05PVElGSUNBVElPTl9FTkFCTEVEOi1mYWxzZX0nCiAgICAgIC0gJ0VNQUlMX09ORV9USU1FX0FDQ0VTU19BU19BRE1JTl9FTkFCTEVEPSR7RU1BSUxfT05FX1RJTUVfQUNDRVNTX0FTX0FETUlOX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSAnRU1BSUxfQVBJX0tFWV9FWFBJUkFUSU9OX0VOQUJMRUQ9JHtFTUFJTF9BUElfS0VZX0VYUElSQVRJT05fRU5BQkxFRDotZmFsc2V9JwogICAgICAtICdQVUlEPSR7UFVJRDotMTAwMH0nCiAgICAgIC0gJ1BHSUQ9JHtQR0lEOi0xMDAwfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3BvY2tldC1pZC1kYXRhOi9hcHAvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvYXBwL3BvY2tldC1pZAogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDMwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
+        "tags": [
+            "identity",
+            "oidc",
+            "oauth",
+            "passkey",
+            "webauthn",
+            "authentication",
+            "sso",
+            "openid"
+        ],
+        "category": "auth",
+        "logo": "svgs/pocketid-logo.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-10-19T21:35:49+02:00",
+        "port": "1411"
+    },
     "pocket-id-with-postgresql": {
         "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
         "slogan": "A simple and secure OIDC provider with passkey authentication",
@@ -4224,26 +4277,6 @@
         "logo": "svgs/pocketid-logo.png",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-10-19T21:35:18+02:00",
-        "port": "1411"
-    },
-    "pocket-id": {
-        "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
-        "slogan": "A simple and secure OIDC provider with passkey authentication",
-        "compose": "c2VydmljZXM6CiAgcG9ja2V0LWlkOgogICAgaW1hZ2U6ICdnaGNyLmlvL3BvY2tldC1pZC9wb2NrZXQtaWQ6djEuMTMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9QT0NLRVRJRF8xNDExCiAgICAgIC0gJ0FQUF9VUkw9JHtTRVJWSUNFX1VSTF9QT0NLRVRJRH0nCiAgICAgIC0gJ1RSVVNUX1BST1hZPSR7VFJVU1RfUFJPWFk6LXRydWV9JwogICAgICAtICdNQVhNSU5EX0xJQ0VOU0VfS0VZPSR7TUFYTUlORF9MSUNFTlNFX0tFWX0nCiAgICAgIC0gJ1NNVFBfSE9TVD0ke1NNVFBfSE9TVH0nCiAgICAgIC0gJ1NNVFBfUE9SVD0ke1NNVFBfUE9SVDotNTg3fScKICAgICAgLSAnU01UUF9GUk9NPSR7U01UUF9GUk9NfScKICAgICAgLSAnU01UUF9VU0VSPSR7U01UUF9VU0VSfScKICAgICAgLSAnU01UUF9QQVNTV09SRD0ke1NNVFBfUEFTU1dPUkR9JwogICAgICAtICdTTVRQX1RMUz0ke1NNVFBfVExTOi1zdGFydHRsc30nCiAgICAgIC0gJ1NNVFBfU0tJUF9DRVJUX1ZFUklGWT0ke1NNVFBfU0tJUF9DRVJUX1ZFUklGWTotZmFsc2V9JwogICAgICAtICdFTUFJTF9MT0dJTl9OT1RJRklDQVRJT05fRU5BQkxFRD0ke0VNQUlMX0xPR0lOX05PVElGSUNBVElPTl9FTkFCTEVEOi1mYWxzZX0nCiAgICAgIC0gJ0VNQUlMX09ORV9USU1FX0FDQ0VTU19BU19BRE1JTl9FTkFCTEVEPSR7RU1BSUxfT05FX1RJTUVfQUNDRVNTX0FTX0FETUlOX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSAnRU1BSUxfQVBJX0tFWV9FWFBJUkFUSU9OX0VOQUJMRUQ9JHtFTUFJTF9BUElfS0VZX0VYUElSQVRJT05fRU5BQkxFRDotZmFsc2V9JwogICAgICAtICdQVUlEPSR7UFVJRDotMTAwMH0nCiAgICAgIC0gJ1BHSUQ9JHtQR0lEOi0xMDAwfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3BvY2tldC1pZC1kYXRhOi9hcHAvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSAvYXBwL3BvY2tldC1pZAogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDMwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
-        "tags": [
-            "identity",
-            "oidc",
-            "oauth",
-            "passkey",
-            "webauthn",
-            "authentication",
-            "sso",
-            "openid"
-        ],
-        "category": "auth",
-        "logo": "svgs/pocketid-logo.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-10-19T21:35:49+02:00",
         "port": "1411"
     },
     "pocketbase": {
@@ -4329,7 +4362,7 @@
     },
     "prowlarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/prowlarr?utm_source=coolify.io",
-        "slogan": "Prowlarr\u2060 is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps.",
+        "slogan": "Prowlarr⁠ is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps.",
         "compose": "c2VydmljZXM6CiAgcHJvd2xhcnI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvcHJvd2xhcnI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfUFJPV0xBUlJfOTY5NgogICAgICAtIF9BUFBfVVJMPSRTRVJWSUNFX1VSTF9QUk9XTEFSUgogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgICAtICdUWj0ke1RaOi1BbWVyaWNhL1Rvcm9udG99JwogICAgdm9sdW1lczoKICAgICAgLSAncHJvd2xhcnItY29uZmlnOi9jb25maWcnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6OTY5Ni9waW5nJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
         "tags": [
             "media",
@@ -4362,9 +4395,22 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "9159"
     },
+    "pydio-cells": {
+        "documentation": "https://docs.pydio.com/?utm_source=coolify.io",
+        "slogan": "High-performance large file sharing, native no-code automation, and a collaboration-centric architecture that simplifies access control without compromising security or compliance.",
+        "compose": "c2VydmljZXM6CiAgY2VsbHM6CiAgICBpbWFnZTogJ3B5ZGlvL2NlbGxzOjQuNCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0NFTExTXzgwODAKICAgICAgLSAnQ0VMTFNfU0lURV9FWFRFUk5BTD0ke1NFUlZJQ0VfVVJMX0NFTExTfScKICAgICAgLSBDRUxMU19TSVRFX05PX1RMUz0xCiAgICB2b2x1bWVzOgogICAgICAtICdjZWxsc19kYXRhOi92YXIvY2VsbHMnCiAgbWFyaWFkYjoKICAgIGltYWdlOiAnbWFyaWFkYjoxMScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ215c3FsX2RhdGE6L3Zhci9saWIvbXlzcWwnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTVlTUUxfUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTVlTUUxST09UfScKICAgICAgLSAnTVlTUUxfREFUQUJBU0U9JHtNWVNRTF9EQVRBQkFTRTotY2VsbHN9JwogICAgICAtICdNWVNRTF9VU0VSPSR7U0VSVklDRV9VU0VSX01ZU1FMfScKICAgICAgLSAnTVlTUUxfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01ZU1FMfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAgIC0gJy0tY29ubmVjdCcKICAgICAgICAtICctLWlubm9kYl9pbml0aWFsaXplZCcKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogNQo=",
+        "tags": [
+            "storage"
+        ],
+        "category": "storage",
+        "logo": "svgs/cells.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "8080"
+    },
     "qbittorrent": {
         "documentation": "https://docs.linuxserver.io/images/docker-qbittorrent/?utm_source=coolify.io",
-        "slogan": "The qBittorrent project aims to provide an open-source software alternative to \u03bcTorrent.",
+        "slogan": "The qBittorrent project aims to provide an open-source software alternative to μTorrent.",
         "compose": "c2VydmljZXM6CiAgcWJpdDoKICAgIGltYWdlOiAnbHNjci5pby9saW51eHNlcnZlci9xYml0dG9ycmVudDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnV0VCVUlfUE9SVD0ke1dFQlVJX1BPUlQ6LTgwODB9JwogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgdm9sdW1lczoKICAgICAgLSAncWJpdHRvcnJlbnQtY29uZmlnOi9jb25maWcnCiAgICAgIC0gJ3FiaXR0b3JyZW50LWRvd25sb2FkczovZG93bmxvYWRzJwogICAgICAtICdxYml0dG9ycmVudC10b3JyZW50czovdG9ycmVudHMnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MC8nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICB2dWV0b3JyZW50LWJhY2tlbmQ6CiAgICBpbWFnZTogJ2doY3IuaW8vdnVldG9ycmVudC92dWV0b3JyZW50LWJhY2tlbmQ6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfUUJJVE9SUkVOVF84MDgwCiAgICAgIC0gJ1BPUlQ9JHtXRUJVSV9QT1JUOi04MDgwfScKICAgICAgLSAnUUJJVF9CQVNFPSR7U0VSVklDRV9VUkxfUUJJVE9SUkVOVH0nCiAgICAgIC0gJ1JFTEVBU0VfVFlQRT0ke1JFTEVBU0VfVFlQRTotc3RhYmxlfScKICAgICAgLSAnVVBEQVRFX1ZUX0NST049JHtVUERBVEVfVlRfQ1JPTjotIjAgKiAqICogKiJ9JwogICAgdm9sdW1lczoKICAgICAgLSAndnVldG9ycmVudC1jb25maWc6L2NvbmZpZycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLXEnCiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MDgwLycKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "torrent",
@@ -4418,7 +4464,7 @@
     },
     "radarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/radarr?utm_source=coolify.io",
-        "slogan": "Radarr\u2060 - A fork of Sonarr to work with movies \u00e0 la Couchpotato.",
+        "slogan": "Radarr⁠ - A fork of Sonarr to work with movies à la Couchpotato.",
         "compose": "c2VydmljZXM6CiAgcmFkYXJyOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL3JhZGFycjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9SQURBUlJfNzg3OAogICAgICAtIF9BUFBfVVJMPSRTRVJWSUNFX1VSTF9SQURBUlIKICAgICAgLSBQVUlEPTEwMDAKICAgICAgLSBQR0lEPTEwMDAKICAgICAgLSAnVFo9JHtUWjotQW1lcmljYS9Ub3JvbnRvfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3JhZGFyci1jb25maWc6L2NvbmZpZycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo3ODc4L3BpbmcnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
         "tags": [
             "media",
@@ -4840,22 +4886,6 @@
         "template_last_updated_at": "2025-12-09T00:35:53+03:00",
         "port": "80"
     },
-    "soketi-app-manager": {
-        "documentation": "https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io",
-        "slogan": "Manage soketi websocket server and apps with ease.",
-        "compose": "c2VydmljZXM6CiAgc29rZXRpLWFwcC1tYW5hZ2VyOgogICAgaW1hZ2U6ICdnaGNyLmlvL3JhaHVsaGFxdWUvc29rZXRpLWFwcC1tYW5hZ2VyLWZpbGFtZW50LWFscGluZTpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUl84MDgwCiAgICAgIC0gQVVUT1JVTl9FTkFCTEVEPXRydWUKICAgICAgLSAnQVVUT1JVTl9MQVJBVkVMX01JR1JBVElPTj0ke0FVVE9SVU5fTEFSQVZFTF9NSUdSQVRJT046LXRydWV9JwogICAgICAtICdBUFBfREVCVUc9JHtBUFBfREVCVUc6LWZhbHNlfScKICAgICAgLSBBUFBfVVJMPSRTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUgogICAgICAtIEFQUF9LRVk9JEFQUF9LRVkKICAgICAgLSBEQl9DT05ORUNUSU9OPSREQl9DT05ORUNUSU9OCiAgICAgIC0gREJfSE9TVD0kREJfSE9TVAogICAgICAtIERCX1BPUlQ9JERCX1BPUlQKICAgICAgLSBEQl9EQVRBQkFTRT0kREJfREFUQUJBU0UKICAgICAgLSBEQl9VU0VSTkFNRT0kREJfVVNFUk5BTUUKICAgICAgLSBEQl9QQVNTV09SRD0kREJfUEFTU1dPUkQKICAgICAgLSBQVVNIRVJfSE9TVD0kUFVTSEVSX0hPU1QKICAgICAgLSBQVVNIRVJfUE9SVD0kUFVTSEVSX1BPUlQKICAgICAgLSBQVVNIRVJfU0NIRU1FPSRQVVNIRVJfU0NIRU1FCiAgICAgIC0gUFVTSEVSX0FQUF9DTFVTVEVSPSRQVVNIRVJfQVBQX0NMVVNURVIKICAgICAgLSBTT0tFVElfREJfUkVESVNfVVNFUk5BTUU9JFNPS0VUSV9EQl9SRURJU19VU0VSTkFNRQogICAgICAtIFNPS0VUSV9EQl9SRURJU19QQVNTV09SRD0kU09LRVRJX0RCX1JFRElTX1BBU1NXT1JECiAgICAgIC0gTUVUUklDU19IT1NUPSRNRVRSSUNTX0hPU1QKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBwaHAtZnBtLWhlYWx0aGNoZWNrCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
-        "tags": [
-            "soketi",
-            "websockets",
-            "app-manager",
-            "dashboard"
-        ],
-        "category": "devtools",
-        "logo": "svgs/soketi-app-manager.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "8080"
-    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",
@@ -4872,9 +4902,25 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "6001"
     },
+    "soketi-app-manager": {
+        "documentation": "https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io",
+        "slogan": "Manage soketi websocket server and apps with ease.",
+        "compose": "c2VydmljZXM6CiAgc29rZXRpLWFwcC1tYW5hZ2VyOgogICAgaW1hZ2U6ICdnaGNyLmlvL3JhaHVsaGFxdWUvc29rZXRpLWFwcC1tYW5hZ2VyLWZpbGFtZW50LWFscGluZTpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUl84MDgwCiAgICAgIC0gQVVUT1JVTl9FTkFCTEVEPXRydWUKICAgICAgLSAnQVVUT1JVTl9MQVJBVkVMX01JR1JBVElPTj0ke0FVVE9SVU5fTEFSQVZFTF9NSUdSQVRJT046LXRydWV9JwogICAgICAtICdBUFBfREVCVUc9JHtBUFBfREVCVUc6LWZhbHNlfScKICAgICAgLSBBUFBfVVJMPSRTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUgogICAgICAtIEFQUF9LRVk9JEFQUF9LRVkKICAgICAgLSBEQl9DT05ORUNUSU9OPSREQl9DT05ORUNUSU9OCiAgICAgIC0gREJfSE9TVD0kREJfSE9TVAogICAgICAtIERCX1BPUlQ9JERCX1BPUlQKICAgICAgLSBEQl9EQVRBQkFTRT0kREJfREFUQUJBU0UKICAgICAgLSBEQl9VU0VSTkFNRT0kREJfVVNFUk5BTUUKICAgICAgLSBEQl9QQVNTV09SRD0kREJfUEFTU1dPUkQKICAgICAgLSBQVVNIRVJfSE9TVD0kUFVTSEVSX0hPU1QKICAgICAgLSBQVVNIRVJfUE9SVD0kUFVTSEVSX1BPUlQKICAgICAgLSBQVVNIRVJfU0NIRU1FPSRQVVNIRVJfU0NIRU1FCiAgICAgIC0gUFVTSEVSX0FQUF9DTFVTVEVSPSRQVVNIRVJfQVBQX0NMVVNURVIKICAgICAgLSBTT0tFVElfREJfUkVESVNfVVNFUk5BTUU9JFNPS0VUSV9EQl9SRURJU19VU0VSTkFNRQogICAgICAtIFNPS0VUSV9EQl9SRURJU19QQVNTV09SRD0kU09LRVRJX0RCX1JFRElTX1BBU1NXT1JECiAgICAgIC0gTUVUUklDU19IT1NUPSRNRVRSSUNTX0hPU1QKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBwaHAtZnBtLWhlYWx0aGNoZWNrCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
+        "tags": [
+            "soketi",
+            "websockets",
+            "app-manager",
+            "dashboard"
+        ],
+        "category": "devtools",
+        "logo": "svgs/soketi-app-manager.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "8080"
+    },
     "sonarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/sonarr?utm_source=coolify.io",
-        "slogan": "Sonarr\u2060 (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
+        "slogan": "Sonarr⁠ (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
         "compose": "c2VydmljZXM6CiAgc29uYXJyOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL3NvbmFycjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9TT05BUlJfODk4OQogICAgICAtIF9BUFBfVVJMPSRTRVJWSUNFX1VSTF9TT05BUlIKICAgICAgLSBQVUlEPTEwMDAKICAgICAgLSBQR0lEPTEwMDAKICAgICAgLSAnVFo9JHtUWjotQW1lcmljYS9Ub3JvbnRvfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3NvbmFyci1jb25maWc6L2NvbmZpZycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4OTg5L3BpbmcnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
         "tags": [
             "media",
@@ -5400,6 +5446,25 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8000"
     },
+    "uptime-kuma": {
+        "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
+        "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
+        "compose": "c2VydmljZXM6CiAgdXB0aW1lLWt1bWE6CiAgICBpbWFnZTogJ2xvdWlzbGFtL3VwdGltZS1rdW1hOjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9VUFRJTUVLVU1BXzMwMDEKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3VwdGltZS1rdW1hLWRhdGE6L2FwcC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtIGV4dHJhL2hlYWx0aGNoZWNrCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "monitoring",
+            "status",
+            "performance",
+            "web",
+            "services",
+            "applications",
+            "real-time"
+        ],
+        "category": "monitoring",
+        "logo": "svgs/uptime-kuma.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-01-08T21:10:17+01:00",
+        "port": "3001"
+    },
     "uptime-kuma-with-mariadb": {
         "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
         "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
@@ -5436,25 +5501,6 @@
         "logo": "svgs/uptime-kuma.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-01-08T21:10:43+01:00",
-        "port": "3001"
-    },
-    "uptime-kuma": {
-        "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
-        "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
-        "compose": "c2VydmljZXM6CiAgdXB0aW1lLWt1bWE6CiAgICBpbWFnZTogJ2xvdWlzbGFtL3VwdGltZS1rdW1hOjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9VUFRJTUVLVU1BXzMwMDEKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3VwdGltZS1rdW1hLWRhdGE6L2FwcC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtIGV4dHJhL2hlYWx0aGNoZWNrCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAo=",
-        "tags": [
-            "monitoring",
-            "status",
-            "performance",
-            "web",
-            "services",
-            "applications",
-            "real-time"
-        ],
-        "category": "monitoring",
-        "logo": "svgs/uptime-kuma.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-01-08T21:10:17+01:00",
         "port": "3001"
     },
     "usesend": {
@@ -5524,6 +5570,20 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
+    "vikunja": {
+        "documentation": "https://vikunja.io?utm_source=coolify.io",
+        "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
+        "compose": "c2VydmljZXM6CiAgdmlrdW5qYToKICAgIGltYWdlOiB2aWt1bmphL3Zpa3VuamEKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1ZJS1VOSkEKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfUFVCTElDVVJMPSRTRVJWSUNFX1VSTF9WSUtVTkpBCiAgICAgIC0gVklLVU5KQV9TRVJWSUNFX0pXVFNFQ1JFVD0kU0VSVklDRV9QQVNTV09SRF9KV1RTRUNSRVQKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfRU5BQkxFUkVHSVNUUkFUSU9OPXRydWUKICAgICAgLSBWSUtVTkpBX0RBVEFCQVNFX1BBVEg9L2RiL3Zpa3VuamEuZGIKICAgICAgLSBWSUtVTkpBX0RBVEFCQVNFX1RZUEU9c3FsaXRlCiAgICB2b2x1bWVzOgogICAgICAtICd2aWt1bmphLWRhdGE6L2FwcC92aWt1bmphLycKICAgICAgLSAndmlrdW5qYS1zcWxpdGUtZGF0YTovZGInCiAgICBkZXBlbmRzX29uOgogICAgICAtIGluaXQKICBpbml0OgogICAgaW1hZ2U6IGJ1c3lib3gKICAgIHJlc3RhcnQ6ICdubycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Zpa3VuamEtc3FsaXRlLWRhdGE6L2RiJwogICAgY29tbWFuZDoKICAgICAgLSBzaAogICAgICAtICctYycKICAgICAgLSAndG91Y2ggL2RiL3Zpa3VuamEuZGIgJiYgY2hvd24gLVIgMTAwMCAvZGInCg==",
+        "tags": [
+            "productivity",
+            "todo"
+        ],
+        "category": "productivity",
+        "logo": "svgs/vikunja.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3456"
+    },
     "vikunja-with-postgresql": {
         "documentation": "https://vikunja.io?utm_source=coolify.io",
         "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
@@ -5538,19 +5598,27 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3456"
     },
-    "vikunja": {
-        "documentation": "https://vikunja.io?utm_source=coolify.io",
-        "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
-        "compose": "c2VydmljZXM6CiAgdmlrdW5qYToKICAgIGltYWdlOiB2aWt1bmphL3Zpa3VuamEKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1ZJS1VOSkEKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfUFVCTElDVVJMPSRTRVJWSUNFX1VSTF9WSUtVTkpBCiAgICAgIC0gVklLVU5KQV9TRVJWSUNFX0pXVFNFQ1JFVD0kU0VSVklDRV9QQVNTV09SRF9KV1RTRUNSRVQKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfRU5BQkxFUkVHSVNUUkFUSU9OPXRydWUKICAgICAgLSBWSUtVTkpBX0RBVEFCQVNFX1BBVEg9L2RiL3Zpa3VuamEuZGIKICAgICAgLSBWSUtVTkpBX0RBVEFCQVNFX1RZUEU9c3FsaXRlCiAgICB2b2x1bWVzOgogICAgICAtICd2aWt1bmphLWRhdGE6L2FwcC92aWt1bmphLycKICAgICAgLSAndmlrdW5qYS1zcWxpdGUtZGF0YTovZGInCiAgICBkZXBlbmRzX29uOgogICAgICAtIGluaXQKICBpbml0OgogICAgaW1hZ2U6IGJ1c3lib3gKICAgIHJlc3RhcnQ6ICdubycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Zpa3VuamEtc3FsaXRlLWRhdGE6L2RiJwogICAgY29tbWFuZDoKICAgICAgLSBzaAogICAgICAtICctYycKICAgICAgLSAndG91Y2ggL2RiL3Zpa3VuamEuZGIgJiYgY2hvd24gLVIgMTAwMCAvZGInCg==",
+    "vvveb": {
+        "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
+        "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
+        "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1ZWVkVCXzgwCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjEnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
-            "productivity",
-            "todo"
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "ecommerce",
+            "page-builder",
+            "nocode",
+            "mysql",
+            "sqlite",
+            "pgsql"
         ],
-        "category": "productivity",
-        "logo": "svgs/vikunja.svg",
+        "category": "cms",
+        "logo": "svgs/vvveb.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3456"
+        "port": "80"
     },
     "vvveb-with-mariadb": {
         "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
@@ -5578,28 +5646,6 @@
         "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
         "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
         "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1ZWVkVCXzgwCiAgICAgIC0gREJfRU5HSU5FPW15c3FsaQogICAgICAtIERCX0hPU1Q9bXlzcWwKICAgICAgLSAnREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9WVlZFQn0nCiAgICAgIC0gJ0RCX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9WVlZFQn0nCiAgICAgIC0gJ0RCX05BTUU9JHtNWVNRTF9EQVRBQkFTRTotdnZ2ZWJ9JwogICAgZGVwZW5kc19vbjoKICAgICAgbXlzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMScKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxMAogIG15c3FsOgogICAgaW1hZ2U6ICdteXNxbDo4LjQuMicKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLW15c3FsLWRhdGE6L3Zhci9saWIvbXlzcWwnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTVlTUUxfUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUk9PVH0nCiAgICAgIC0gJ01ZU1FMX0RBVEFCQVNFPSR7TVlTUUxfREFUQUJBU0U6LXZ2dmVifScKICAgICAgLSAnTVlTUUxfVVNFUj0ke1NFUlZJQ0VfVVNFUl9WVlZFQn0nCiAgICAgIC0gJ01ZU1FMX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9WVlZFQn0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gbXlzcWxhZG1pbgogICAgICAgIC0gcGluZwogICAgICAgIC0gJy1oJwogICAgICAgIC0gMTI3LjAuMC4xCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
-        "tags": [
-            "cms",
-            "blog",
-            "content",
-            "management",
-            "ecommerce",
-            "page-builder",
-            "nocode",
-            "mysql",
-            "sqlite",
-            "pgsql"
-        ],
-        "category": "cms",
-        "logo": "svgs/vvveb.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "80"
-    },
-    "vvveb": {
-        "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
-        "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
-        "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1ZWVkVCXzgwCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjEnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "cms",
             "blog",
@@ -5804,6 +5850,26 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "WordPress running behind OpenLiteSpeed with persistent MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1dPUkRQUkVTU184MAogICAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGIKICAgICAgLSBXT1JEUFJFU1NfREJfTkFNRT0ke1dPUkRQUkVTU19EQl9OQU1FOi13b3JkcHJlc3N9CiAgICAgIC0gV09SRFBSRVNTX0RCX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgICAgLSBXT1JEUFJFU1NfREJfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICAgIC0gV09SRFBSRVNTX1RBQkxFX1BSRUZJWD0ke1dPUkRQUkVTU19UQUJMRV9QUkVGSVg6LXdwX30KICAgICAgLSBUWj0ke1RaOi1VVEN9CiAgICBjb21tYW5kOgogICAgICAtIGJhc2gKICAgICAgLSAvdXNyL2xvY2FsL2Jpbi9jb29saWZ5LXdvcmRwcmVzcy1pbml0LnNoCiAgICB2b2x1bWVzOgogICAgICAtIHdvcmRwcmVzcy1maWxlczovdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgICAgLSBvcGVubGl0ZXNwZWVkLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWFkbWluLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2FkbWluL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgICAgLSB0eXBlOiBiaW5kCiAgICAgICAgc291cmNlOiAuL2Nvb2xpZnktd29yZHByZXNzLWluaXQuc2gKICAgICAgICB0YXJnZXQ6IC91c3IvbG9jYWwvYmluL2Nvb2xpZnktd29yZHByZXNzLWluaXQuc2gKICAgICAgICBjb250ZW50OiB8CiAgICAgICAgICAjIS91c3IvYmluL2VudiBiYXNoCiAgICAgICAgICBzZXQgLWV1byBwaXBlZmFpbAoKICAgICAgICAgIGNkIC92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAoKICAgICAgICAgIHVudGlsIG15c3FsYWRtaW4gcGluZyAtaCIke1dPUkRQUkVTU19EQl9IT1NUfSIgLXUiJHtXT1JEUFJFU1NfREJfVVNFUn0iIC1wIiR7V09SRFBSRVNTX0RCX1BBU1NXT1JEfSIgLS1zaWxlbnQ7IGRvCiAgICAgICAgICAgIGVjaG8gIldhaXRpbmcgZm9yIE1hcmlhREIuLi4iCiAgICAgICAgICAgIHNsZWVwIDIKICAgICAgICAgIGRvbmUKCiAgICAgICAgICBpZiBbICEgLWYgaW5kZXgucGhwIF07IHRoZW4KICAgICAgICAgICAgd3AgY29yZSBkb3dubG9hZCAtLWFsbG93LXJvb3QKICAgICAgICAgIGZpCgogICAgICAgICAgaWYgWyAhIC1mIHdwLWNvbmZpZy5waHAgXTsgdGhlbgogICAgICAgICAgICB3cCBjb25maWcgY3JlYXRlIFwKICAgICAgICAgICAgICAtLWFsbG93LXJvb3QgXAogICAgICAgICAgICAgIC0tZGJuYW1lPSIke1dPUkRQUkVTU19EQl9OQU1FfSIgXAogICAgICAgICAgICAgIC0tZGJ1c2VyPSIke1dPUkRQUkVTU19EQl9VU0VSfSIgXAogICAgICAgICAgICAgIC0tZGJwYXNzPSIke1dPUkRQUkVTU19EQl9QQVNTV09SRH0iIFwKICAgICAgICAgICAgICAtLWRiaG9zdD0iJHtXT1JEUFJFU1NfREJfSE9TVH0iIFwKICAgICAgICAgICAgICAtLWRicHJlZml4PSIke1dPUkRQUkVTU19UQUJMRV9QUkVGSVh9IgogICAgICAgICAgZmkKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAtZgogICAgICAgIC0gaHR0cDovLzEyNy4wLjAuMQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgbWFyaWFkYjoKICAgIGltYWdlOiBtYXJpYWRiOjExCiAgICB2b2x1bWVzOgogICAgICAtIG1hcmlhZGItZGF0YTovdmFyL2xpYi9teXNxbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9ST09UCiAgICAgIC0gTVlTUUxfREFUQUJBU0U9JHtXT1JEUFJFU1NfREJfTkFNRTotd29yZHByZXNzfQogICAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgICAgLSBNWVNRTF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1MKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAgIC0gLS1jb25uZWN0CiAgICAgICAgLSAtLWlubm9kYl9pbml0aWFsaXplZAogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": null,
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
@@ -5819,10 +5885,10 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
-    "yamtrack-with-postgresql": {
+    "yamtrack": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",
-        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1lBTVRSQUNLXzgwMDAKICAgICAgLSAnVVJMUz0ke1NFUlZJQ0VfVVJMX1lBTVRSQUNLfScKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL0Jlcmxpbn0nCiAgICAgIC0gJ1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfU0VDUkVUfScKICAgICAgLSAnUkVHSVNUUkFUSU9OPSR7UkVHSVNUUkFUSU9OX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdSRURJU19VUkw9cmVkaXM6Ly9yZWRpczo2Mzc5JwogICAgICAtIERCX0hPU1Q9cG9zdGdyZXMKICAgICAgLSAnREJfTkFNRT0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LXlhbXRyYWNrLWRifScKICAgICAgLSAnREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfScKICAgICAgLSAnREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9JwogICAgICAtIERCX1BPUlQ9NTQzMgogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgcmVkaXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLS1uby12ZXJib3NlJwogICAgICAgIC0gJy0tdHJpZXM9MScKICAgICAgICAtICctLXNwaWRlcicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwMDAvaGVhbHRoLycKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUE9TVEdSRVNfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LXlhbXRyYWNrLWRifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3Bvc3RncmVzX2RhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3JlZGlzX2RhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1lBTVRSQUNLXzgwMDAKICAgICAgLSAnVVJMUz0ke1NFUlZJQ0VfVVJMX1lBTVRSQUNLfScKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL0Jlcmxpbn0nCiAgICAgIC0gJ1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfU0VDUkVUfScKICAgICAgLSAnUkVHSVNUUkFUSU9OPSR7UkVHSVNUUkFUSU9OX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdSRURJU19VUkw9cmVkaXM6Ly9yZWRpczo2Mzc5JwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfZGF0YToveWFtdHJhY2svZGInCiAgICBkZXBlbmRzX29uOgogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd3Z2V0IC0tcXVpZXQgLS10cmllcz0xIC0tc3BpZGVyIGh0dHA6Ly8xMjcuMC4wLjE6ODAwMC9oZWFsdGgvIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3JlZGlzX2RhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "self-hosted",
             "automation",
@@ -5842,10 +5908,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8000"
     },
-    "yamtrack": {
+    "yamtrack-with-postgresql": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",
-        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1lBTVRSQUNLXzgwMDAKICAgICAgLSAnVVJMUz0ke1NFUlZJQ0VfVVJMX1lBTVRSQUNLfScKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL0Jlcmxpbn0nCiAgICAgIC0gJ1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfU0VDUkVUfScKICAgICAgLSAnUkVHSVNUUkFUSU9OPSR7UkVHSVNUUkFUSU9OX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdSRURJU19VUkw9cmVkaXM6Ly9yZWRpczo2Mzc5JwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfZGF0YToveWFtdHJhY2svZGInCiAgICBkZXBlbmRzX29uOgogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd3Z2V0IC0tcXVpZXQgLS10cmllcz0xIC0tc3BpZGVyIGh0dHA6Ly8xMjcuMC4wLjE6ODAwMC9oZWFsdGgvIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3JlZGlzX2RhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1lBTVRSQUNLXzgwMDAKICAgICAgLSAnVVJMUz0ke1NFUlZJQ0VfVVJMX1lBTVRSQUNLfScKICAgICAgLSAnVFo9JHtUWjotRXVyb3BlL0Jlcmxpbn0nCiAgICAgIC0gJ1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfU0VDUkVUfScKICAgICAgLSAnUkVHSVNUUkFUSU9OPSR7UkVHSVNUUkFUSU9OX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdSRURJU19VUkw9cmVkaXM6Ly9yZWRpczo2Mzc5JwogICAgICAtIERCX0hPU1Q9cG9zdGdyZXMKICAgICAgLSAnREJfTkFNRT0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LXlhbXRyYWNrLWRifScKICAgICAgLSAnREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfScKICAgICAgLSAnREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9JwogICAgICAtIERCX1BPUlQ9NTQzMgogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgcmVkaXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLS1uby12ZXJib3NlJwogICAgICAgIC0gJy0tdHJpZXM9MScKICAgICAgICAtICctLXNwaWRlcicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwMDAvaGVhbHRoLycKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUE9TVEdSRVNfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LXlhbXRyYWNrLWRifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3Bvc3RncmVzX2RhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3lhbXRyYWNrX3JlZGlzX2RhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "self-hosted",
             "automation",
@@ -5880,51 +5946,5 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
-    },
-    "convertx": {
-        "documentation": "https://github.com/C4illin/ConvertX?utm_source=coolify.io",
-        "slogan": "A self-hosted online file converter. Supports over a thousand different formats.",
-        "compose": "c2VydmljZXM6CiAgY29udmVydHg6CiAgICBpbWFnZTogJ2doY3IuaW8vYzRpbGxpbi9jb252ZXJ0eDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9DT05WRVJUWAogICAgICAtICdBQ0NPVU5UX1JFR0lTVFJBVElPTj0ke0FDQ09VTlRfUkVHSVNUUkFUSU9OOi1mYWxzZX0nCiAgICAgIC0gJ0hUVFBfQUxMT1dFRD0ke0hUVFBfQUxMT1dFRDotdHJ1ZX0nCiAgICAgIC0gJ0FMTE9XX1VOQVVUSEVOVElDQVRFRD0ke0FMTE9XX1VOQVVUSEVOVElDQVRFRDotZmFsc2V9JwogICAgICAtICdBVVRPX0RFTEVURV9FVkVSWV9OX0hPVVJTPSR7QVVUT19ERUxFVEVfRVZFUllfTl9IT1VSUzotMjR9JwogICAgICAtICdKV1RfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9DT05WRVJUWEpXVFNFQ1JFVH0nCiAgICB2b2x1bWVzOgogICAgICAtICdjb252ZXJ0eF9kYXRhOi9hcHAvZGF0YScK",
-        "tags": [
-            "converter",
-            "file",
-            "documents",
-            "files",
-            "directories"
-        ],
-        "category": "backend",
-        "logo": "svgs/convertx.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3000"
-    },
-    "marimo": {
-        "documentation": "https://marimo.io/?utm_source=coolify.io",
-        "slogan": "An open-source reactive notebook for Python \u2014 reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.",
-        "compose": "c2VydmljZXM6CiAgbWFyaW1vOgogICAgaW1hZ2U6ICdnaGNyLmlvL21hcmltby10ZWFtL21hcmltbzpsYXRlc3Qtc3FsJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfTUFSSU1PXzgwODAKICAgICAgLSBUT0tFTl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NQVJJTU8KICAgIHZvbHVtZXM6CiAgICAgIC0gJ21hcmltbzovYXBwJwogICAgY29tbWFuZDoKICAgICAgLSBtYXJpbW8KICAgICAgLSBlZGl0CiAgICAgIC0gJy0tdG9rZW4tcGFzc3dvcmQnCiAgICAgIC0gJyR7U0VSVklDRV9QQVNTV09SRF9NQVJJTU99JwogICAgICAtICctLXBvcnQnCiAgICAgIC0gJzgwODAnCiAgICAgIC0gJy0taG9zdCcKICAgICAgLSAwLjAuMC4wCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gdXZ4CiAgICAgICAgLSAnLS13aXRoJwogICAgICAgIC0gJ2h0dHB4W2NsaV0nCiAgICAgICAgLSBodHRweAogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9oZWFsdGgnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
-        "tags": [
-            "notebook",
-            "python",
-            "data",
-            "analysis"
-        ],
-        "category": "devtools",
-        "logo": "svgs/marimo.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8080"
-    },
-    "pydio-cells": {
-        "documentation": "https://docs.pydio.com/?utm_source=coolify.io",
-        "slogan": "High-performance large file sharing, native no-code automation, and a collaboration-centric architecture that simplifies access control without compromising security or compliance.",
-        "compose": "c2VydmljZXM6CiAgY2VsbHM6CiAgICBpbWFnZTogJ3B5ZGlvL2NlbGxzOjQuNCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX0NFTExTXzgwODAKICAgICAgLSAnQ0VMTFNfU0lURV9FWFRFUk5BTD0ke1NFUlZJQ0VfVVJMX0NFTExTfScKICAgICAgLSBDRUxMU19TSVRFX05PX1RMUz0xCiAgICB2b2x1bWVzOgogICAgICAtICdjZWxsc19kYXRhOi92YXIvY2VsbHMnCiAgbWFyaWFkYjoKICAgIGltYWdlOiAnbWFyaWFkYjoxMScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ215c3FsX2RhdGE6L3Zhci9saWIvbXlzcWwnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTVlTUUxfUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTVlTUUxST09UfScKICAgICAgLSAnTVlTUUxfREFUQUJBU0U9JHtNWVNRTF9EQVRBQkFTRTotY2VsbHN9JwogICAgICAtICdNWVNRTF9VU0VSPSR7U0VSVklDRV9VU0VSX01ZU1FMfScKICAgICAgLSAnTVlTUUxfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01ZU1FMfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAgIC0gJy0tY29ubmVjdCcKICAgICAgICAtICctLWlubm9kYl9pbml0aWFsaXplZCcKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogNQo=",
-        "tags": [
-            "storage"
-        ],
-        "category": "storage",
-        "logo": "svgs/cells.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "8080"
     }
 }

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -219,7 +219,7 @@
     },
     "autobase": {
         "documentation": "https://autobase.tech/docs/?utm_source=coolify.io",
-        "slogan": "Autobase for PostgreSQL\u00ae is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
+        "slogan": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
         "compose": "c2VydmljZXM6CiAgYXV0b2Jhc2U6CiAgICBpbWFnZTogJ2F1dG9iYXNlL2NvbnNvbGVfdWk6Mi41LjInCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9BVVRPQkFTRV84MAogICAgICAtICdQR19DT05TT0xFX0FVVEhPUklaQVRJT05fVE9LRU49JHtTRVJWSUNFX1BBU1NXT1JEX1VJfScKICAgICAgLSBQR19DT05TT0xFX0FQSV9IT1NUPWF1dG9iYXNlLWFwaQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwLycKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgICBkZXBlbmRzX29uOgogICAgICBhdXRvYmFzZS1hcGk6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICBhdXRvYmFzZS1kYjoKICAgIGltYWdlOiAnYXV0b2Jhc2UvY29uc29sZV9kYjoyLjUuMicKICAgIHBsYXRmb3JtOiBsaW51eC9hbWQ2NAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICB2b2x1bWVzOgogICAgICAtICdhdXRvYmFzZS1kYi1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgcG9zdGdyZXMnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAogIGF1dG9iYXNlLWFwaToKICAgIGltYWdlOiAnYXV0b2Jhc2UvY29uc29sZV9hcGk6Mi41LjInCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFBHX0NPTlNPTEVfREJfSE9TVD1hdXRvYmFzZS1kYgogICAgICAtICdQR19DT05TT0xFX0RCX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICAgIC0gJ1BHX0NPTlNPTEVfQVVUSE9SSVpBVElPTl9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfVUl9JwogICAgICAtICdQR19DT05TT0xFX0VOQ1JZUFRJT05LRVk9JHtTRVJWSUNFX0JBU0U2NF9FTkNSWVBUSU9OS0VZfScKICAgICAgLSAnUEdfQ09OU09MRV9MT0dHRVJfTEVWRUw9JHtQR19DT05TT0xFX0xPR0dFUl9MRVZFTDotaW5mb30nCiAgICB2b2x1bWVzOgogICAgICAtICcvdmFyL3J1bi9kb2NrZXIuc29jazovdmFyL3J1bi9kb2NrZXIuc29jaycKICAgICAgLSAnL3RtcC9hbnNpYmxlOi90bXAvYW5zaWJsZScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWZzUycKICAgICAgICAtICctSCcKICAgICAgICAtICdhY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24nCiAgICAgICAgLSAnLUgnCiAgICAgICAgLSAnQXV0aG9yaXphdGlvbjogQmVhcmVyICR7U0VSVklDRV9QQVNTV09SRF9VSX0nCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4MDgwL2FwaS92MS92ZXJzaW9uJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDUKICAgIGRlcGVuZHNfb246CiAgICAgIGF1dG9iYXNlLWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5Cg==",
         "tags": [
             "database",
@@ -266,22 +266,6 @@
         "template_last_updated_at": "2026-02-03T22:27:36+01:00",
         "port": "8080"
     },
-    "beszel-agent": {
-        "documentation": "https://www.beszel.dev/guide/agent-installation?utm_source=coolify.io",
-        "slogan": "Monitoring agent for Beszel",
-        "compose": "c2VydmljZXM6CiAgYmVzemVsLWFnZW50OgogICAgaW1hZ2U6ICdoZW5yeWdkL2Jlc3plbC1hZ2VudDowLjE4LjcnCiAgICBuZXR3b3JrX21vZGU6IGhvc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIExJU1RFTj0vYmVzemVsX3NvY2tldC9iZXN6ZWwuc29jawogICAgICAtIEhVQl9VUkw9JFNFUlZJQ0VfRlFETl9CRVNaRUwKICAgICAgLSAnVE9LRU49JHtUT0tFTn0nCiAgICAgIC0gJ0tFWT0ke0tFWX0nCiAgICAgIC0gJ0RJU0FCTEVfU1NIPSR7RElTQUJMRV9TU0g6LWZhbHNlfScKICAgICAgLSAnTE9HX0xFVkVMPSR7TE9HX0xFVkVMOi13YXJufScKICAgICAgLSAnU0tJUF9HUFU9JHtTS0lQX0dQVTotZmFsc2V9JwogICAgICAtICdTWVNURU1fTkFNRT0ke1NZU1RFTV9OQU1FfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2Jlc3plbF9hZ2VudF9kYXRhOi92YXIvbGliL2Jlc3plbC1hZ2VudCcKICAgICAgLSAnYmVzemVsX3NvY2tldDovYmVzemVsX3NvY2tldCcKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2s6cm8nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2FnZW50CiAgICAgICAgLSBoZWFsdGgKICAgICAgaW50ZXJ2YWw6IDYwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICAgICAgc3RhcnRfcGVyaW9kOiA1cwo=",
-        "tags": [
-            "beszel",
-            "monitoring",
-            "server",
-            "stats",
-            "alerts"
-        ],
-        "category": "monitoring",
-        "logo": "svgs/beszel.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-24T02:22:08+05:30"
-    },
     "beszel": {
         "documentation": "https://github.com/henrygd/beszel?tab=readme-ov-file#getting-started?utm_source=coolify.io",
         "slogan": "A lightweight server resource monitoring hub with historical data, docker stats, and alerts.",
@@ -298,6 +282,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-24T02:21:33+05:30",
         "port": "8090"
+    },
+    "beszel-agent": {
+        "documentation": "https://www.beszel.dev/guide/agent-installation?utm_source=coolify.io",
+        "slogan": "Monitoring agent for Beszel",
+        "compose": "c2VydmljZXM6CiAgYmVzemVsLWFnZW50OgogICAgaW1hZ2U6ICdoZW5yeWdkL2Jlc3plbC1hZ2VudDowLjE4LjcnCiAgICBuZXR3b3JrX21vZGU6IGhvc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIExJU1RFTj0vYmVzemVsX3NvY2tldC9iZXN6ZWwuc29jawogICAgICAtIEhVQl9VUkw9JFNFUlZJQ0VfRlFETl9CRVNaRUwKICAgICAgLSAnVE9LRU49JHtUT0tFTn0nCiAgICAgIC0gJ0tFWT0ke0tFWX0nCiAgICAgIC0gJ0RJU0FCTEVfU1NIPSR7RElTQUJMRV9TU0g6LWZhbHNlfScKICAgICAgLSAnTE9HX0xFVkVMPSR7TE9HX0xFVkVMOi13YXJufScKICAgICAgLSAnU0tJUF9HUFU9JHtTS0lQX0dQVTotZmFsc2V9JwogICAgICAtICdTWVNURU1fTkFNRT0ke1NZU1RFTV9OQU1FfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2Jlc3plbF9hZ2VudF9kYXRhOi92YXIvbGliL2Jlc3plbC1hZ2VudCcKICAgICAgLSAnYmVzemVsX3NvY2tldDovYmVzemVsX3NvY2tldCcKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2s6cm8nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2FnZW50CiAgICAgICAgLSBoZWFsdGgKICAgICAgaW50ZXJ2YWw6IDYwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICAgICAgc3RhcnRfcGVyaW9kOiA1cwo=",
+        "tags": [
+            "beszel",
+            "monitoring",
+            "server",
+            "stats",
+            "alerts"
+        ],
+        "category": "monitoring",
+        "logo": "svgs/beszel.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-24T02:22:08+05:30"
     },
     "bitcoin-core": {
         "documentation": "https://hub.docker.com/r/ruimarinho/bitcoin-core/?utm_source=coolify.io",
@@ -438,6 +438,27 @@
         "template_last_updated_at": null,
         "port": "3000"
     },
+    "calibre-web": {
+        "documentation": "https://github.com/linuxserver/docker-calibre-web?utm_source=coolify.io",
+        "slogan": "Calibre-web is a web app providing a clean interface for browsing, reading and downloading eBooks.",
+        "compose": "c2VydmljZXM6CiAgY2FsaWJyZS13ZWI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvY2FsaWJyZS13ZWI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0NBTElCUkVfODA4MwogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgICAtICdUWj0ke1RaOi1FdGMvVVRDfScKICAgICAgLSAnRE9DS0VSX01PRFM9JHtET0NLRVJfTU9EUzotbGludXhzZXJ2ZXIvbW9kczp1bml2ZXJzYWwtY2FsaWJyZX0nCiAgICB2b2x1bWVzOgogICAgICAtICdjYWxpYnJlX3dlYl9kYXRhOi9jb25maWcnCiAgICAgIC0gJ2NhbGlicmVfbGlicmFyeTovYm9va3MnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MycKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "calibre",
+            "calibre-web",
+            "ebook",
+            "library",
+            "epub",
+            "ereader",
+            "kindle",
+            "book",
+            "reader"
+        ],
+        "category": "media",
+        "logo": "svgs/calibre-web.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8083"
+    },
     "calibre-web-automated-book-downloader": {
         "documentation": "https://github.com/calibrain/calibre-web-automated-book-downloader?utm_source=coolify.io",
         "slogan": "An intuitive web interface for searching and requesting book downloads, designed to work seamlessly with Calibre-Web-Automated.",
@@ -461,43 +482,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "8083"
     },
-    "calibre-web": {
-        "documentation": "https://github.com/linuxserver/docker-calibre-web?utm_source=coolify.io",
-        "slogan": "Calibre-web is a web app providing a clean interface for browsing, reading and downloading eBooks.",
-        "compose": "c2VydmljZXM6CiAgY2FsaWJyZS13ZWI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvY2FsaWJyZS13ZWI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0NBTElCUkVfODA4MwogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgICAtICdUWj0ke1RaOi1FdGMvVVRDfScKICAgICAgLSAnRE9DS0VSX01PRFM9JHtET0NLRVJfTU9EUzotbGludXhzZXJ2ZXIvbW9kczp1bml2ZXJzYWwtY2FsaWJyZX0nCiAgICB2b2x1bWVzOgogICAgICAtICdjYWxpYnJlX3dlYl9kYXRhOi9jb25maWcnCiAgICAgIC0gJ2NhbGlicmVfbGlicmFyeTovYm9va3MnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MycKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
-        "tags": [
-            "calibre",
-            "calibre-web",
-            "ebook",
-            "library",
-            "epub",
-            "ereader",
-            "kindle",
-            "book",
-            "reader"
-        ],
-        "category": "media",
-        "logo": "svgs/calibre-web.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8083"
-    },
-    "cap-captcha": {
-        "documentation": "https://capjs.js.org/guide/?utm_source=coolify.io",
-        "slogan": "The self-hosted CAPTCHA for the modern web.",
-        "compose": "c2VydmljZXM6CiAgY2FwOgogICAgaW1hZ2U6ICd0aWFnbzIvY2FwOjMuMC40JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0NBUF8zMDAwCiAgICAgIC0gQURNSU5fS0VZPSRTRVJWSUNFX1BBU1NXT1JEX0FETUlOCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3ZhbGtleTo2Mzc5JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGJ1bgogICAgICAgIC0gJy1lJwogICAgICAgIC0gImZldGNoKCdodHRwOi8vbG9jYWxob3N0OjMwMDAnKS50aGVuKHIgPT4geyBpZiAoIXIub2spIHByb2Nlc3MuZXhpdCgxKSB9KS5jYXRjaCgoKSA9PiBwcm9jZXNzLmV4aXQoMSkpIgogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiA1cwogICAgZGVwZW5kc19vbjoKICAgICAgdmFsa2V5OgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgdmFsa2V5OgogICAgaW1hZ2U6ICd2YWxrZXkvdmFsa2V5OjktYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAndmFsa2V5LWRhdGE6L2RhdGEnCiAgICBjb21tYW5kOiAndmFsa2V5LXNlcnZlciAtLXNhdmUgNjAgMSAtLWxvZ2xldmVsIHdhcm5pbmcgLS1tYXhtZW1vcnktcG9saWN5IG5vZXZpY3Rpb24nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gdmFsa2V5LWNsaQogICAgICAgIC0gcGluZwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogM3MKICAgICAgcmV0cmllczogNQo=",
-        "tags": [
-            "captcha",
-            "security",
-            "privacy",
-            "proof-of-work"
-        ],
-        "category": "security",
-        "logo": "svgs/cap-captcha.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-23T01:07:14+05:30",
-        "port": "3000"
-    },
     "cap": {
         "documentation": "https://cap.so?utm_source=coolify.io",
         "slogan": "Cap is the open source alternative to Loom. Lightweight, powerful, and cross-platform. Record and share in seconds.",
@@ -515,6 +499,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "5679"
+    },
+    "cap-captcha": {
+        "documentation": "https://capjs.js.org/guide/?utm_source=coolify.io",
+        "slogan": "The self-hosted CAPTCHA for the modern web.",
+        "compose": "c2VydmljZXM6CiAgY2FwOgogICAgaW1hZ2U6ICd0aWFnbzIvY2FwOjMuMC40JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0NBUF8zMDAwCiAgICAgIC0gQURNSU5fS0VZPSRTRVJWSUNFX1BBU1NXT1JEX0FETUlOCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3ZhbGtleTo2Mzc5JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGJ1bgogICAgICAgIC0gJy1lJwogICAgICAgIC0gImZldGNoKCdodHRwOi8vbG9jYWxob3N0OjMwMDAnKS50aGVuKHIgPT4geyBpZiAoIXIub2spIHByb2Nlc3MuZXhpdCgxKSB9KS5jYXRjaCgoKSA9PiBwcm9jZXNzLmV4aXQoMSkpIgogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiA1cwogICAgZGVwZW5kc19vbjoKICAgICAgdmFsa2V5OgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgdmFsa2V5OgogICAgaW1hZ2U6ICd2YWxrZXkvdmFsa2V5OjktYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAndmFsa2V5LWRhdGE6L2RhdGEnCiAgICBjb21tYW5kOiAndmFsa2V5LXNlcnZlciAtLXNhdmUgNjAgMSAtLWxvZ2xldmVsIHdhcm5pbmcgLS1tYXhtZW1vcnktcG9saWN5IG5vZXZpY3Rpb24nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gdmFsa2V5LWNsaQogICAgICAgIC0gcGluZwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogM3MKICAgICAgcmV0cmllczogNQo=",
+        "tags": [
+            "captcha",
+            "security",
+            "privacy",
+            "proof-of-work"
+        ],
+        "category": "security",
+        "logo": "svgs/cap-captcha.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-23T01:07:14+05:30",
+        "port": "3000"
     },
     "castopod": {
         "documentation": "https://docs.castopod.org/main/en/?utm_source=coolify.io",
@@ -823,6 +823,23 @@
         "template_last_updated_at": "2025-11-03T21:29:53+08:00",
         "port": "3000"
     },
+    "convertx": {
+        "documentation": "https://github.com/C4illin/ConvertX?utm_source=coolify.io",
+        "slogan": "A self-hosted online file converter. Supports over a thousand different formats.",
+        "compose": "c2VydmljZXM6CiAgY29udmVydHg6CiAgICBpbWFnZTogJ2doY3IuaW8vYzRpbGxpbi9jb252ZXJ0eDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fQ09OVkVSVFgKICAgICAgLSAnQUNDT1VOVF9SRUdJU1RSQVRJT049JHtBQ0NPVU5UX1JFR0lTVFJBVElPTjotZmFsc2V9JwogICAgICAtICdIVFRQX0FMTE9XRUQ9JHtIVFRQX0FMTE9XRUQ6LXRydWV9JwogICAgICAtICdBTExPV19VTkFVVEhFTlRJQ0FURUQ9JHtBTExPV19VTkFVVEhFTlRJQ0FURUQ6LWZhbHNlfScKICAgICAgLSAnQVVUT19ERUxFVEVfRVZFUllfTl9IT1VSUz0ke0FVVE9fREVMRVRFX0VWRVJZX05fSE9VUlM6LTI0fScKICAgICAgLSAnSldUX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfQ09OVkVSVFhKV1RTRUNSRVR9JwogICAgdm9sdW1lczoKICAgICAgLSAnY29udmVydHhfZGF0YTovYXBwL2RhdGEnCg==",
+        "tags": [
+            "converter",
+            "file",
+            "documents",
+            "files",
+            "directories"
+        ],
+        "category": "backend",
+        "logo": "svgs/convertx.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3000"
+    },
     "convex": {
         "documentation": "https://github.com/get-convex/convex-backend/blob/main/self-hosted/README.md?utm_source=coolify.io",
         "slogan": "Convex is the open-source reactive database for app developers.",
@@ -929,22 +946,6 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "4512"
     },
-    "directus-with-postgresql": {
-        "documentation": "https://directus.io?utm_source=coolify.io",
-        "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
-        "compose": "c2VydmljZXM6CiAgZGlyZWN0dXM6CiAgICBpbWFnZTogJ2RpcmVjdHVzL2RpcmVjdHVzOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtdXBsb2FkczovZGlyZWN0dXMvdXBsb2FkcycKICAgICAgLSAnZGlyZWN0dXMtZXh0ZW5zaW9uczovZGlyZWN0dXMvZXh0ZW5zaW9ucycKICAgICAgLSAnZGlyZWN0dXMtdGVtcGxhdGVzOi9kaXJlY3R1cy90ZW1wbGF0ZXMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fRElSRUNUVVNfODA1NQogICAgICAtIEtFWT0kU0VSVklDRV9CQVNFNjRfNjRfS0VZCiAgICAgIC0gU0VDUkVUPSRTRVJWSUNFX0JBU0U2NF82NF9TRUNSRVQKICAgICAgLSAnQURNSU5fRU1BSUw9JHtBRE1JTl9FTUFJTDotYWRtaW5AZXhhbXBsZS5jb219JwogICAgICAtIEFETUlOX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX0FETUlOCiAgICAgIC0gREJfQ0xJRU5UPXBvc3RncmVzCiAgICAgIC0gREJfSE9TVD1wb3N0Z3Jlc3FsCiAgICAgIC0gREJfUE9SVD01NDMyCiAgICAgIC0gJ0RCX0RBVEFCQVNFPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotZGlyZWN0dXN9JwogICAgICAtIERCX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMCiAgICAgIC0gREJfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTAogICAgICAtIFJFRElTX0hPU1Q9cmVkaXMKICAgICAgLSBSRURJU19QT1JUPTYzNzkKICAgICAgLSBXRUJTT0NLRVRTX0VOQUJMRUQ9dHJ1ZQogICAgICAtICdDT1JTX0VOQUJMRUQ9JHtDT1JTX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdDT1JTX09SSUdJTj0ke0NPUlNfT1JJR0lOfScKICAgICAgLSAnQ09SU19NRVRIT0RTPSR7Q09SU19NRVRIT0RTOi1HRVQsUE9TVCxQQVRDSCxERUxFVEUsT1BUSU9OU30nCiAgICAgIC0gJ0NPUlNfQUxMT1dFRF9IRUFERVJTPSR7Q09SU19BTExPV0VEX0hFQURFUlM6LUNvbnRlbnQtVHlwZSxBdXRob3JpemF0aW9ufScKICAgICAgLSAnQ09SU19DUkVERU5USUFMUz0ke0NPUlNfQ1JFREVOVElBTFM6LXRydWV9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHdnZXQKICAgICAgICAtICctcScKICAgICAgICAtICctLXNwaWRlcicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwNTUvYWRtaW4vbG9naW4nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgcmVkaXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z2lzL3Bvc3RnaXM6MTYtMy40LWFscGluZScKICAgIHBsYXRmb3JtOiBsaW51eC9hbWQ2NAogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotZGlyZWN0dXN9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIGNvbW1hbmQ6ICdyZWRpcy1zZXJ2ZXIgLS1hcHBlbmRvbmx5IHllcycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RpcmVjdHVzLXJlZGlzLWRhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
-        "tags": [
-            "directus",
-            "cms",
-            "database",
-            "sql"
-        ],
-        "category": "cms",
-        "logo": "svgs/directus.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-03T19:25:51+05:30",
-        "port": "8055"
-    },
     "directus": {
         "documentation": "https://directus.io?utm_source=coolify.io",
         "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
@@ -959,6 +960,22 @@
         "logo": "svgs/directus.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-03T19:26:06+05:30",
+        "port": "8055"
+    },
+    "directus-with-postgresql": {
+        "documentation": "https://directus.io?utm_source=coolify.io",
+        "slogan": "Directus wraps databases with a dynamic API, and provides an intuitive app for managing its content.",
+        "compose": "c2VydmljZXM6CiAgZGlyZWN0dXM6CiAgICBpbWFnZTogJ2RpcmVjdHVzL2RpcmVjdHVzOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtdXBsb2FkczovZGlyZWN0dXMvdXBsb2FkcycKICAgICAgLSAnZGlyZWN0dXMtZXh0ZW5zaW9uczovZGlyZWN0dXMvZXh0ZW5zaW9ucycKICAgICAgLSAnZGlyZWN0dXMtdGVtcGxhdGVzOi9kaXJlY3R1cy90ZW1wbGF0ZXMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fRElSRUNUVVNfODA1NQogICAgICAtIEtFWT0kU0VSVklDRV9CQVNFNjRfNjRfS0VZCiAgICAgIC0gU0VDUkVUPSRTRVJWSUNFX0JBU0U2NF82NF9TRUNSRVQKICAgICAgLSAnQURNSU5fRU1BSUw9JHtBRE1JTl9FTUFJTDotYWRtaW5AZXhhbXBsZS5jb219JwogICAgICAtIEFETUlOX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX0FETUlOCiAgICAgIC0gREJfQ0xJRU5UPXBvc3RncmVzCiAgICAgIC0gREJfSE9TVD1wb3N0Z3Jlc3FsCiAgICAgIC0gREJfUE9SVD01NDMyCiAgICAgIC0gJ0RCX0RBVEFCQVNFPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotZGlyZWN0dXN9JwogICAgICAtIERCX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFU1FMCiAgICAgIC0gREJfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTAogICAgICAtIFJFRElTX0hPU1Q9cmVkaXMKICAgICAgLSBSRURJU19QT1JUPTYzNzkKICAgICAgLSBXRUJTT0NLRVRTX0VOQUJMRUQ9dHJ1ZQogICAgICAtICdDT1JTX0VOQUJMRUQ9JHtDT1JTX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdDT1JTX09SSUdJTj0ke0NPUlNfT1JJR0lOfScKICAgICAgLSAnQ09SU19NRVRIT0RTPSR7Q09SU19NRVRIT0RTOi1HRVQsUE9TVCxQQVRDSCxERUxFVEUsT1BUSU9OU30nCiAgICAgIC0gJ0NPUlNfQUxMT1dFRF9IRUFERVJTPSR7Q09SU19BTExPV0VEX0hFQURFUlM6LUNvbnRlbnQtVHlwZSxBdXRob3JpemF0aW9ufScKICAgICAgLSAnQ09SU19DUkVERU5USUFMUz0ke0NPUlNfQ1JFREVOVElBTFM6LXRydWV9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHdnZXQKICAgICAgICAtICctcScKICAgICAgICAtICctLXNwaWRlcicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwNTUvYWRtaW4vbG9naW4nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgcmVkaXM6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z2lzL3Bvc3RnaXM6MTYtMy40LWFscGluZScKICAgIHBsYXRmb3JtOiBsaW51eC9hbWQ2NAogICAgdm9sdW1lczoKICAgICAgLSAnZGlyZWN0dXMtcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotZGlyZWN0dXN9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczo3LWFscGluZScKICAgIGNvbW1hbmQ6ICdyZWRpcy1zZXJ2ZXIgLS1hcHBlbmRvbmx5IHllcycKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2RpcmVjdHVzLXJlZGlzLWRhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSBwaW5nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "directus",
+            "cms",
+            "database",
+            "sql"
+        ],
+        "category": "cms",
+        "logo": "svgs/directus.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-03T19:25:51+05:30",
         "port": "8055"
     },
     "diun": {
@@ -1031,10 +1048,10 @@
         "template_last_updated_at": "2025-11-07T17:08:01+05:30",
         "port": "3000"
     },
-    "docuseal-with-postgres": {
+    "docuseal": {
         "documentation": "https://www.docuseal.co/?utm_source=coolify.io",
         "slogan": "Document Signing for Everyone free forever for individuals, extensible for businesses and developers. Open Source Alternative to DocuSign, PandaDoc and more.",
-        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET0NVU0VBTF8zMDAwCiAgICAgIC0gJ0hPU1Q9JHtTRVJWSUNFX0ZRRE5fRE9DVVNFQUx9JwogICAgICAtICdEQVRBQkFTRV9VUkw9cG9zdGdyZXNxbDovLyRTRVJWSUNFX1VTRVJfUE9TVEdSRVM6JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNAcG9zdGdyZXNxbDo1NDMyLyR7UE9TVEdSRVNfREJ9JwogICAgdm9sdW1lczoKICAgICAgLSAnZG9jdXNlYWwtZGF0YTovZGF0YScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLXEnCiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcG9zdGdyZXNxbDoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAncG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFBPU1RHUkVTX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFUwogICAgICAtIFBPU1RHUkVTX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREI6LWRvY3VzZWFsfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET0NVU0VBTF8zMDAwCiAgICAgIC0gJ0hPU1Q9JHtTRVJWSUNFX0ZRRE5fRE9DVVNFQUx9JwogICAgdm9sdW1lczoKICAgICAgLSAnZG9jdXNlYWwtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLXEnCiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "documentation"
         ],
@@ -1044,10 +1061,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "docuseal": {
+    "docuseal-with-postgres": {
         "documentation": "https://www.docuseal.co/?utm_source=coolify.io",
         "slogan": "Document Signing for Everyone free forever for individuals, extensible for businesses and developers. Open Source Alternative to DocuSign, PandaDoc and more.",
-        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET0NVU0VBTF8zMDAwCiAgICAgIC0gJ0hPU1Q9JHtTRVJWSUNFX0ZRRE5fRE9DVVNFQUx9JwogICAgdm9sdW1lczoKICAgICAgLSAnZG9jdXNlYWwtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLXEnCiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAgZG9jdXNlYWw6CiAgICBpbWFnZTogJ2RvY3VzZWFsL2RvY3VzZWFsOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET0NVU0VBTF8zMDAwCiAgICAgIC0gJ0hPU1Q9JHtTRVJWSUNFX0ZRRE5fRE9DVVNFQUx9JwogICAgICAtICdEQVRBQkFTRV9VUkw9cG9zdGdyZXNxbDovLyRTRVJWSUNFX1VTRVJfUE9TVEdSRVM6JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNAcG9zdGdyZXNxbDo1NDMyLyR7UE9TVEdSRVNfREJ9JwogICAgdm9sdW1lczoKICAgICAgLSAnZG9jdXNlYWwtZGF0YTovZGF0YScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzcWw6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSB3Z2V0CiAgICAgICAgLSAnLXEnCiAgICAgICAgLSAnLS1zcGlkZXInCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcG9zdGdyZXNxbDoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAncG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFBPU1RHUkVTX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFUwogICAgICAtIFBPU1RHUkVTX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREI6LWRvY3VzZWFsfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "documentation"
         ],
@@ -1086,10 +1103,10 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "dozzle-with-auth": {
-        "documentation": "https://dozzle.dev/?utm_source=coolify.io",
+    "dozzle": {
+        "documentation": "https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io",
         "slogan": "Dozzle is a simple and lightweight web UI for Docker logs.",
-        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET1paTEVfODA4MAogICAgICAtIERPWlpMRV9BVVRIX1BST1ZJREVSPXNpbXBsZQogICAgdm9sdW1lczoKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2snCiAgICAgIC0KICAgICAgICB0eXBlOiBiaW5kCiAgICAgICAgc291cmNlOiAuL2RhdGEvdXNlcnMueW1sCiAgICAgICAgdGFyZ2V0OiAnL2RhdGEvdXNlcnMueW1sOnJvJwogICAgICAgIGNvbnRlbnQ6ICJ1c2VyczpcbiAgIyBcImFkbWluXCIgaXMgdGhlIHVzZXJuYW1lXG4gIGFkbWluOlxuICAgIGVtYWlsOiB0ZXN0QGVtYWlsLmNvbVxuICAgIG5hbWU6IEFkbWluXG4gICAgIyBBIHNoYS0yNTYgaGFzaCBvZiB0aGUgcGFzc3dvcmQgeW91IHdhbnQgdG8gdXNlLiBDYW4gYmUgY29tcHV0ZWQgd2l0aCBcImVjaG8gLW4gcGFzc3dvcmQgfCBzaGFzdW0gLWEgMjU2XCIuIERlZmF1bHQgcGFzc3dvcmQgaXMgXCJUZXN0XCIuXG4gICAgcGFzc3dvcmQ6ICQyYSQxMSR2aXVjQ3ZGTGxIV3ZCTk9PSTZ1eXB1VlUuRDA5VVdiLnpzd1J4RWcwTWtEUGkxcS9iS2JkR1xuIgogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIC9kb3p6bGUKICAgICAgICAtIGhlYWx0aGNoZWNrCiAgICAgIGludGVydmFsOiAzcwogICAgICB0aW1lb3V0OiAzMHMKICAgICAgcmV0cmllczogNQo=",
+        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET1paTEVfODA4MAogICAgdm9sdW1lczoKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2snCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2RvenpsZQogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDNzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogMzBzCg==",
         "tags": [
             "dozzle",
             "docker",
@@ -1102,10 +1119,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
-    "dozzle": {
-        "documentation": "https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io",
+    "dozzle-with-auth": {
+        "documentation": "https://dozzle.dev/?utm_source=coolify.io",
         "slogan": "Dozzle is a simple and lightweight web UI for Docker logs.",
-        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET1paTEVfODA4MAogICAgdm9sdW1lczoKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2snCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL2RvenpsZQogICAgICAgIC0gaGVhbHRoY2hlY2sKICAgICAgaW50ZXJ2YWw6IDNzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogMzBzCg==",
+        "compose": "c2VydmljZXM6CiAgZG96emxlOgogICAgaW1hZ2U6ICdhbWlyMjAvZG96emxlOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ET1paTEVfODA4MAogICAgICAtIERPWlpMRV9BVVRIX1BST1ZJREVSPXNpbXBsZQogICAgdm9sdW1lczoKICAgICAgLSAnL3Zhci9ydW4vZG9ja2VyLnNvY2s6L3Zhci9ydW4vZG9ja2VyLnNvY2snCiAgICAgIC0KICAgICAgICB0eXBlOiBiaW5kCiAgICAgICAgc291cmNlOiAuL2RhdGEvdXNlcnMueW1sCiAgICAgICAgdGFyZ2V0OiAnL2RhdGEvdXNlcnMueW1sOnJvJwogICAgICAgIGNvbnRlbnQ6ICJ1c2VyczpcbiAgIyBcImFkbWluXCIgaXMgdGhlIHVzZXJuYW1lXG4gIGFkbWluOlxuICAgIGVtYWlsOiB0ZXN0QGVtYWlsLmNvbVxuICAgIG5hbWU6IEFkbWluXG4gICAgIyBBIHNoYS0yNTYgaGFzaCBvZiB0aGUgcGFzc3dvcmQgeW91IHdhbnQgdG8gdXNlLiBDYW4gYmUgY29tcHV0ZWQgd2l0aCBcImVjaG8gLW4gcGFzc3dvcmQgfCBzaGFzdW0gLWEgMjU2XCIuIERlZmF1bHQgcGFzc3dvcmQgaXMgXCJUZXN0XCIuXG4gICAgcGFzc3dvcmQ6ICQyYSQxMSR2aXVjQ3ZGTGxIV3ZCTk9PSTZ1eXB1VlUuRDA5VVdiLnpzd1J4RWcwTWtEUGkxcS9iS2JkR1xuIgogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIC9kb3p6bGUKICAgICAgICAtIGhlYWx0aGNoZWNrCiAgICAgIGludGVydmFsOiAzcwogICAgICB0aW1lb3V0OiAzMHMKICAgICAgcmV0cmllczogNQo=",
         "tags": [
             "dozzle",
             "docker",
@@ -1180,6 +1197,24 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
+    "elasticsearch": {
+        "documentation": "https://www.elastic.co/products/elasticsearch?utm_source=coolify.io",
+        "slogan": "Elasticsearch is free and Open Source, Distributed, RESTful Search Engine.",
+        "compose": "c2VydmljZXM6CiAgZWxhc3RpY3NlYXJjaDoKICAgIGltYWdlOiAnZG9ja2VyLmVsYXN0aWMuY28vZWxhc3RpY3NlYXJjaC9lbGFzdGljc2VhcmNoLXdvbGZpOjguMTkuMCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9FTEFTVElDU0VBUkNIXzkyMDAKICAgICAgLSAnRUxBU1RJQ19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfRUxBU1RJQ1NFQVJDSH0nCiAgICAgIC0gJ0VTX0pBVkFfT1BUUz0tWG1zNTEybSAtWG14NTEybScKICAgICAgLSBkaXNjb3ZlcnkudHlwZT1zaW5nbGUtbm9kZQogICAgICAtIGJvb3RzdHJhcC5tZW1vcnlfbG9jaz10cnVlCiAgICAgIC0geHBhY2suc2VjdXJpdHkuaHR0cC5zc2wuZW5hYmxlZD1mYWxzZQogICAgdm9sdW1lczoKICAgICAgLSAnZWxhc3RpY3NlYXJjaC1kYXRhOi91c3Ivc2hhcmUvZWxhc3RpY3NlYXJjaC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdjdXJsIC0tdXNlciBlbGFzdGljOiR7U0VSVklDRV9QQVNTV09SRF9FTEFTVElDU0VBUkNIfSAtLXNpbGVudCAtLWZhaWwgaHR0cDovL2xvY2FsaG9zdDo5MjAwL19jbHVzdGVyL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMjQK",
+        "tags": [
+            "search",
+            "engine",
+            "fulltext",
+            "full",
+            "text",
+            "elasticsearch"
+        ],
+        "category": "search",
+        "logo": "svgs/elasticsearch.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-18T18:30:06+02:00",
+        "port": "9200"
+    },
     "elasticsearch-with-kibana": {
         "documentation": "https://www.elastic.co/docs/deploy-manage/deploy/self-managed/install-kibana-with-docker?utm_source=coolify.io",
         "slogan": "Elastic + Kibana is a Free and Open Source Search, Monitoring, and Visualization Stack",
@@ -1202,24 +1237,6 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-04-09T00:43:59-05:00",
         "port": "5601"
-    },
-    "elasticsearch": {
-        "documentation": "https://www.elastic.co/products/elasticsearch?utm_source=coolify.io",
-        "slogan": "Elasticsearch is free and Open Source, Distributed, RESTful Search Engine.",
-        "compose": "c2VydmljZXM6CiAgZWxhc3RpY3NlYXJjaDoKICAgIGltYWdlOiAnZG9ja2VyLmVsYXN0aWMuY28vZWxhc3RpY3NlYXJjaC9lbGFzdGljc2VhcmNoLXdvbGZpOjguMTkuMCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9FTEFTVElDU0VBUkNIXzkyMDAKICAgICAgLSAnRUxBU1RJQ19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfRUxBU1RJQ1NFQVJDSH0nCiAgICAgIC0gJ0VTX0pBVkFfT1BUUz0tWG1zNTEybSAtWG14NTEybScKICAgICAgLSBkaXNjb3ZlcnkudHlwZT1zaW5nbGUtbm9kZQogICAgICAtIGJvb3RzdHJhcC5tZW1vcnlfbG9jaz10cnVlCiAgICAgIC0geHBhY2suc2VjdXJpdHkuaHR0cC5zc2wuZW5hYmxlZD1mYWxzZQogICAgdm9sdW1lczoKICAgICAgLSAnZWxhc3RpY3NlYXJjaC1kYXRhOi91c3Ivc2hhcmUvZWxhc3RpY3NlYXJjaC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdjdXJsIC0tdXNlciBlbGFzdGljOiR7U0VSVklDRV9QQVNTV09SRF9FTEFTVElDU0VBUkNIfSAtLXNpbGVudCAtLWZhaWwgaHR0cDovL2xvY2FsaG9zdDo5MjAwL19jbHVzdGVyL2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMjQK",
-        "tags": [
-            "search",
-            "engine",
-            "fulltext",
-            "full",
-            "text",
-            "elasticsearch"
-        ],
-        "category": "search",
-        "logo": "svgs/elasticsearch.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-18T18:30:06+02:00",
-        "port": "9200"
     },
     "electricsql": {
         "documentation": "https://electric-sql.com/docs/guides/deployment?utm_source=coolify.io",
@@ -1290,26 +1307,6 @@
         "template_last_updated_at": "2026-04-27T09:25:48+03:00",
         "port": "18083"
     },
-    "ente-photos-with-s3": {
-        "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
-        "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
-        "compose": "c2VydmljZXM6CiAgbXVzZXVtOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vc2VydmVyOjYxM2M2YTk2MzkwZDdhNjI0Y2YzMGI5NDY5NTU3MDVkNjMyNDIzY2MnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTVVTRVVNXzgwODAKICAgICAgLSBFTlRFX0RCX0hPU1Q9cG9zdGdyZXMKICAgICAgLSBFTlRFX0RCX1BPUlQ9NTQzMgogICAgICAtICdFTlRFX0RCX05BTUU9JHtQT1NUR1JFU19EQjotZW50ZV9kYn0nCiAgICAgIC0gJ0VOVEVfREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgIC0gJ0VOVEVfREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTfScKICAgICAgLSAnRU5URV9IVFRQX1VTRV9UTFM9JHtFTlRFX0hUVFBfVVNFX1RMUzotZmFsc2V9JwogICAgICAtIEVOVEVfUzNfQVJFX0xPQ0FMX0JVQ0tFVFM9ZmFsc2UKICAgICAgLSBFTlRFX1MzX1VTRV9QQVRIX1NUWUxFX1VSTFM9dHJ1ZQogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9LRVk9JHtTRVJWSUNFX1VTRVJfTUlOSU99JwogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9TRUNSRVQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnRU5URV9TM19CMl9FVV9DRU5fRU5EUE9JTlQ9JHtTRVJWSUNFX0ZRRE5fTUlOSU9fOTAwMH0nCiAgICAgIC0gRU5URV9TM19CMl9FVV9DRU5fUkVHSU9OPWV1LWNlbnRyYWwtMgogICAgICAtIEVOVEVfUzNfQjJfRVVfQ0VOX0JVQ0tFVD1iMi1ldS1jZW4KICAgICAgLSAnRU5URV9LRVlfRU5DUllQVElPTj0ke1NFUlZJQ0VfUkVBTEJBU0U2NF9FTkNSWVBUSU9OfScKICAgICAgLSAnRU5URV9LRVlfSEFTSD0ke1NFUlZJQ0VfUkVBTEJBU0U2NF82NF9IQVNIfScKICAgICAgLSAnRU5URV9KV1RfU0VDUkVUPSR7U0VSVklDRV9SRUFMQkFTRTY0X0pXVH0nCiAgICAgIC0gJ0VOVEVfSU5URVJOQUxfQURNSU49JHtFTlRFX0lOVEVSTkFMX0FETUlOOi0xNTgwNTU5OTYyMzg2NDM4fScKICAgICAgLSAnRU5URV9JTlRFUk5BTF9ESVNBQkxFX1JFR0lTVFJBVElPTj0ke0VOVEVfSU5URVJOQUxfRElTQUJMRV9SRUdJU1RSQVRJT046LWZhbHNlfScKICAgICAgLSAnRU5URV9TTVRQX0hPU1Q9JHtFTlRFX1NNVFBfSE9TVDotc210cC5nbWFpbC5jb219JwogICAgICAtICdFTlRFX1NNVFBfUE9SVD0ke0VOVEVfU01UUF9QT1JUOi01ODd9JwogICAgICAtICdFTlRFX1NNVFBfVVNFUk5BTUU9JHtFTlRFX1NNVFBfVVNFUk5BTUV9JwogICAgICAtICdFTlRFX1NNVFBfUEFTU1dPUkQ9JHtFTlRFX1NNVFBfUEFTU1dPUkR9JwogICAgICAtICdFTlRFX1NNVFBfRU1BSUw9JHtFTlRFX1NNVFBfRU1BSUx9JwogICAgICAtICdFTlRFX1NNVFBfU0VOREVSX05BTUU9JHtFTlRFX1NNVFBfU0VOREVSX05BTUV9JwogICAgICAtICdFTlRFX1NNVFBfRU5DUllQVElPTj0ke0VOVEVfU01UUF9FTkNSWVBUSU9OOi10bHN9JwogICAgdm9sdW1lczoKICAgICAgLSAnbXVzZXVtLWRhdGE6L2RhdGEnCiAgICAgIC0gJ211c2V1bS1jb25maWc6L2NvbmZpZycKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIG1pbmlvOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9zdGFydGVkCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MC9waW5nJwogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAzCiAgd2ViOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vd2ViOmNhMDMxNjVmNWU3ZjJhNTAxMDVlNmU0MDAxOWMxN2FlNmNkZDkzNGYnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fV0VCXzMwMDAKICAgICAgLSAnRU5URV9BUElfT1JJR0lOPSR7U0VSVklDRV9GUUROX01VU0VVTX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy0tZmFpbCcKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjMwMDAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTUtYWxwaW5lJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfSAtZCAke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgbWluaW86CiAgICBpbWFnZTogJ2doY3IuaW8vY29vbGxhYnNpby9taW5pbzpSRUxFQVNFLjIwMjUtMTAtMTVUMTctMjktNTVaJwogICAgY29tbWFuZDogJ3NlcnZlciAvZGF0YSAtLWNvbnNvbGUtYWRkcmVzcyAiOjkwMDEiJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTUlOSU9fU0VSVkVSX1VSTD0kTUlOSU9fU0VSVkVSX1VSTAogICAgICAtIE1JTklPX0JST1dTRVJfUkVESVJFQ1RfVVJMPSRNSU5JT19CUk9XU0VSX1JFRElSRUNUX1VSTAogICAgICAtIE1JTklPX1JPT1RfVVNFUj0kU0VSVklDRV9VU0VSX01JTklPCiAgICAgIC0gTUlOSU9fUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NSU5JTwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpSRUxFQVNFLjIwMjUtMDgtMTNUMDgtMzUtNDFaJwogICAgZGVwZW5kc19vbjoKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIHJlc3RhcnQ6IG9uLWZhaWx1cmUKICAgIGV4Y2x1ZGVfZnJvbV9oYzogdHJ1ZQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ01JTklPX1JPT1RfVVNFUj0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ01JTklPX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnTUlOSU9fQ09SU19VUkxTPSRTRVJWSUNFX0ZRRE5fTVVTRVVNLCRTRVJWSUNFX0ZRRE5fV0VCJwogICAgZW50cnlwb2ludDogIi9iaW4vc2ggLWMgXCJcbiAgZWNobyBcXFwiTUlOSU9fQ09SU19VUkxTOiBcXCQke01JTklPX0NPUlNfVVJMU31cXFwiO1xuICBzbGVlcCA1O1xuICB1bnRpbCBtYyBhbGlhcyBzZXQgbWluaW8gaHR0cDovL21pbmlvOjkwMDAgXFwkJHtNSU5JT19ST09UX1VTRVJ9IFxcJCR7TUlOSU9fUk9PVF9QQVNTV09SRH07IGRvXG4gICAgZWNobyAnV2FpdGluZyBmb3IgTWluSU8uLi4nO1xuICAgIHNsZWVwIDI7XG4gIGRvbmU7XG4gIG1jIGFkbWluIGNvbmZpZyBzZXQgbWluaW8gYXBpIGNvcnNfYWxsb3dfb3JpZ2luPSckTUlOSU9fQ09SU19VUkxTJyB8fCB0cnVlO1xuICBtYyBtYiBtaW5pby9iMi1ldS1jZW4gLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIG1jIG1iIG1pbmlvL3dhc2FiaS1ldS1jZW50cmFsLTItdjMgLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIG1jIG1iIG1pbmlvL3Njdy1ldS1mci12MyAtLWlnbm9yZS1leGlzdGluZztcbiAgZWNobyAnTWluSU8gYnVja2V0cyBhbmQgQ09SUyBjb25maWd1cmVkJztcblwiIgo=",
-        "tags": [
-            "photos",
-            "gallery",
-            "backup",
-            "encryption",
-            "privacy",
-            "self-hosted",
-            "google-photos",
-            "alternative"
-        ],
-        "category": "media",
-        "logo": "svgs/ente-photos.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-10-22T16:05:17+02:00",
-        "port": "8080"
-    },
     "ente-photos": {
         "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
         "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
@@ -1328,6 +1325,26 @@
         "logo": "svgs/ente-photos.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-03-02T12:00:19+01:00",
+        "port": "8080"
+    },
+    "ente-photos-with-s3": {
+        "documentation": "https://help.ente.io/self-hosting/installation/compose?utm_source=coolify.io",
+        "slogan": "Ente Photos is a fully open source, End to End Encrypted alternative to Google Photos and Apple Photos.",
+        "compose": "c2VydmljZXM6CiAgbXVzZXVtOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vc2VydmVyOjYxM2M2YTk2MzkwZDdhNjI0Y2YzMGI5NDY5NTU3MDVkNjMyNDIzY2MnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTVVTRVVNXzgwODAKICAgICAgLSBFTlRFX0RCX0hPU1Q9cG9zdGdyZXMKICAgICAgLSBFTlRFX0RCX1BPUlQ9NTQzMgogICAgICAtICdFTlRFX0RCX05BTUU9JHtQT1NUR1JFU19EQjotZW50ZV9kYn0nCiAgICAgIC0gJ0VOVEVfREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU30nCiAgICAgIC0gJ0VOVEVfREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTfScKICAgICAgLSAnRU5URV9IVFRQX1VTRV9UTFM9JHtFTlRFX0hUVFBfVVNFX1RMUzotZmFsc2V9JwogICAgICAtIEVOVEVfUzNfQVJFX0xPQ0FMX0JVQ0tFVFM9ZmFsc2UKICAgICAgLSBFTlRFX1MzX1VTRV9QQVRIX1NUWUxFX1VSTFM9dHJ1ZQogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9LRVk9JHtTRVJWSUNFX1VTRVJfTUlOSU99JwogICAgICAtICdFTlRFX1MzX0IyX0VVX0NFTl9TRUNSRVQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnRU5URV9TM19CMl9FVV9DRU5fRU5EUE9JTlQ9JHtTRVJWSUNFX0ZRRE5fTUlOSU9fOTAwMH0nCiAgICAgIC0gRU5URV9TM19CMl9FVV9DRU5fUkVHSU9OPWV1LWNlbnRyYWwtMgogICAgICAtIEVOVEVfUzNfQjJfRVVfQ0VOX0JVQ0tFVD1iMi1ldS1jZW4KICAgICAgLSAnRU5URV9LRVlfRU5DUllQVElPTj0ke1NFUlZJQ0VfUkVBTEJBU0U2NF9FTkNSWVBUSU9OfScKICAgICAgLSAnRU5URV9LRVlfSEFTSD0ke1NFUlZJQ0VfUkVBTEJBU0U2NF82NF9IQVNIfScKICAgICAgLSAnRU5URV9KV1RfU0VDUkVUPSR7U0VSVklDRV9SRUFMQkFTRTY0X0pXVH0nCiAgICAgIC0gJ0VOVEVfSU5URVJOQUxfQURNSU49JHtFTlRFX0lOVEVSTkFMX0FETUlOOi0xNTgwNTU5OTYyMzg2NDM4fScKICAgICAgLSAnRU5URV9JTlRFUk5BTF9ESVNBQkxFX1JFR0lTVFJBVElPTj0ke0VOVEVfSU5URVJOQUxfRElTQUJMRV9SRUdJU1RSQVRJT046LWZhbHNlfScKICAgICAgLSAnRU5URV9TTVRQX0hPU1Q9JHtFTlRFX1NNVFBfSE9TVDotc210cC5nbWFpbC5jb219JwogICAgICAtICdFTlRFX1NNVFBfUE9SVD0ke0VOVEVfU01UUF9QT1JUOi01ODd9JwogICAgICAtICdFTlRFX1NNVFBfVVNFUk5BTUU9JHtFTlRFX1NNVFBfVVNFUk5BTUV9JwogICAgICAtICdFTlRFX1NNVFBfUEFTU1dPUkQ9JHtFTlRFX1NNVFBfUEFTU1dPUkR9JwogICAgICAtICdFTlRFX1NNVFBfRU1BSUw9JHtFTlRFX1NNVFBfRU1BSUx9JwogICAgICAtICdFTlRFX1NNVFBfU0VOREVSX05BTUU9JHtFTlRFX1NNVFBfU0VOREVSX05BTUV9JwogICAgICAtICdFTlRFX1NNVFBfRU5DUllQVElPTj0ke0VOVEVfU01UUF9FTkNSWVBUSU9OOi10bHN9JwogICAgdm9sdW1lczoKICAgICAgLSAnbXVzZXVtLWRhdGE6L2RhdGEnCiAgICAgIC0gJ211c2V1bS1jb25maWc6L2NvbmZpZycKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIG1pbmlvOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9zdGFydGVkCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MC9waW5nJwogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAzCiAgd2ViOgogICAgaW1hZ2U6ICdnaGNyLmlvL2VudGUtaW8vd2ViOmNhMDMxNjVmNWU3ZjJhNTAxMDVlNmU0MDAxOWMxN2FlNmNkZDkzNGYnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fV0VCXzMwMDAKICAgICAgLSAnRU5URV9BUElfT1JJR0lOPSR7U0VSVklDRV9GUUROX01VU0VVTX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy0tZmFpbCcKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjMwMDAnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMKICBwb3N0Z3JlczoKICAgIGltYWdlOiAncG9zdGdyZXM6MTUtYWxwaW5lJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Bvc3RncmVzLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfSAtZCAke1BPU1RHUkVTX0RCOi1lbnRlX2RifScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgbWluaW86CiAgICBpbWFnZTogJ2doY3IuaW8vY29vbGxhYnNpby9taW5pbzpSRUxFQVNFLjIwMjUtMTAtMTVUMTctMjktNTVaJwogICAgY29tbWFuZDogJ3NlcnZlciAvZGF0YSAtLWNvbnNvbGUtYWRkcmVzcyAiOjkwMDEiJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTUlOSU9fU0VSVkVSX1VSTD0kTUlOSU9fU0VSVkVSX1VSTAogICAgICAtIE1JTklPX0JST1dTRVJfUkVESVJFQ1RfVVJMPSRNSU5JT19CUk9XU0VSX1JFRElSRUNUX1VSTAogICAgICAtIE1JTklPX1JPT1RfVVNFUj0kU0VSVklDRV9VU0VSX01JTklPCiAgICAgIC0gTUlOSU9fUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NSU5JTwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpSRUxFQVNFLjIwMjUtMDgtMTNUMDgtMzUtNDFaJwogICAgZGVwZW5kc19vbjoKICAgICAgbWluaW86CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX3N0YXJ0ZWQKICAgIHJlc3RhcnQ6IG9uLWZhaWx1cmUKICAgIGV4Y2x1ZGVfZnJvbV9oYzogdHJ1ZQogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ01JTklPX1JPT1RfVVNFUj0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ01JTklPX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfScKICAgICAgLSAnTUlOSU9fQ09SU19VUkxTPSRTRVJWSUNFX0ZRRE5fTVVTRVVNLCRTRVJWSUNFX0ZRRE5fV0VCJwogICAgZW50cnlwb2ludDogIi9iaW4vc2ggLWMgXCJcbiAgZWNobyBcXFwiTUlOSU9fQ09SU19VUkxTOiBcXCQke01JTklPX0NPUlNfVVJMU31cXFwiO1xuICBzbGVlcCA1O1xuICB1bnRpbCBtYyBhbGlhcyBzZXQgbWluaW8gaHR0cDovL21pbmlvOjkwMDAgXFwkJHtNSU5JT19ST09UX1VTRVJ9IFxcJCR7TUlOSU9fUk9PVF9QQVNTV09SRH07IGRvXG4gICAgZWNobyAnV2FpdGluZyBmb3IgTWluSU8uLi4nO1xuICAgIHNsZWVwIDI7XG4gIGRvbmU7XG4gIG1jIGFkbWluIGNvbmZpZyBzZXQgbWluaW8gYXBpIGNvcnNfYWxsb3dfb3JpZ2luPSckTUlOSU9fQ09SU19VUkxTJyB8fCB0cnVlO1xuICBtYyBtYiBtaW5pby9iMi1ldS1jZW4gLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIG1jIG1iIG1pbmlvL3dhc2FiaS1ldS1jZW50cmFsLTItdjMgLS1pZ25vcmUtZXhpc3Rpbmc7XG4gIG1jIG1iIG1pbmlvL3Njdy1ldS1mci12MyAtLWlnbm9yZS1leGlzdGluZztcbiAgZWNobyAnTWluSU8gYnVja2V0cyBhbmQgQ09SUyBjb25maWd1cmVkJztcblwiIgo=",
+        "tags": [
+            "photos",
+            "gallery",
+            "backup",
+            "encryption",
+            "privacy",
+            "self-hosted",
+            "google-photos",
+            "alternative"
+        ],
+        "category": "media",
+        "logo": "svgs/ente-photos.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-10-22T16:05:17+02:00",
         "port": "8080"
     },
     "esphome": {
@@ -1546,6 +1563,32 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
+    "flowise": {
+        "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
+        "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents.",
+        "compose": "c2VydmljZXM6CiAgZmxvd2lzZToKICAgIGltYWdlOiAnZmxvd2lzZWFpL2Zsb3dpc2U6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0ZMT1dJU0VfMzAwMQogICAgICAtICdERUJVRz0ke0RFQlVHOi1mYWxzZX0nCiAgICAgIC0gJ0RJU0FCTEVfRkxPV0lTRV9URUxFTUVUUlk9JHtESVNBQkxFX0ZMT1dJU0VfVEVMRU1FVFJZOi10cnVlfScKICAgICAgLSAnUE9SVD0ke1BPUlQ6LTMwMDF9JwogICAgICAtIERBVEFCQVNFX1BBVEg9L3Jvb3QvLmZsb3dpc2UKICAgICAgLSBBUElLRVlfUEFUSD0vcm9vdC8uZmxvd2lzZQogICAgICAtIFNFQ1JFVEtFWV9QQVRIPS9yb290Ly5mbG93aXNlCiAgICAgIC0gTE9HX1BBVEg9L3Jvb3QvLmZsb3dpc2UvbG9ncwogICAgICAtIEJMT0JfU1RPUkFHRV9QQVRIPS9yb290Ly5mbG93aXNlL3N0b3JhZ2UKICAgICAgLSAnRkxPV0lTRV9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9GTE9XSVNFfScKICAgICAgLSAnRkxPV0lTRV9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfRkxPV0lTRX0nCiAgICB2b2x1bWVzOgogICAgICAtICdmbG93aXNlLWRhdGE6L3Jvb3QvLmZsb3dpc2UnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjMwMDEgfHwgZXhpdCAxJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwo=",
+        "tags": [
+            "lowcode",
+            "nocode",
+            "ai",
+            "llm",
+            "openai",
+            "anthropic",
+            "machine-learning",
+            "rag",
+            "agents",
+            "chatbot",
+            "api",
+            "team",
+            "bot",
+            "flows"
+        ],
+        "category": "ai",
+        "logo": "svgs/flowise.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3001"
+    },
     "flowise-with-databases": {
         "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
         "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents. Also deploys Redis, Postgres and other services.",
@@ -1572,31 +1615,22 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3001"
     },
-    "flowise": {
-        "documentation": "https://docs.flowiseai.com/?utm_source=coolify.io",
-        "slogan": "Flowise is an open source low-code tool for developers to build customized LLM orchestration flows & AI agents.",
-        "compose": "c2VydmljZXM6CiAgZmxvd2lzZToKICAgIGltYWdlOiAnZmxvd2lzZWFpL2Zsb3dpc2U6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX0ZMT1dJU0VfMzAwMQogICAgICAtICdERUJVRz0ke0RFQlVHOi1mYWxzZX0nCiAgICAgIC0gJ0RJU0FCTEVfRkxPV0lTRV9URUxFTUVUUlk9JHtESVNBQkxFX0ZMT1dJU0VfVEVMRU1FVFJZOi10cnVlfScKICAgICAgLSAnUE9SVD0ke1BPUlQ6LTMwMDF9JwogICAgICAtIERBVEFCQVNFX1BBVEg9L3Jvb3QvLmZsb3dpc2UKICAgICAgLSBBUElLRVlfUEFUSD0vcm9vdC8uZmxvd2lzZQogICAgICAtIFNFQ1JFVEtFWV9QQVRIPS9yb290Ly5mbG93aXNlCiAgICAgIC0gTE9HX1BBVEg9L3Jvb3QvLmZsb3dpc2UvbG9ncwogICAgICAtIEJMT0JfU1RPUkFHRV9QQVRIPS9yb290Ly5mbG93aXNlL3N0b3JhZ2UKICAgICAgLSAnRkxPV0lTRV9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9GTE9XSVNFfScKICAgICAgLSAnRkxPV0lTRV9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfRkxPV0lTRX0nCiAgICB2b2x1bWVzOgogICAgICAtICdmbG93aXNlLWRhdGE6L3Jvb3QvLmZsb3dpc2UnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjMwMDEgfHwgZXhpdCAxJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwo=",
+    "forgejo": {
+        "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
+        "slogan": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
+        "compose": "c2VydmljZXM6CiAgZm9yZ2VqbzoKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2Zvcmdlam8vZm9yZ2VqbzoxNScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GT1JHRUpPXzMwMDAKICAgICAgLSAnRk9SR0VKT19fc2VydmVyX19ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9GT1JHRUpPfScKICAgICAgLSAnRk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dFRF9ET01BSU5TPSR7Rk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dFRF9ET01BSU5TfScKICAgICAgLSAnRk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dfTE9DQUxORVRXT1JLUz0ke0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XX0xPQ0FMTkVUV09SS1MtZmFsc2V9JwogICAgICAtIFVTRVJfVUlEPTEwMDAKICAgICAgLSBVU0VSX0dJRD0xMDAwCiAgICBwb3J0czoKICAgICAgLSAnMjIyMjI6MjInCiAgICB2b2x1bWVzOgogICAgICAtICdmb3JnZWpvLWRhdGE6L2RhdGEnCiAgICAgIC0gJ2Zvcmdlam8tdGltZXpvbmU6L2V0Yy90aW1lem9uZTpybycKICAgICAgLSAnZm9yZ2Vqby1sb2NhbHRpbWU6L2V0Yy9sb2NhbHRpbWU6cm8nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
         "tags": [
-            "lowcode",
-            "nocode",
-            "ai",
-            "llm",
-            "openai",
-            "anthropic",
-            "machine-learning",
-            "rag",
-            "agents",
-            "chatbot",
-            "api",
-            "team",
-            "bot",
-            "flows"
+            "version control",
+            "collaboration",
+            "code",
+            "hosting",
+            "lightweight"
         ],
-        "category": "ai",
-        "logo": "svgs/flowise.png",
+        "category": "git",
+        "logo": "svgs/forgejo.svg",
         "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3001"
+        "template_last_updated_at": "2026-08-10T11:35:20+02:00",
+        "port": "3000"
     },
     "forgejo-with-mariadb": {
         "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
@@ -1645,23 +1679,6 @@
             "hosting",
             "lightweight",
             "postgresql"
-        ],
-        "category": "git",
-        "logo": "svgs/forgejo.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-08-10T11:35:20+02:00",
-        "port": "3000"
-    },
-    "forgejo": {
-        "documentation": "https://forgejo.org/docs?utm_source=coolify.io",
-        "slogan": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
-        "compose": "c2VydmljZXM6CiAgZm9yZ2VqbzoKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2Zvcmdlam8vZm9yZ2VqbzoxNScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GT1JHRUpPXzMwMDAKICAgICAgLSAnRk9SR0VKT19fc2VydmVyX19ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9GT1JHRUpPfScKICAgICAgLSAnRk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dFRF9ET01BSU5TPSR7Rk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dFRF9ET01BSU5TfScKICAgICAgLSAnRk9SR0VKT19fbWlncmF0aW9uc19fQUxMT1dfTE9DQUxORVRXT1JLUz0ke0ZPUkdFSk9fX21pZ3JhdGlvbnNfX0FMTE9XX0xPQ0FMTkVUV09SS1MtZmFsc2V9JwogICAgICAtIFVTRVJfVUlEPTEwMDAKICAgICAgLSBVU0VSX0dJRD0xMDAwCiAgICBwb3J0czoKICAgICAgLSAnMjIyMjI6MjInCiAgICB2b2x1bWVzOgogICAgICAtICdmb3JnZWpvLWRhdGE6L2RhdGEnCiAgICAgIC0gJ2Zvcmdlam8tdGltZXpvbmU6L2V0Yy90aW1lem9uZTpybycKICAgICAgLSAnZm9yZ2Vqby1sb2NhbHRpbWU6L2V0Yy9sb2NhbHRpbWU6cm8nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMCcKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
-        "tags": [
-            "version control",
-            "collaboration",
-            "code",
-            "hosting",
-            "lightweight"
         ],
         "category": "git",
         "logo": "svgs/forgejo.svg",
@@ -1718,6 +1735,20 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
+    "freshrss": {
+        "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
+        "slogan": "A free, self-hostable feed aggregator.",
+        "compose": "c2VydmljZXM6CiAgZnJlc2hyc3M6CiAgICBpbWFnZTogJ2ZyZXNocnNzL2ZyZXNocnNzOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GUkVTSFJTU184MAogICAgICAtICdDUk9OX01JTj0ke0NST05fTUlOOi0xLDMxfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ZyZXNocnNzLWRhdGE6L3Zhci93d3cvRnJlc2hSU1MvZGF0YScKICAgICAgLSAnZnJlc2hyc3MtZXh0ZW5zaW9uczovdmFyL3d3dy9GcmVzaFJTUy9leHRlbnNpb25zJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc6PiAvZGV2L3RjcC8xMjcuMC4wLjEvODAnIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAzCg==",
+        "tags": [
+            "rss",
+            "feed"
+        ],
+        "category": "RSS",
+        "logo": "svgs/freshrss.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "80"
+    },
     "freshrss-with-mariadb": {
         "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
         "slogan": "A free, self-hostable feed aggregator.",
@@ -1760,20 +1791,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "freshrss": {
-        "documentation": "https://freshrss.org/index.html?utm_source=coolify.io",
-        "slogan": "A free, self-hostable feed aggregator.",
-        "compose": "c2VydmljZXM6CiAgZnJlc2hyc3M6CiAgICBpbWFnZTogJ2ZyZXNocnNzL2ZyZXNocnNzOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GUkVTSFJTU184MAogICAgICAtICdDUk9OX01JTj0ke0NST05fTUlOOi0xLDMxfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ZyZXNocnNzLWRhdGE6L3Zhci93d3cvRnJlc2hSU1MvZGF0YScKICAgICAgLSAnZnJlc2hyc3MtZXh0ZW5zaW9uczovdmFyL3d3dy9GcmVzaFJTUy9leHRlbnNpb25zJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc6PiAvZGV2L3RjcC8xMjcuMC4wLjEvODAnIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAzCg==",
-        "tags": [
-            "rss",
-            "feed"
-        ],
-        "category": "RSS",
-        "logo": "svgs/freshrss.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "80"
-    },
     "garage": {
         "documentation": "https://garagehq.deuxfleurs.fr/documentation/?utm_source=coolify.io",
         "slogan": "Garage is an S3-compatible distributed object storage service designed for self-hosting.",
@@ -1794,7 +1811,7 @@
     },
     "getoutline": {
         "documentation": "https://docs.getoutline.com/s/hosting/doc/hosting-outline-nipGaCRBDu?utm_source=coolify.io",
-        "slogan": "Your team\u2019s knowledge base",
+        "slogan": "Your team’s knowledge base",
         "compose": "c2VydmljZXM6CiAgb3V0bGluZToKICAgIGltYWdlOiAnZG9ja2VyLmdldG91dGxpbmUuY29tL291dGxpbmV3aWtpL291dGxpbmU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc3RvcmFnZS1kYXRhOi92YXIvbGliL291dGxpbmUvZGF0YScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIHJlZGlzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fT1VUTElORV8zMDAwCiAgICAgIC0gTk9ERV9FTlY9cHJvZHVjdGlvbgogICAgICAtICdTRUNSRVRfS0VZPSR7U0VSVklDRV9IRVhfNjRfT1VUTElORX0nCiAgICAgIC0gJ1VUSUxTX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfT1VUTElORX0nCiAgICAgIC0gJ0RBVEFCQVNFX1VSTD1wb3N0Z3JlczovLyR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfToke1NFUlZJQ0VfUEFTU1dPUkRfNjRfUE9TVEdSRVN9QHBvc3RncmVzOjU0MzIvJHtQT1NUR1JFU19EQVRBQkFTRTotb3V0bGluZX0nCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovLzoke1NFUlZJQ0VfUEFTU1dPUkRfNjRfUkVESVN9QHJlZGlzOjYzNzknCiAgICAgIC0gJ1VSTD0ke1NFUlZJQ0VfRlFETl9PVVRMSU5FfScKICAgICAgLSAnUE9SVD0ke09VVExJTkVfUE9SVDotMzAwMH0nCiAgICAgIC0gJ0ZJTEVfU1RPUkFHRT0ke0ZJTEVfU1RPUkFHRTotbG9jYWx9JwogICAgICAtICdGSUxFX1NUT1JBR0VfTE9DQUxfUk9PVF9ESVI9JHtGSUxFX1NUT1JBR0VfTE9DQUxfUk9PVF9ESVI6LS92YXIvbGliL291dGxpbmUvZGF0YX0nCiAgICAgIC0gJ0ZJTEVfU1RPUkFHRV9VUExPQURfTUFYX1NJWkU9JHtGSUxFX1NUT1JBR0VfVVBMT0FEX01BWF9TSVpFOi0yMDAwfScKICAgICAgLSAnRklMRV9TVE9SQUdFX0lNUE9SVF9NQVhfU0laRT0ke0ZJTEVfU1RPUkFHRV9JTVBPUlRfTUFYX1NJWkU6LTEwMH0nCiAgICAgIC0gJ0ZJTEVfU1RPUkFHRV9XT1JLU1BBQ0VfSU1QT1JUX01BWF9TSVpFPSR7RklMRV9TVE9SQUdFX1dPUktTUEFDRV9JTVBPUlRfTUFYX1NJWkV9JwogICAgICAtICdBV1NfQUNDRVNTX0tFWV9JRD0ke0FXU19BQ0NFU1NfS0VZX0lEfScKICAgICAgLSAnQVdTX1NFQ1JFVF9BQ0NFU1NfS0VZPSR7QVdTX1NFQ1JFVF9BQ0NFU1NfS0VZfScKICAgICAgLSAnQVdTX1JFR0lPTj0ke0FXU19SRUdJT059JwogICAgICAtICdBV1NfUzNfQUNDRUxFUkFURV9VUkw9JHtBV1NfUzNfQUNDRUxFUkFURV9VUkx9JwogICAgICAtICdBV1NfUzNfVVBMT0FEX0JVQ0tFVF9VUkw9JHtBV1NfUzNfVVBMT0FEX0JVQ0tFVF9VUkx9JwogICAgICAtICdBV1NfUzNfVVBMT0FEX0JVQ0tFVF9OQU1FPSR7QVdTX1MzX1VQTE9BRF9CVUNLRVRfTkFNRX0nCiAgICAgIC0gJ0FXU19TM19GT1JDRV9QQVRIX1NUWUxFPSR7QVdTX1MzX0ZPUkNFX1BBVEhfU1RZTEU6LXRydWV9JwogICAgICAtICdBV1NfUzNfQUNMPSR7QVdTX1MzX0FDTDotcHJpdmF0ZX0nCiAgICAgIC0gJ1NMQUNLX0NMSUVOVF9JRD0ke1NMQUNLX0NMSUVOVF9JRH0nCiAgICAgIC0gJ1NMQUNLX0NMSUVOVF9TRUNSRVQ9JHtTTEFDS19DTElFTlRfU0VDUkVUfScKICAgICAgLSAnR09PR0xFX0NMSUVOVF9JRD0ke0dPT0dMRV9DTElFTlRfSUR9JwogICAgICAtICdHT09HTEVfQ0xJRU5UX1NFQ1JFVD0ke0dPT0dMRV9DTElFTlRfU0VDUkVUfScKICAgICAgLSAnQVpVUkVfQ0xJRU5UX0lEPSR7QVpVUkVfQ0xJRU5UX0lEfScKICAgICAgLSAnQVpVUkVfQ0xJRU5UX1NFQ1JFVD0ke0FaVVJFX0NMSUVOVF9TRUNSRVR9JwogICAgICAtICdBWlVSRV9SRVNPVVJDRV9BUFBfSUQ9JHtBWlVSRV9SRVNPVVJDRV9BUFBfSUR9JwogICAgICAtICdPSURDX0NMSUVOVF9JRD0ke09JRENfQ0xJRU5UX0lEfScKICAgICAgLSAnT0lEQ19DTElFTlRfU0VDUkVUPSR7T0lEQ19DTElFTlRfU0VDUkVUfScKICAgICAgLSAnT0lEQ19BVVRIX1VSST0ke09JRENfQVVUSF9VUkl9JwogICAgICAtICdPSURDX1RPS0VOX1VSST0ke09JRENfVE9LRU5fVVJJfScKICAgICAgLSAnT0lEQ19VU0VSSU5GT19VUkk9JHtPSURDX1VTRVJJTkZPX1VSSX0nCiAgICAgIC0gJ09JRENfTE9HT1VUX1VSST0ke09JRENfTE9HT1VUX1VSSX0nCiAgICAgIC0gJ09JRENfVVNFUk5BTUVfQ0xBSU09JHtPSURDX1VTRVJOQU1FX0NMQUlNfScKICAgICAgLSAnT0lEQ19ESVNQTEFZX05BTUU9JHtPSURDX0RJU1BMQVlfTkFNRX0nCiAgICAgIC0gJ09JRENfU0NPUEVTPSR7T0lEQ19TQ09QRVN9JwogICAgICAtICdHSVRIVUJfQ0xJRU5UX0lEPSR7R0lUSFVCX0NMSUVOVF9JRH0nCiAgICAgIC0gJ0dJVEhVQl9DTElFTlRfU0VDUkVUPSR7R0lUSFVCX0NMSUVOVF9TRUNSRVR9JwogICAgICAtICdHSVRIVUJfQVBQX05BTUU9JHtHSVRIVUJfQVBQX05BTUV9JwogICAgICAtICdHSVRIVUJfQVBQX0lEPSR7R0lUSFVCX0FQUF9JRH0nCiAgICAgIC0gJ0dJVEhVQl9BUFBfUFJJVkFURV9LRVk9JHtHSVRIVUJfQVBQX1BSSVZBVEVfS0VZfScKICAgICAgLSAnRElTQ09SRF9DTElFTlRfSUQ9JHtESVNDT1JEX0NMSUVOVF9JRH0nCiAgICAgIC0gJ0RJU0NPUkRfQ0xJRU5UX1NFQ1JFVD0ke0RJU0NPUkRfQ0xJRU5UX1NFQ1JFVH0nCiAgICAgIC0gJ0RJU0NPUkRfU0VSVkVSX0lEPSR7RElTQ09SRF9TRVJWRVJfSUR9JwogICAgICAtICdESVNDT1JEX1NFUlZFUl9ST0xFUz0ke0RJU0NPUkRfU0VSVkVSX1JPTEVTfScKICAgICAgLSAnUEdTU0xNT0RFPSR7UEdTU0xNT0RFOi1kaXNhYmxlfScKICAgICAgLSAnRk9SQ0VfSFRUUFM9JHtGT1JDRV9IVFRQUzotdHJ1ZX0nCiAgICAgIC0gJ1NNVFBfSE9TVD0ke1NNVFBfSE9TVH0nCiAgICAgIC0gJ1NNVFBfUE9SVD0ke1NNVFBfUE9SVH0nCiAgICAgIC0gJ1NNVFBfVVNFUk5BTUU9JHtTTVRQX1VTRVJOQU1FfScKICAgICAgLSAnU01UUF9QQVNTV09SRD0ke1NNVFBfUEFTU1dPUkR9JwogICAgICAtICdTTVRQX0ZST01fRU1BSUw9JHtTTVRQX0ZST01fRU1BSUx9JwogICAgICAtICdTTVRQX1JFUExZX0VNQUlMPSR7U01UUF9SRVBMWV9FTUFJTH0nCiAgICAgIC0gJ1NNVFBfVExTX0NJUEhFUlM9JHtTTVRQX1RMU19DSVBIRVJTfScKICAgICAgLSAnU01UUF9TRUNVUkU9JHtTTVRQX1NFQ1VSRX0nCiAgICAgIC0gJ1NNVFBfTkFNRT0ke1NNVFBfTkFNRX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgZGlzYWJsZTogdHJ1ZQogIHJlZGlzOgogICAgaW1hZ2U6ICdyZWRpczphbHBpbmUnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnUkVESVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X1JFRElTfScKICAgIGNvbW1hbmQ6CiAgICAgIC0gcmVkaXMtc2VydmVyCiAgICAgIC0gJy0tcmVxdWlyZXBhc3MnCiAgICAgIC0gJyR7U0VSVklDRV9QQVNTV09SRF82NF9SRURJU30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcmVkaXMtY2xpCiAgICAgICAgLSAnLWEnCiAgICAgICAgLSAnJHtTRVJWSUNFX1BBU1NXT1JEXzY0X1JFRElTfScKICAgICAgICAtIFBJTkcKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAzMHMKICAgICAgcmV0cmllczogMwogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxMi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdkYXRhYmFzZS1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X1BPU1RHUkVTfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU19EQVRBQkFTRTotb3V0bGluZX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gcGdfaXNyZWFkeQogICAgICAgIC0gJy1VJwogICAgICAgIC0gJyR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgICAtICctZCcKICAgICAgICAtICcke1BPU1RHUkVTX0RBVEFCQVNFOi1vdXRsaW5lfScKICAgICAgaW50ZXJ2YWw6IDMwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMwo=",
         "tags": [
             "knowledge base",
@@ -1822,6 +1839,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-11-14T23:33:47+05:30",
         "port": "2368"
+    },
+    "gitea": {
+        "documentation": "https://docs.gitea.com?utm_source=coolify.io",
+        "slogan": "Gitea is a self-hosted, lightweight Git service, offering version control, collaboration, and code hosting.",
+        "compose": "c2VydmljZXM6CiAgZ2l0ZWE6CiAgICBpbWFnZTogJ2dpdGVhL2dpdGVhOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HSVRFQV8zMDAwCiAgICAgIC0gVVNFUl9VSUQ9MTAwMAogICAgICAtIFVTRVJfR0lEPTEwMDAKICAgIHBvcnRzOgogICAgICAtICcyMjIyMjoyMicKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dpdGVhLWRhdGE6L2RhdGEnCiAgICAgIC0gJ2dpdGVhLXRpbWV6b25lOi9ldGMvdGltZXpvbmU6cm8nCiAgICAgIC0gJ2dpdGVhLWxvY2FsdGltZTovZXRjL2xvY2FsdGltZTpybycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
+        "tags": [
+            "version control",
+            "collaboration",
+            "code",
+            "hosting",
+            "lightweight"
+        ],
+        "category": "git",
+        "logo": "svgs/gitea.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
     "gitea-runner": {
         "documentation": "https://github.com/go-gitea/gitea?utm_source=coolify.io",
@@ -1883,22 +1916,6 @@
             "hosting",
             "lightweight",
             "postgresql"
-        ],
-        "category": "git",
-        "logo": "svgs/gitea.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00"
-    },
-    "gitea": {
-        "documentation": "https://docs.gitea.com?utm_source=coolify.io",
-        "slogan": "Gitea is a self-hosted, lightweight Git service, offering version control, collaboration, and code hosting.",
-        "compose": "c2VydmljZXM6CiAgZ2l0ZWE6CiAgICBpbWFnZTogJ2dpdGVhL2dpdGVhOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HSVRFQV8zMDAwCiAgICAgIC0gVVNFUl9VSUQ9MTAwMAogICAgICAtIFVTRVJfR0lEPTEwMDAKICAgIHBvcnRzOgogICAgICAtICcyMjIyMjoyMicKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2dpdGVhLWRhdGE6L2RhdGEnCiAgICAgIC0gJ2dpdGVhLXRpbWV6b25lOi9ldGMvdGltZXpvbmU6cm8nCiAgICAgIC0gJ2dpdGVhLWxvY2FsdGltZTovZXRjL2xvY2FsdGltZTpybycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTozMDAwJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
-        "tags": [
-            "version control",
-            "collaboration",
-            "code",
-            "hosting",
-            "lightweight"
         ],
         "category": "git",
         "logo": "svgs/gitea.svg",
@@ -2077,10 +2094,10 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "3000"
     },
-    "grafana-with-postgresql": {
+    "grafana": {
         "documentation": "https://grafana.com?utm_source=coolify.io",
         "slogan": "Grafana is the open source analytics & monitoring solution for every database.",
-        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fR1JBRkFOQV8zMDAwCiAgICAgIC0gJ0dGX1NFUlZFUl9ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VSVkVSX0RPTUFJTj0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VDVVJJVFlfQURNSU5fUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0dSQUZBTkF9JwogICAgICAtIEdGX0RBVEFCQVNFX1RZUEU9cG9zdGdyZXMKICAgICAgLSBHRl9EQVRBQkFTRV9IT1NUPXBvc3RncmVzcWwKICAgICAgLSBHRl9EQVRBQkFTRV9VU0VSPSRTRVJWSUNFX1VTRVJfUE9TVEdSRVMKICAgICAgLSBHRl9EQVRBQkFTRV9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFUwogICAgICAtICdHRl9EQVRBQkFTRV9OQU1FPSR7UE9TVEdSRVNfREI6LWdyYWZhbmF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZ3JhZmFuYS1kYXRhOi92YXIvbGliL2dyYWZhbmEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hcGkvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgICBkZXBlbmRzX29uOgogICAgICAtIHBvc3RncmVzcWwKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdwb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gUE9TVEdSRVNfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gUE9TVEdSRVNfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVMKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU19EQjotZ3JhZmFuYX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fR1JBRkFOQV8zMDAwCiAgICAgIC0gJ0dGX1NFUlZFUl9ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VSVkVSX0RPTUFJTj0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VDVVJJVFlfQURNSU5fUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0dSQUZBTkF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZ3JhZmFuYS1kYXRhOi92YXIvbGliL2dyYWZhbmEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hcGkvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "grafana",
             "analytics",
@@ -2093,10 +2110,10 @@
         "template_last_updated_at": "2026-03-22T22:04:22+07:00",
         "port": "3000"
     },
-    "grafana": {
+    "grafana-with-postgresql": {
         "documentation": "https://grafana.com?utm_source=coolify.io",
         "slogan": "Grafana is the open source analytics & monitoring solution for every database.",
-        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fR1JBRkFOQV8zMDAwCiAgICAgIC0gJ0dGX1NFUlZFUl9ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VSVkVSX0RPTUFJTj0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VDVVJJVFlfQURNSU5fUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0dSQUZBTkF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZ3JhZmFuYS1kYXRhOi92YXIvbGliL2dyYWZhbmEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hcGkvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "compose": "c2VydmljZXM6CiAgZ3JhZmFuYToKICAgIGltYWdlOiBncmFmYW5hL2dyYWZhbmEtb3NzCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fR1JBRkFOQV8zMDAwCiAgICAgIC0gJ0dGX1NFUlZFUl9ST09UX1VSTD0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VSVkVSX0RPTUFJTj0ke1NFUlZJQ0VfRlFETl9HUkFGQU5BfScKICAgICAgLSAnR0ZfU0VDVVJJVFlfQURNSU5fUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0dSQUZBTkF9JwogICAgICAtIEdGX0RBVEFCQVNFX1RZUEU9cG9zdGdyZXMKICAgICAgLSBHRl9EQVRBQkFTRV9IT1NUPXBvc3RncmVzcWwKICAgICAgLSBHRl9EQVRBQkFTRV9VU0VSPSRTRVJWSUNFX1VTRVJfUE9TVEdSRVMKICAgICAgLSBHRl9EQVRBQkFTRV9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFUwogICAgICAtICdHRl9EQVRBQkFTRV9OQU1FPSR7UE9TVEdSRVNfREI6LWdyYWZhbmF9JwogICAgdm9sdW1lczoKICAgICAgLSAnZ3JhZmFuYS1kYXRhOi92YXIvbGliL2dyYWZhbmEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hcGkvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgICBkZXBlbmRzX29uOgogICAgICAtIHBvc3RncmVzcWwKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdwb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gUE9TVEdSRVNfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gUE9TVEdSRVNfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVMKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU19EQjotZ3JhZmFuYX0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "grafana",
             "analytics",
@@ -2225,7 +2242,7 @@
     },
     "hermes-agent-with-webui": {
         "documentation": "https://github.com/nesquena/hermes-webui?utm_source=coolify.io",
-        "slogan": "Hermes Agent \u2014 autonomous AI agent with persistent memory, scheduling, and a self-hosted web chat UI.",
+        "slogan": "Hermes Agent — autonomous AI agent with persistent memory, scheduling, and a self-hosted web chat UI.",
         "compose": "c2VydmljZXM6CiAgaGVybWVzLWFnZW50OgogICAgaW1hZ2U6ICdub3VzcmVzZWFyY2gvaGVybWVzLWFnZW50QHNoYTI1NjoyZjFmMmYxNzI1ZTVkYzlhNjFjZjZhMmRlYTVhY2E1MmE3NzZlYzRkMDIyY2IyOTY3OWU2YWEzZmYzMDNlNzdhJwogICAgY29tbWFuZDogJ2dhdGV3YXkgcnVuJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gSEVSTUVTX0hPTUU9L2hvbWUvaGVybWVzLy5oZXJtZXMKICAgICAgLSBIRVJNRVNfVUlEPTEwMDAKICAgICAgLSBIRVJNRVNfR0lEPTEwMDAKICAgICAgLSAnT1BFTlJPVVRFUl9BUElfS0VZPSR7T1BFTlJPVVRFUl9BUElfS0VZfScKICAgICAgLSAnQU5USFJPUElDX0FQSV9LRVk9JHtBTlRIUk9QSUNfQVBJX0tFWX0nCiAgICAgIC0gJ09QRU5BSV9BUElfS0VZPSR7T1BFTkFJX0FQSV9LRVl9JwogICAgICAtICdHT09HTEVfQVBJX0tFWT0ke0dPT0dMRV9BUElfS0VZfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2hlcm1lcy1ob21lOi9ob21lL2hlcm1lcy8uaGVybWVzJwogICAgICAtICdoZXJtZXMtYWdlbnQtc3JjOi9vcHQvaGVybWVzJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd0ZXN0IC1kIC9ob21lL2hlcm1lcy8uaGVybWVzIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgaGVybWVzLXdlYnVpOgogICAgaW1hZ2U6ICdnaGNyLmlvL25lc3F1ZW5hL2hlcm1lcy13ZWJ1aTowLjUxLjkyJwogICAgZGVwZW5kc19vbjoKICAgICAgLSBoZXJtZXMtYWdlbnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9IRVJNRVNXRUJVSV84Nzg3CiAgICAgIC0gSEVSTUVTX1dFQlVJX0hPU1Q9MC4wLjAuMAogICAgICAtIEhFUk1FU19XRUJVSV9QT1JUPTg3ODcKICAgICAgLSBIRVJNRVNfV0VCVUlfU1RBVEVfRElSPS9ob21lL2hlcm1lc3dlYnVpLy5oZXJtZXMvd2VidWkKICAgICAgLSBXQU5URURfVUlEPTEwMDAKICAgICAgLSBXQU5URURfR0lEPTEwMDAKICAgICAgLSAnSEVSTUVTX1dFQlVJX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9IRVJNRVNXRUJVSX0nCiAgICB2b2x1bWVzOgogICAgICAtICdoZXJtZXMtaG9tZTovaG9tZS9oZXJtZXN3ZWJ1aS8uaGVybWVzJwogICAgICAtICdoZXJtZXMtYWdlbnQtc3JjOi9ob21lL2hlcm1lc3dlYnVpLy5oZXJtZXMvaGVybWVzLWFnZW50OnJvJwogICAgICAtICdoZXJtZXMtd29ya3NwYWNlOi93b3Jrc3BhY2UnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODc4Ny9oZWFsdGgnCiAgICAgIGludGVydmFsOiAzMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwo=",
         "tags": [
             "ai",
@@ -2524,7 +2541,7 @@
     },
     "jitsi": {
         "documentation": "https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/?utm_source=coolify.io",
-        "slogan": "Self-hosted Jitsi Meet \u2014 open-source video conferencing platform",
+        "slogan": "Self-hosted Jitsi Meet — open-source video conferencing platform",
         "compose": "c2VydmljZXM6CiAgaml0c2ktd2ViOgogICAgaW1hZ2U6ICdqaXRzaS93ZWI6c3RhYmxlLTEwODg4JwogICAgcmVzdGFydDogdW5sZXNzLXN0b3BwZWQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9KSVRTSQogICAgICAtIFBVQkxJQ19VUkw9JFNFUlZJQ0VfRlFETl9KSVRTSQogICAgICAtIEVOQUJMRV9BVVRIPTAKICAgICAgLSBFTkFCTEVfR1VFU1RTPTEKICAgICAgLSBFTkFCTEVfTEVUU0VOQ1JZUFQ9MAogICAgICAtIEVOQUJMRV9IVFRQX1JFRElSRUNUPTAKICAgICAgLSBESVNBQkxFX0hUVFBTPTEKICAgICAgLSBYTVBQX0RPTUFJTj1tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9BVVRIX0RPTUFJTj1hdXRoLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX0dVRVNUX0RPTUFJTj1ndWVzdC5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9NVUNfRE9NQUlOPWNvbmZlcmVuY2UubWVldC5qaXRzaQogICAgICAtIFhNUFBfSU5URVJOQUxfTVVDX0RPTUFJTj1pbnRlcm5hbC5hdXRoLm1lZXQuaml0c2kKICAgICAgLSAnWE1QUF9CT1NIX1VSTF9CQVNFPWh0dHA6Ly9wcm9zb2R5OjUyODAnCiAgICAgIC0gSlZCX0JSRVdFUllfTVVDPWp2YmJyZXdlcnkKICAgICAgLSAnSklDT0ZPX0NPTVBPTkVOVF9TRUNSRVQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pJQ09GT30nCiAgICAgIC0gJ0pJQ09GT19BVVRIX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9KSUNPRk99JwogICAgICAtICdKVkJfQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfSlZCfScKICAgICAgLSAnVFo9JHtUWjotVVRDfScKICAgIGRlcGVuZHNfb246CiAgICAgIC0gcHJvc29keQogICAgICAtIGppY29mbwogICAgICAtIGp2YgogICAgdm9sdW1lczoKICAgICAgLSAnaml0c2ktd2ViOi9jb25maWcnCiAgICBuZXR3b3JrczoKICAgICAgbWVldC5qaXRzaToKICAgICAgICBhbGlhc2VzOgogICAgICAgICAgLSBtZWV0LmppdHNpCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3QnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUKICBwcm9zb2R5OgogICAgaW1hZ2U6ICdqaXRzaS9wcm9zb2R5OnN0YWJsZS0xMDg4OCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBBVVRIX1RZUEU9aW50ZXJuYWwKICAgICAgLSBFTkFCTEVfQVVUSD0wCiAgICAgIC0gRU5BQkxFX0dVRVNUUz0xCiAgICAgIC0gWE1QUF9ET01BSU49bWVldC5qaXRzaQogICAgICAtIFhNUFBfQVVUSF9ET01BSU49YXV0aC5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9HVUVTVF9ET01BSU49Z3Vlc3QubWVldC5qaXRzaQogICAgICAtIFhNUFBfTVVDX0RPTUFJTj1jb25mZXJlbmNlLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX0lOVEVSTkFMX01VQ19ET01BSU49aW50ZXJuYWwuYXV0aC5tZWV0LmppdHNpCiAgICAgIC0gJ0pJQ09GT19DT01QT05FTlRfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9KSUNPRk99JwogICAgICAtICdKSUNPRk9fQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfSklDT0ZPfScKICAgICAgLSAnSlZCX0FVVEhfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pWQn0nCiAgICAgIC0gUFVCTElDX1VSTD0kU0VSVklDRV9GUUROX0pJVFNJCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICAgIC0gJ0xPR19MRVZFTD0ke0xPR19MRVZFTDotaW5mb30nCiAgICB2b2x1bWVzOgogICAgICAtICdqaXRzaS1wcm9zb2R5Oi9jb25maWcnCiAgICBuZXR3b3JrczoKICAgICAgbWVldC5qaXRzaToKICAgICAgICBhbGlhc2VzOgogICAgICAgICAgLSB4bXBwLm1lZXQuaml0c2kKICAgICAgICAgIC0gYXV0aC5tZWV0LmppdHNpCiAgICAgICAgICAtIGd1ZXN0Lm1lZXQuaml0c2kKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo1MjgwL2h0dHAtYmluZCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIGppY29mbzoKICAgIGltYWdlOiAnaml0c2kvamljb2ZvOnN0YWJsZS0xMDg4OCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBBVVRIX1RZUEU9aW50ZXJuYWwKICAgICAgLSBFTkFCTEVfQVVUSD0wCiAgICAgIC0gWE1QUF9ET01BSU49bWVldC5qaXRzaQogICAgICAtIFhNUFBfQVVUSF9ET01BSU49YXV0aC5tZWV0LmppdHNpCiAgICAgIC0gWE1QUF9JTlRFUk5BTF9NVUNfRE9NQUlOPWludGVybmFsLmF1dGgubWVldC5qaXRzaQogICAgICAtIFhNUFBfTVVDX0RPTUFJTj1jb25mZXJlbmNlLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX1NFUlZFUj1wcm9zb2R5CiAgICAgIC0gJ0pJQ09GT19DT01QT05FTlRfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9KSUNPRk99JwogICAgICAtICdKSUNPRk9fQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfSklDT0ZPfScKICAgICAgLSBKVkJfQlJFV0VSWV9NVUM9anZiYnJld2VyeQogICAgICAtIEpJQ09GT19FTkFCTEVfSEVBTFRIX0NIRUNLUz0xCiAgICAgIC0gJ1RaPSR7VFo6LVVUQ30nCiAgICBkZXBlbmRzX29uOgogICAgICAtIHByb3NvZHkKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2ppdHNpLWppY29mbzovY29uZmlnJwogICAgbmV0d29ya3M6CiAgICAgIG1lZXQuaml0c2k6IG51bGwKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo4ODg4L2Fib3V0L2hlYWx0aCcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIGp2YjoKICAgIGltYWdlOiAnaml0c2kvanZiOnN0YWJsZS0xMDg4OCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBwb3J0czoKICAgICAgLSAnMTAwMDA6MTAwMDAvdWRwJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gWE1QUF9TRVJWRVI9cHJvc29keQogICAgICAtIFhNUFBfRE9NQUlOPW1lZXQuaml0c2kKICAgICAgLSBYTVBQX0FVVEhfRE9NQUlOPWF1dGgubWVldC5qaXRzaQogICAgICAtIFhNUFBfSU5URVJOQUxfTVVDX0RPTUFJTj1pbnRlcm5hbC5hdXRoLm1lZXQuaml0c2kKICAgICAgLSBYTVBQX01VQ19ET01BSU49Y29uZmVyZW5jZS5tZWV0LmppdHNpCiAgICAgIC0gSlZCX0FVVEhfVVNFUj1qdmIKICAgICAgLSAnSlZCX0FVVEhfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX0pWQn0nCiAgICAgIC0gSlZCX0JSRVdFUllfTVVDPWp2YmJyZXdlcnkKICAgICAgLSBKVkJfUE9SVD0xMDAwMAogICAgICAtICdKVkJfQURWRVJUSVNFX0lQUz0ke0pWQl9BRFZFUlRJU0VfSVBTOi19JwogICAgICAtICdKVkJfU1RVTl9TRVJWRVJTPSR7SlZCX1NUVU5fU0VSVkVSUzotc3R1bi5sLmdvb2dsZS5jb206MTkzMDJ9JwogICAgICAtIFBVQkxJQ19VUkw9JFNFUlZJQ0VfRlFETl9KSVRTSQogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgZGVwZW5kc19vbjoKICAgICAgLSBwcm9zb2R5CiAgICB2b2x1bWVzOgogICAgICAtICdqaXRzaS1qdmI6L2NvbmZpZycKICAgIG5ldHdvcmtzOgogICAgICBtZWV0LmppdHNpOiBudWxsCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9hYm91dC9oZWFsdGgnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUKbmV0d29ya3M6CiAgbWVldC5qaXRzaTogbnVsbAo=",
         "tags": [
             "jitsi",
@@ -2603,10 +2620,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "keycloak-with-postgres": {
+    "keycloak": {
         "documentation": "https://www.keycloak.org?utm_source=coolify.io",
         "slogan": "Keycloak is an open-source Identity and Access Management tool.",
-        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9LRVlDTE9BS184MDgwCiAgICAgIC0gJ1RaPSR7VElNRVpPTkU6LVVUQ30nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9BRE1JTn0nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfQURNSU59JwogICAgICAtIEtDX0RCPXBvc3RncmVzCiAgICAgIC0gJ0tDX0RCX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0RBVEFCQVNFfScKICAgICAgLSAnS0NfREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X0RBVEFCQVNFfScKICAgICAgLSBLQ19EQl9VUkxfUE9SVD01NDMyCiAgICAgIC0gJ0tDX0RCX1VSTD1qZGJjOnBvc3RncmVzcWw6Ly9wb3N0Z3Jlcy8ke1BPU1RHUkVTUUxfREFUQUJBU0U6LWtleWNsb2FrfScKICAgICAgLSAnS0NfSE9TVE5BTUU9JHtTRVJWSUNFX0ZRRE5fS0VZQ0xPQUt9JwogICAgICAtICdLQ19IVFRQX0VOQUJMRUQ9JHtLQ19IVFRQX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19IRUFMVEhfRU5BQkxFRD0ke0tDX0hFQUxUSF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfUFJPWFlfSEVBREVSUz0ke0tDX1BST1hZX0hFQURFUlM6LXhmb3J3YXJkZWR9JwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstZGF0YTovb3B0L2tleWNsb2FrL2RhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJleGVjIDM8Pi9kZXYvdGNwLzEyNy4wLjAuMS85MDAwOyBlY2hvIC1lICdHRVQgL2hlYWx0aC9yZWFkeSBIVFRQLzEuMVxyXG5Ib3N0OiBsb2NhbGhvc3Q6OTAwMFxyXG5Db25uZWN0aW9uOiBjbG9zZVxyXG5cclxuJyA+JjM7Y2F0IDwmMyB8IGdyZXAgLXEgJ1wic3RhdHVzXCI6IFwiVVBcIicgJiYgZXhpdCAwIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdrZXljbG9hay1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfREFUQUJBU0V9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfREFUQUJBU0V9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LWtleWNsb2FrfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9LRVlDTE9BS184MDgwCiAgICAgIC0gJ1RaPSR7VElNRVpPTkU6LVVUQ30nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9BRE1JTn0nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfQURNSU59JwogICAgICAtICdLQ19IT1NUTkFNRT0ke1NFUlZJQ0VfRlFETl9LRVlDTE9BS30nCiAgICAgIC0gJ0tDX0hUVFBfRU5BQkxFRD0ke0tDX0hUVFBfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0tDX0hFQUxUSF9FTkFCTEVEPSR7S0NfSEVBTFRIX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19QUk9YWV9IRUFERVJTPSR7S0NfUFJPWFlfSEVBREVSUzoteGZvcndhcmRlZH0nCiAgICB2b2x1bWVzOgogICAgICAtICdrZXljbG9hay1kYXRhOi9vcHQva2V5Y2xvYWsvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiZXhlYyAzPD4vZGV2L3RjcC8xMjcuMC4wLjEvOTAwMDsgZWNobyAtZSAnR0VUIC9oZWFsdGgvcmVhZHkgSFRUUC8xLjFcclxuSG9zdDogbG9jYWxob3N0OjkwMDBcclxuQ29ubmVjdGlvbjogY2xvc2VcclxuXHJcbicgPiYzO2NhdCA8JjMgfCBncmVwIC1xICdcInN0YXR1c1wiOiBcIlVQXCInICYmIGV4aXQgMCB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "keycloak",
             "identity",
@@ -2632,10 +2649,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8080"
     },
-    "keycloak": {
+    "keycloak-with-postgres": {
         "documentation": "https://www.keycloak.org?utm_source=coolify.io",
         "slogan": "Keycloak is an open-source Identity and Access Management tool.",
-        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9LRVlDTE9BS184MDgwCiAgICAgIC0gJ1RaPSR7VElNRVpPTkU6LVVUQ30nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9BRE1JTn0nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfQURNSU59JwogICAgICAtICdLQ19IT1NUTkFNRT0ke1NFUlZJQ0VfRlFETl9LRVlDTE9BS30nCiAgICAgIC0gJ0tDX0hUVFBfRU5BQkxFRD0ke0tDX0hUVFBfRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ0tDX0hFQUxUSF9FTkFCTEVEPSR7S0NfSEVBTFRIX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19QUk9YWV9IRUFERVJTPSR7S0NfUFJPWFlfSEVBREVSUzoteGZvcndhcmRlZH0nCiAgICB2b2x1bWVzOgogICAgICAtICdrZXljbG9hay1kYXRhOi9vcHQva2V5Y2xvYWsvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAiZXhlYyAzPD4vZGV2L3RjcC8xMjcuMC4wLjEvOTAwMDsgZWNobyAtZSAnR0VUIC9oZWFsdGgvcmVhZHkgSFRUUC8xLjFcclxuSG9zdDogbG9jYWxob3N0OjkwMDBcclxuQ29ubmVjdGlvbjogY2xvc2VcclxuXHJcbicgPiYzO2NhdCA8JjMgfCBncmVwIC1xICdcInN0YXR1c1wiOiBcIlVQXCInICYmIGV4aXQgMCB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAga2V5Y2xvYWs6CiAgICBpbWFnZTogJ3F1YXkuaW8va2V5Y2xvYWsva2V5Y2xvYWs6MjYuMScKICAgIGNvbW1hbmQ6CiAgICAgIC0gc3RhcnQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9LRVlDTE9BS184MDgwCiAgICAgIC0gJ1RaPSR7VElNRVpPTkU6LVVUQ30nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9VU0VSTkFNRT0ke1NFUlZJQ0VfVVNFUl9BRE1JTn0nCiAgICAgIC0gJ0tDX0JPT1RTVFJBUF9BRE1JTl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfQURNSU59JwogICAgICAtIEtDX0RCPXBvc3RncmVzCiAgICAgIC0gJ0tDX0RCX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX0RBVEFCQVNFfScKICAgICAgLSAnS0NfREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X0RBVEFCQVNFfScKICAgICAgLSBLQ19EQl9VUkxfUE9SVD01NDMyCiAgICAgIC0gJ0tDX0RCX1VSTD1qZGJjOnBvc3RncmVzcWw6Ly9wb3N0Z3Jlcy8ke1BPU1RHUkVTUUxfREFUQUJBU0U6LWtleWNsb2FrfScKICAgICAgLSAnS0NfSE9TVE5BTUU9JHtTRVJWSUNFX0ZRRE5fS0VZQ0xPQUt9JwogICAgICAtICdLQ19IVFRQX0VOQUJMRUQ9JHtLQ19IVFRQX0VOQUJMRUQ6LXRydWV9JwogICAgICAtICdLQ19IRUFMVEhfRU5BQkxFRD0ke0tDX0hFQUxUSF9FTkFCTEVEOi10cnVlfScKICAgICAgLSAnS0NfUFJPWFlfSEVBREVSUz0ke0tDX1BST1hZX0hFQURFUlM6LXhmb3J3YXJkZWR9JwogICAgdm9sdW1lczoKICAgICAgLSAna2V5Y2xvYWstZGF0YTovb3B0L2tleWNsb2FrL2RhdGEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJleGVjIDM8Pi9kZXYvdGNwLzEyNy4wLjAuMS85MDAwOyBlY2hvIC1lICdHRVQgL2hlYWx0aC9yZWFkeSBIVFRQLzEuMVxyXG5Ib3N0OiBsb2NhbGhvc3Q6OTAwMFxyXG5Db25uZWN0aW9uOiBjbG9zZVxyXG5cclxuJyA+JjM7Y2F0IDwmMyB8IGdyZXAgLXEgJ1wic3RhdHVzXCI6IFwiVVBcIicgJiYgZXhpdCAwIHx8IGV4aXQgMSIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICdrZXljbG9hay1wb3N0Z3Jlc3FsLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfREFUQUJBU0V9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfREFUQUJBU0V9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTUUxfREFUQUJBU0U6LWtleWNsb2FrfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "keycloak",
             "identity",
@@ -2871,10 +2888,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
-    "linkding-plus": {
+    "linkding": {
         "documentation": "https://linkding.link/?utm_source=coolify.io",
-        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up. (Includes feature for archiving websites as HTML snapshots)",
-        "compose": "c2VydmljZXM6CiAgbGlua2RpbmctcGx1czoKICAgIGltYWdlOiAnc2lzc2JydWVja2VyL2xpbmtkaW5nOmxhdGVzdC1wbHVzJwogICAgdm9sdW1lczoKICAgICAgLSAnbGlua2RpbmdfZGF0YTovZXRjL2xpbmtkaW5nL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTElOS0RJTkdfOTA5MAogICAgICAtICdMRF9TVVBFUlVTRVJfTkFNRT0ke1NFUlZJQ0VfVVNFUl9MSU5LRElOR30nCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTElOS0RJTkd9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc6PiAvZGV2L3RjcC8xMjcuMC4wLjEvOTA5MCcgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMK",
+        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up.",
+        "compose": "c2VydmljZXM6CiAgbGlua2Rpbmc6CiAgICBpbWFnZTogJ3Npc3NicnVlY2tlci9saW5rZGluZzpsYXRlc3QnCiAgICB2b2x1bWVzOgogICAgICAtICdsaW5rZGluZ19kYXRhOi9ldGMvbGlua2RpbmcvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9MSU5LRElOR185MDkwCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9OQU1FPSR7U0VSVklDRV9VU0VSX0xJTktESU5HfScKICAgICAgLSAnTERfU1VQRVJVU0VSX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9MSU5LRElOR30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS85MDkwJyB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwo=",
         "tags": [
             "rss",
             "feed"
@@ -2885,10 +2902,10 @@
         "template_last_updated_at": "2026-01-13T00:05:43+01:00",
         "port": "9090"
     },
-    "linkding": {
+    "linkding-plus": {
         "documentation": "https://linkding.link/?utm_source=coolify.io",
-        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up.",
-        "compose": "c2VydmljZXM6CiAgbGlua2Rpbmc6CiAgICBpbWFnZTogJ3Npc3NicnVlY2tlci9saW5rZGluZzpsYXRlc3QnCiAgICB2b2x1bWVzOgogICAgICAtICdsaW5rZGluZ19kYXRhOi9ldGMvbGlua2RpbmcvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9MSU5LRElOR185MDkwCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9OQU1FPSR7U0VSVklDRV9VU0VSX0xJTktESU5HfScKICAgICAgLSAnTERfU1VQRVJVU0VSX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9MSU5LRElOR30nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gImJhc2ggLWMgJzo+IC9kZXYvdGNwLzEyNy4wLjAuMS85MDkwJyB8fCBleGl0IDEiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwo=",
+        "slogan": "A self-hosted bookmark manager designed to be minimal, fast, and easy to set up. (Includes feature for archiving websites as HTML snapshots)",
+        "compose": "c2VydmljZXM6CiAgbGlua2RpbmctcGx1czoKICAgIGltYWdlOiAnc2lzc2JydWVja2VyL2xpbmtkaW5nOmxhdGVzdC1wbHVzJwogICAgdm9sdW1lczoKICAgICAgLSAnbGlua2RpbmdfZGF0YTovZXRjL2xpbmtkaW5nL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTElOS0RJTkdfOTA5MAogICAgICAtICdMRF9TVVBFUlVTRVJfTkFNRT0ke1NFUlZJQ0VfVVNFUl9MSU5LRElOR30nCiAgICAgIC0gJ0xEX1NVUEVSVVNFUl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTElOS0RJTkd9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc6PiAvZGV2L3RjcC8xMjcuMC4wLjEvOTA5MCcgfHwgZXhpdCAxIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMK",
         "tags": [
             "rss",
             "feed"
@@ -3029,6 +3046,22 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8025"
+    },
+    "marimo": {
+        "documentation": "https://marimo.io/?utm_source=coolify.io",
+        "slogan": "An open-source reactive notebook for Python — reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.",
+        "compose": "c2VydmljZXM6CiAgbWFyaW1vOgogICAgaW1hZ2U6ICdnaGNyLmlvL21hcmltby10ZWFtL21hcmltbzpsYXRlc3Qtc3FsJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX01BUklNT184MDgwCiAgICAgIC0gVE9LRU5fUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfTUFSSU1PCiAgICB2b2x1bWVzOgogICAgICAtICdtYXJpbW86L2FwcCcKICAgIGNvbW1hbmQ6CiAgICAgIC0gbWFyaW1vCiAgICAgIC0gZWRpdAogICAgICAtICctLXRva2VuLXBhc3N3b3JkJwogICAgICAtICcke1NFUlZJQ0VfUEFTU1dPUkRfTUFSSU1PfScKICAgICAgLSAnLS1wb3J0JwogICAgICAtICc4MDgwJwogICAgICAtICctLWhvc3QnCiAgICAgIC0gMC4wLjAuMAogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHV2eAogICAgICAgIC0gJy0td2l0aCcKICAgICAgICAtICdodHRweFtjbGldJwogICAgICAgIC0gaHR0cHgKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwODAvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwo=",
+        "tags": [
+            "notebook",
+            "python",
+            "data",
+            "analysis"
+        ],
+        "category": "devtools",
+        "logo": "svgs/marimo.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8080"
     },
     "martin": {
         "documentation": "https://maplibre.org/martin/introduction.html/?utm_source=coolify.io",
@@ -3283,7 +3316,7 @@
     },
     "moodle": {
         "documentation": "https://moodle.org?utm_source=coolify.io",
-        "slogan": "Moodle is the world\u2019s most customisable and trusted eLearning solution that empowers educators to improve our world.",
+        "slogan": "Moodle is the world’s most customisable and trusted eLearning solution that empowers educators to improve our world.",
         "compose": "c2VydmljZXM6CiAgbWFyaWFkYjoKICAgIGltYWdlOiAnbWFyaWFkYjoxMS4xJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gQUxMT1dfRU1QVFlfUEFTU1dPUkQ9bm8KICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgICAgLSBNWVNRTF9EQVRBQkFTRT1iaXRuYW1pX21vb2RsZQogICAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9NQVJJQURCCiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfTUFSSUFEQgogICAgICAtIE1BUklBREJfQ0hBUkFDVEVSX1NFVD11dGY4bWI0CiAgICAgIC0gTUFSSUFEQl9DT0xMQVRFPXV0ZjhtYjRfdW5pY29kZV9jaQogICAgdm9sdW1lczoKICAgICAgLSAnbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICJiYXNoIC1jICc8L2Rldi90Y3AvbG9jYWxob3N0LzMzMDYnIgogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDUKICBtb29kbGU6CiAgICBpbWFnZTogJ2RvY2tlci5pby9iaXRuYW1pbGVnYWN5L21vb2RsZTo0LjMnCiAgICBkZXBlbmRzX29uOgogICAgICAtIG1hcmlhZGIKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9NT09ETEVfODA4MAogICAgICAtIE1PT0RMRV9EQVRBQkFTRV9IT1NUPW1hcmlhZGIKICAgICAgLSBNT09ETEVfREFUQUJBU0VfUE9SVF9OVU1CRVI9MzMwNgogICAgICAtIE1PT0RMRV9EQVRBQkFTRV9VU0VSPSRTRVJWSUNFX1VTRVJfTUFSSUFEQgogICAgICAtIE1PT0RMRV9EQVRBQkFTRV9OQU1FPWJpdG5hbWlfbW9vZGxlCiAgICAgIC0gTU9PRExFX0RBVEFCQVNFX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX01BUklBREIKICAgICAgLSBBTExPV19FTVBUWV9QQVNTV09SRD1ubwogICAgICAtICdNT09ETEVfVVNFUk5BTUU9JHtNT09ETEVfVVNFUk5BTUU6LXVzZXJ9JwogICAgICAtIE1PT0RMRV9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9NT09ETEUKICAgICAgLSBNT09ETEVfRU1BSUw9dXNlckBleGFtcGxlLmNvbQogICAgICAtICdNT09ETEVfU0lURV9OQU1FPSR7TU9PRExFX1NJVEVfTkFNRTotTmV3IFNpdGV9JwogICAgdm9sdW1lczoKICAgICAgLSAnbW9vZGxlLWRhdGE6L2JpdG5hbWkvbW9vZGxlJwogICAgICAtICdtb29kbGVkYXRhLWRhdGE6L2JpdG5hbWkvbW9vZGxlZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBwaHAKICAgICAgICAtICctcicKICAgICAgICAtICJleGl0KGZpbGVfZXhpc3RzKCcvb3B0L2JpdG5hbWkvbW9vZGxlL2NvbmZpZy5waHAnKSA/IDAgOiAxKTsiCiAgICAgIGludGVydmFsOiAyMHMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDUK",
         "tags": [
             "moodle",
@@ -3317,6 +3350,25 @@
         "template_last_updated_at": "2026-01-05T18:25:15+01:00",
         "port": "1883"
     },
+    "n8n": {
+        "documentation": "https://n8n.io?utm_source=coolify.io",
+        "slogan": "n8n is an extendable workflow automation tool.",
+        "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX044Tl81Njc4CiAgICAgIC0gJ044Tl9FRElUT1JfQkFTRV9VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnV0VCSE9PS19VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX1BST1RPQ09MPSR7TjhOX1BST1RPQ09MOi1odHRwc30nCiAgICAgIC0gJ0dFTkVSSUNfVElNRVpPTkU9JHtHRU5FUklDX1RJTUVaT05FOi1VVEN9JwogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdEQl9TUUxJVEVfUE9PTF9TSVpFPSR7REJfU1FMSVRFX1BPT0xfU0laRTotMn0nCiAgICAgIC0gTjhOX1JVTk5FUlNfRU5BQkxFRD10cnVlCiAgICAgIC0gTjhOX1JVTk5FUlNfTU9ERT1leHRlcm5hbAogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M9JHtOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M6LTAuMC4wLjB9JwogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfUE9SVD0ke044Tl9SVU5ORVJTX0JST0tFUl9QT1JUOi01Njc5fScKICAgICAgLSAnTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfTjhOfScKICAgICAgLSAnTjhOX05BVElWRV9QWVRIT05fUlVOTkVSPSR7TjhOX05BVElWRV9QWVRIT05fUlVOTkVSOi10cnVlfScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgICAgLSAnTjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERT0ke044Tl9CTE9DS19FTlZfQUNDRVNTX0lOX05PREU6LXRydWV9JwogICAgICAtICdOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TPSR7TjhOX0dJVF9OT0RFX0RJU0FCTEVfQkFSRV9SRVBPUzotdHJ1ZX0nCiAgICAgIC0gJ044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM9JHtOOE5fRU5GT1JDRV9TRVRUSU5HU19GSUxFX1BFUk1JU1NJT05TOi10cnVlfScKICAgICAgLSAnTjhOX1BST1hZX0hPUFM9JHtOOE5fUFJPWFlfSE9QUzotMX0nCiAgICAgIC0gJ044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s9JHtOOE5fU0tJUF9BVVRIX09OX09BVVRIX0NBTExCQUNLOi1mYWxzZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduOG4tZGF0YTovaG9tZS9ub2RlLy5uOG4nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2NzgvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHRhc2stcnVubmVyczoKICAgIGltYWdlOiAnbjhuaW8vcnVubmVyczoyLjEwLjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJPSR7TjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJOi1odHRwOi8vbjhuOjU2Nzl9JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRIX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9OOE59JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ9JHtOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ6LTE1fScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgIGRlcGVuZHNfb246CiAgICAgIC0gbjhuCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2ODAvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "n8n",
+            "workflow",
+            "automation",
+            "open",
+            "source",
+            "low",
+            "code"
+        ],
+        "category": "automation",
+        "logo": "svgs/n8n.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-03-30T20:40:07+02:00",
+        "port": "5678"
+    },
     "n8n-with-postgres-and-worker": {
         "documentation": "https://n8n.io?utm_source=coolify.io",
         "slogan": "n8n is an extendable workflow automation tool with queue mode and workers.",
@@ -3343,25 +3395,6 @@
         "documentation": "https://n8n.io?utm_source=coolify.io",
         "slogan": "n8n is an extendable workflow automation tool.",
         "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX044Tl81Njc4CiAgICAgIC0gJ044Tl9FRElUT1JfQkFTRV9VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnV0VCSE9PS19VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX1BST1RPQ09MPSR7TjhOX1BST1RPQ09MOi1odHRwc30nCiAgICAgIC0gJ0dFTkVSSUNfVElNRVpPTkU9JHtHRU5FUklDX1RJTUVaT05FOi1VVEN9JwogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtIERCX1RZUEU9cG9zdGdyZXNkYgogICAgICAtICdEQl9QT1NUR1JFU0RCX0RBVEFCQVNFPSR7UE9TVEdSRVNfREI6LW44bn0nCiAgICAgIC0gREJfUE9TVEdSRVNEQl9IT1NUPXBvc3RncmVzcWwKICAgICAgLSBEQl9QT1NUR1JFU0RCX1BPUlQ9NTQzMgogICAgICAtIERCX1BPU1RHUkVTREJfVVNFUj0kU0VSVklDRV9VU0VSX1BPU1RHUkVTCiAgICAgIC0gREJfUE9TVEdSRVNEQl9TQ0hFTUE9cHVibGljCiAgICAgIC0gREJfUE9TVEdSRVNEQl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9QT1NUR1JFUwogICAgICAtIE44Tl9SVU5ORVJTX0VOQUJMRUQ9dHJ1ZQogICAgICAtIE44Tl9SVU5ORVJTX01PREU9ZXh0ZXJuYWwKICAgICAgLSAnTjhOX1JVTk5FUlNfQlJPS0VSX0xJU1RFTl9BRERSRVNTPSR7TjhOX1JVTk5FUlNfQlJPS0VSX0xJU1RFTl9BRERSRVNTOi0wLjAuMC4wfScKICAgICAgLSAnTjhOX1JVTk5FUlNfQlJPS0VSX1BPUlQ9JHtOOE5fUlVOTkVSU19CUk9LRVJfUE9SVDotNTY3OX0nCiAgICAgIC0gTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0kU0VSVklDRV9QQVNTV09SRF9OOE4KICAgICAgLSAnTjhOX05BVElWRV9QWVRIT05fUlVOTkVSPSR7TjhOX05BVElWRV9QWVRIT05fUlVOTkVSOi10cnVlfScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgICAgLSAnTjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERT0ke044Tl9CTE9DS19FTlZfQUNDRVNTX0lOX05PREU6LXRydWV9JwogICAgICAtICdOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TPSR7TjhOX0dJVF9OT0RFX0RJU0FCTEVfQkFSRV9SRVBPUzotdHJ1ZX0nCiAgICAgIC0gJ044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM9JHtOOE5fRU5GT1JDRV9TRVRUSU5HU19GSUxFX1BFUk1JU1NJT05TOi10cnVlfScKICAgICAgLSAnTjhOX1BST1hZX0hPUFM9JHtOOE5fUFJPWFlfSE9QUzotMX0nCiAgICAgIC0gJ044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s9JHtOOE5fU0tJUF9BVVRIX09OX09BVVRIX0NBTExCQUNLOi1mYWxzZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduOG4tZGF0YTovaG9tZS9ub2RlLy5uOG4nCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3Jlc3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2NzgvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHRhc2stcnVubmVyczoKICAgIGltYWdlOiAnbjhuaW8vcnVubmVyczoyLjEwLjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJPSR7TjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJOi1odHRwOi8vbjhuOjU2Nzl9JwogICAgICAtIE44Tl9SVU5ORVJTX0FVVEhfVE9LRU49JFNFUlZJQ0VfUEFTU1dPUkRfTjhOCiAgICAgIC0gJ044Tl9SVU5ORVJTX0FVVE9fU0hVVERPV05fVElNRU9VVD0ke044Tl9SVU5ORVJTX0FVVE9fU0hVVERPV05fVElNRU9VVDotMTV9JwogICAgICAtICdOOE5fUlVOTkVSU19NQVhfQ09OQ1VSUkVOQ1k9JHtOOE5fUlVOTkVSU19NQVhfQ09OQ1VSUkVOQ1k6LTV9JwogICAgZGVwZW5kc19vbjoKICAgICAgLSBuOG4KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnd2dldCAtcU8tIGh0dHA6Ly8xMjcuMC4wLjE6NTY4MC9oZWFsdGh6JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcG9zdGdyZXNxbDoKICAgIGltYWdlOiAncG9zdGdyZXM6MTYtYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAncG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtIFBPU1RHUkVTX1VTRVI9JFNFUlZJQ0VfVVNFUl9QT1NUR1JFUwogICAgICAtIFBPU1RHUkVTX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNfREI6LW44bn0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
-        "tags": [
-            "n8n",
-            "workflow",
-            "automation",
-            "open",
-            "source",
-            "low",
-            "code"
-        ],
-        "category": "automation",
-        "logo": "svgs/n8n.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-03-30T20:40:07+02:00",
-        "port": "5678"
-    },
-    "n8n": {
-        "documentation": "https://n8n.io?utm_source=coolify.io",
-        "slogan": "n8n is an extendable workflow automation tool.",
-        "compose": "c2VydmljZXM6CiAgbjhuOgogICAgaW1hZ2U6ICduOG5pby9uOG46Mi4xMC4yJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX044Tl81Njc4CiAgICAgIC0gJ044Tl9FRElUT1JfQkFTRV9VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnV0VCSE9PS19VUkw9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX0hPU1Q9JHtTRVJWSUNFX0ZRRE5fTjhOfScKICAgICAgLSAnTjhOX1BST1RPQ09MPSR7TjhOX1BST1RPQ09MOi1odHRwc30nCiAgICAgIC0gJ0dFTkVSSUNfVElNRVpPTkU9JHtHRU5FUklDX1RJTUVaT05FOi1VVEN9JwogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdEQl9TUUxJVEVfUE9PTF9TSVpFPSR7REJfU1FMSVRFX1BPT0xfU0laRTotMn0nCiAgICAgIC0gTjhOX1JVTk5FUlNfRU5BQkxFRD10cnVlCiAgICAgIC0gTjhOX1JVTk5FUlNfTU9ERT1leHRlcm5hbAogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M9JHtOOE5fUlVOTkVSU19CUk9LRVJfTElTVEVOX0FERFJFU1M6LTAuMC4wLjB9JwogICAgICAtICdOOE5fUlVOTkVSU19CUk9LRVJfUE9SVD0ke044Tl9SVU5ORVJTX0JST0tFUl9QT1JUOi01Njc5fScKICAgICAgLSAnTjhOX1JVTk5FUlNfQVVUSF9UT0tFTj0ke1NFUlZJQ0VfUEFTU1dPUkRfTjhOfScKICAgICAgLSAnTjhOX05BVElWRV9QWVRIT05fUlVOTkVSPSR7TjhOX05BVElWRV9QWVRIT05fUlVOTkVSOi10cnVlfScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgICAgLSAnTjhOX0JMT0NLX0VOVl9BQ0NFU1NfSU5fTk9ERT0ke044Tl9CTE9DS19FTlZfQUNDRVNTX0lOX05PREU6LXRydWV9JwogICAgICAtICdOOE5fR0lUX05PREVfRElTQUJMRV9CQVJFX1JFUE9TPSR7TjhOX0dJVF9OT0RFX0RJU0FCTEVfQkFSRV9SRVBPUzotdHJ1ZX0nCiAgICAgIC0gJ044Tl9FTkZPUkNFX1NFVFRJTkdTX0ZJTEVfUEVSTUlTU0lPTlM9JHtOOE5fRU5GT1JDRV9TRVRUSU5HU19GSUxFX1BFUk1JU1NJT05TOi10cnVlfScKICAgICAgLSAnTjhOX1BST1hZX0hPUFM9JHtOOE5fUFJPWFlfSE9QUzotMX0nCiAgICAgIC0gJ044Tl9TS0lQX0FVVEhfT05fT0FVVEhfQ0FMTEJBQ0s9JHtOOE5fU0tJUF9BVVRIX09OX09BVVRIX0NBTExCQUNLOi1mYWxzZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduOG4tZGF0YTovaG9tZS9ub2RlLy5uOG4nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2NzgvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHRhc2stcnVubmVyczoKICAgIGltYWdlOiAnbjhuaW8vcnVubmVyczoyLjEwLjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJPSR7TjhOX1JVTk5FUlNfVEFTS19CUk9LRVJfVVJJOi1odHRwOi8vbjhuOjU2Nzl9JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRIX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9OOE59JwogICAgICAtICdOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ9JHtOOE5fUlVOTkVSU19BVVRPX1NIVVRET1dOX1RJTUVPVVQ6LTE1fScKICAgICAgLSAnTjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZPSR7TjhOX1JVTk5FUlNfTUFYX0NPTkNVUlJFTkNZOi01fScKICAgIGRlcGVuZHNfb246CiAgICAgIC0gbjhuCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLXFPLSBodHRwOi8vMTI3LjAuMC4xOjU2ODAvaGVhbHRoeicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "n8n",
             "workflow",
@@ -3410,7 +3443,7 @@
     },
     "netbird-client": {
         "documentation": "https://docs.netbird.io/how-to/examples#net-bird-client-in-docker?utm_source=coolify.io",
-        "slogan": "Connect your devices into a secure WireGuard\u00ae-based overlay network with SSO, MFA and granular access controls.",
+        "slogan": "Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.",
         "compose": "c2VydmljZXM6CiAgbmV0YmlyZC1jbGllbnQ6CiAgICBpbWFnZTogJ25ldGJpcmRpby9uZXRiaXJkOmxhdGVzdCcKICAgIG5ldHdvcmtfbW9kZTogaG9zdAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ05CX1NFVFVQX0tFWT0ke05CX1NFVFVQX0tFWX0nCiAgICAgIC0gJ05CX0VOQUJMRV9ST1NFTlBBU1M9JHtOQl9FTkFCTEVfUk9TRU5QQVNTOi1mYWxzZX0nCiAgICAgIC0gJ05CX0VOQUJMRV9FWFBFUklNRU5UQUxfTEFaWV9DT05OPSR7TkJfRU5BQkxFX0VYUEVSSU1FTlRBTF9MQVpZX0NPTk46LWZhbHNlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25ldGJpcmQtY2xpZW50Oi92YXIvbGliL25ldGJpcmQnCiAgICBjYXBfYWRkOgogICAgICAtIE5FVF9BRE1JTgogICAgICAtIFNZU19BRE1JTgogICAgICAtIFNZU19SRVNPVVJDRQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIG5ldGJpcmQKICAgICAgICAtIHZlcnNpb24KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "wireguard",
@@ -3472,6 +3505,23 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
+    "nextcloud": {
+        "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
+        "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
+        "compose": "c2VydmljZXM6CiAgbmV4dGNsb3VkOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL25leHRjbG91ZDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTkVYVENMT1VEXzgwCiAgICAgIC0gUFVJRD0xMDAwCiAgICAgIC0gUEdJRD0xMDAwCiAgICAgIC0gJ1RaPSR7VFo6LUV1cm9wZS9NYWRyaWR9JwogICAgdm9sdW1lczoKICAgICAgLSAnbmV4dGNsb3VkLWNvbmZpZzovY29uZmlnJwogICAgICAtICduZXh0Y2xvdWQtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MC9zdGF0dXMucGhwJwogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
+        "tags": [
+            "cloud",
+            "collaboration",
+            "communication",
+            "filestorage",
+            "data"
+        ],
+        "category": "storage",
+        "logo": "svgs/nextcloud.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-07T23:32:57+05:30",
+        "port": "80"
+    },
     "nextcloud-with-mariadb": {
         "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
         "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
@@ -3523,22 +3573,24 @@
         "template_last_updated_at": "2026-04-07T23:32:57+05:30",
         "port": "80"
     },
-    "nextcloud": {
-        "documentation": "https://docs.nextcloud.com?utm_source=coolify.io",
-        "slogan": "NextCloud is a self-hosted, open-source platform that provides file storage, collaboration, and communication tools for seamless data management.",
-        "compose": "c2VydmljZXM6CiAgbmV4dGNsb3VkOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL25leHRjbG91ZDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTkVYVENMT1VEXzgwCiAgICAgIC0gUFVJRD0xMDAwCiAgICAgIC0gUEdJRD0xMDAwCiAgICAgIC0gJ1RaPSR7VFo6LUV1cm9wZS9NYWRyaWR9JwogICAgdm9sdW1lczoKICAgICAgLSAnbmV4dGNsb3VkLWNvbmZpZzovY29uZmlnJwogICAgICAtICduZXh0Y2xvdWQtZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo4MC9zdGF0dXMucGhwJwogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
+    "nexus": {
+        "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
+        "slogan": "Open source Universal Repository Manager (x86_64 version, official), default credentials: admin/admin123",
+        "compose": "c2VydmljZXM6CiAgbmV4dXM6CiAgICBpbWFnZTogc29uYXR5cGUvbmV4dXMzCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ORVhVU184MDgxCiAgICAgIC0gJ05FWFVTX1NFQ1VSSVRZX1JBTkRPTVBBU1NXT1JEPSR7TkVYVVNfU0VDVVJJVFlfUkFORE9NUEFTU1dPUkQ6LWZhbHNlfScKICAgICAgLSAnSU5TVEFMTDRKX0FERF9WTV9QQVJBTVM9LVhtczI3MDNtIC1YbXgyNzAzbSAtWFg6TWF4RGlyZWN0TWVtb3J5U2l6ZT0yNzAzbSAtRGphdmEudXRpbC5wcmVmcy51c2VyUm9vdD0vbmV4dXMtZGF0YS9qYXZhcHJlZnMnCiAgICB2b2x1bWVzOgogICAgICAtICduZXh1c19kYXRhOi9uZXh1cy1kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwODEvc2VydmljZS9yZXN0L3YxL3N0YXR1cycKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMwogICAgICBzdGFydF9wZXJpb2Q6IDYwcwo=",
         "tags": [
-            "cloud",
-            "collaboration",
-            "communication",
-            "filestorage",
-            "data"
+            "repository",
+            "manager",
+            "open source",
+            "docker",
+            "docker",
+            "registry",
+            "container"
         ],
-        "category": "storage",
-        "logo": "svgs/nextcloud.svg",
+        "category": "devtools",
+        "logo": "svgs/nexus.png",
         "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-07T23:32:57+05:30",
-        "port": "80"
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "8081"
     },
     "nexus-arm": {
         "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
@@ -3559,29 +3611,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8081"
     },
-    "nexus": {
-        "documentation": "https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io",
-        "slogan": "Open source Universal Repository Manager (x86_64 version, official), default credentials: admin/admin123",
-        "compose": "c2VydmljZXM6CiAgbmV4dXM6CiAgICBpbWFnZTogc29uYXR5cGUvbmV4dXMzCiAgICBwbGF0Zm9ybTogbGludXgvYW1kNjQKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ORVhVU184MDgxCiAgICAgIC0gJ05FWFVTX1NFQ1VSSVRZX1JBTkRPTVBBU1NXT1JEPSR7TkVYVVNfU0VDVVJJVFlfUkFORE9NUEFTU1dPUkQ6LWZhbHNlfScKICAgICAgLSAnSU5TVEFMTDRKX0FERF9WTV9QQVJBTVM9LVhtczI3MDNtIC1YbXgyNzAzbSAtWFg6TWF4RGlyZWN0TWVtb3J5U2l6ZT0yNzAzbSAtRGphdmEudXRpbC5wcmVmcy51c2VyUm9vdD0vbmV4dXMtZGF0YS9qYXZhcHJlZnMnCiAgICB2b2x1bWVzOgogICAgICAtICduZXh1c19kYXRhOi9uZXh1cy1kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwODEvc2VydmljZS9yZXN0L3YxL3N0YXR1cycKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMwogICAgICBzdGFydF9wZXJpb2Q6IDYwcwo=",
-        "tags": [
-            "repository",
-            "manager",
-            "open source",
-            "docker",
-            "docker",
-            "registry",
-            "container"
-        ],
-        "category": "devtools",
-        "logo": "svgs/nexus.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8081"
-    },
-    "nitropage-with-postgresql": {
+    "nitropage": {
         "documentation": "https://nitropage.org?utm_source=coolify.io",
         "slogan": "Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.",
-        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6IG5pdHJvcGFnZS9uaXRyb3BhZ2UKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9OSVRST1BBR0VfMzAwMAogICAgICAtICdOUF9BVVRIX1NBTFQ9JHtTRVJWSUNFX0JBU0U2NF9TQUxUfScKICAgICAgLSAnTlBfQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfU0VTU0lPTn0nCiAgICAgIC0gJ0RBVEFCQVNFX1VSTD1wb3N0Z3Jlc3FsOi8vJHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH06JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9QHBvc3RncmVzcWw6NTQzMi8ke1BPU1RHUkVTUUxfREFUQUJBU0U6LW5pdHJvcGFnZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduaXRyb3BhZ2UtZGF0YTovYXBwLy5kYXRhJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXNxbDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYWRtaW4nCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICduaXRyb3BhZ2UtcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotbml0cm9wYWdlfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6ICduaXRyb3BhZ2Uvbml0cm9wYWdlOnNxbGl0ZScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9OSVRST1BBR0VfMzAwMAogICAgICAtICdOUF9BVVRIX1NBTFQ9JHtTRVJWSUNFX0JBU0U2NF9TQUxUfScKICAgICAgLSAnTlBfQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfU0VTU0lPTn0nCiAgICAgIC0gJ0RBVEFCQVNFX1VSTD1maWxlOi4uLy5kYXRhL2Rldi5kYicKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1kYXRhOi9hcHAvLmRhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hZG1pbicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
         "tags": [
             "nitropage",
             "builder",
@@ -3597,10 +3630,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
     },
-    "nitropage": {
+    "nitropage-with-postgresql": {
         "documentation": "https://nitropage.org?utm_source=coolify.io",
         "slogan": "Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.",
-        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6ICduaXRyb3BhZ2Uvbml0cm9wYWdlOnNxbGl0ZScKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9OSVRST1BBR0VfMzAwMAogICAgICAtICdOUF9BVVRIX1NBTFQ9JHtTRVJWSUNFX0JBU0U2NF9TQUxUfScKICAgICAgLSAnTlBfQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfU0VTU0lPTn0nCiAgICAgIC0gJ0RBVEFCQVNFX1VSTD1maWxlOi4uLy5kYXRhL2Rldi5kYicKICAgIHZvbHVtZXM6CiAgICAgIC0gJ25pdHJvcGFnZS1kYXRhOi9hcHAvLmRhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6MzAwMC9hZG1pbicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
+        "compose": "c2VydmljZXM6CiAgbml0cm9wYWdlOgogICAgaW1hZ2U6IG5pdHJvcGFnZS9uaXRyb3BhZ2UKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9OSVRST1BBR0VfMzAwMAogICAgICAtICdOUF9BVVRIX1NBTFQ9JHtTRVJWSUNFX0JBU0U2NF9TQUxUfScKICAgICAgLSAnTlBfQVVUSF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfNjRfU0VTU0lPTn0nCiAgICAgIC0gJ0RBVEFCQVNFX1VSTD1wb3N0Z3Jlc3FsOi8vJHtTRVJWSUNFX1VTRVJfUE9TVEdSRVNRTH06JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTUUx9QHBvc3RncmVzcWw6NTQzMi8ke1BPU1RHUkVTUUxfREFUQUJBU0U6LW5pdHJvcGFnZX0nCiAgICB2b2x1bWVzOgogICAgICAtICduaXRyb3BhZ2UtZGF0YTovYXBwLy5kYXRhJwogICAgZGVwZW5kc19vbjoKICAgICAgcG9zdGdyZXNxbDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjMwMDAvYWRtaW4nCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUKICBwb3N0Z3Jlc3FsOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICB2b2x1bWVzOgogICAgICAtICduaXRyb3BhZ2UtcG9zdGdyZXNxbC1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRTotbml0cm9wYWdlfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtVSAkJHtQT1NUR1JFU19VU0VSfSAtZCAkJHtQT1NUR1JFU19EQn0nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
         "tags": [
             "nitropage",
             "builder",
@@ -3847,7 +3880,7 @@
     },
     "openobserve": {
         "documentation": "https://openobserve.ai/docs/?utm_source=coolify.io",
-        "slogan": "Cloud-native observability platform for logs, metrics, traces, RUM, errors and session replays \u2014 a 140x cheaper alternative to Elasticsearch, Splunk and Datadog.",
+        "slogan": "Cloud-native observability platform for logs, metrics, traces, RUM, errors and session replays — a 140x cheaper alternative to Elasticsearch, Splunk and Datadog.",
         "compose": "c2VydmljZXM6CiAgb3Blbm9ic2VydmU6CiAgICBpbWFnZTogJ3B1YmxpYy5lY3IuYXdzL3ppbmNsYWJzL29wZW5vYnNlcnZlOnYwLjkwLjAnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fT1BFTk9CU0VSVkVfNTA4MAogICAgICAtIFpPX0RBVEFfRElSPS9kYXRhCiAgICAgIC0gJ1pPX1JPT1RfVVNFUl9FTUFJTD0ke1pPX1JPT1RfVVNFUl9FTUFJTDotcm9vdEBleGFtcGxlLmNvbX0nCiAgICAgIC0gJ1pPX1JPT1RfVVNFUl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfT1BFTk9CU0VSVkV9JwogICAgICAtICdaT19URUxFTUVUUlk9JHtaT19URUxFTUVUUlk6LWZhbHNlfScKICAgICAgLSAnWk9fQ09PS0lFX1NFQ1VSRV9PTkxZPSR7Wk9fQ09PS0lFX1NFQ1VSRV9PTkxZOi10cnVlfScKICAgIHZvbHVtZXM6CiAgICAgIC0gJ29wZW5vYnNlcnZlLWRhdGE6L2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL29wZW5vYnNlcnZlCiAgICAgICAgLSBub2RlCiAgICAgICAgLSBzdGF0dXMKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogNjBzCg==",
         "tags": [
             "logs",
@@ -4056,24 +4089,6 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "80"
     },
-    "penpot-with-s3": {
-        "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
-        "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
-        "compose": "c2VydmljZXM6CiAgZnJvbnRlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9mcm9udGVuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwZW5wb3QtYmFja2VuZDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtZXhwb3J0ZXI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GUk9OVEVORF84MDgwCiAgICAgIC0gJ1BFTlBPVF9GTEFHUz0ke1BFTlBPVF9CQUNLRU5EX0ZMQUdTOi1lbmFibGUtbG9naW4td2l0aC1wYXNzd29yZH0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MCcKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIHBlbnBvdC1iYWNrZW5kOgogICAgaW1hZ2U6ICdwZW5wb3RhcHAvYmFja2VuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtdmFsa2V5OgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIG1pbmlvLWluaXQ6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2NvbXBsZXRlZF9zdWNjZXNzZnVsbHkKICAgIGVudmlyb25tZW50OgogICAgICAtICdQRU5QT1RfRkxBR1M9JHtQRU5QT1RfQkFDS0VORF9GTEFHUzotZW5hYmxlLWxvZ2luLXdpdGgtcGFzc3dvcmR9JwogICAgICAtIFBFTlBPVF9IVFRQX1NFUlZFUl9QT1JUPTYwNjAKICAgICAgLSAnUEVOUE9UX1NFQ1JFVF9LRVk9JHtTRVJWSUNFX1JFQUxCQVNFNjRfNjRfUEVOUE9UfScKICAgICAgLSAnUEVOUE9UX1BVQkxJQ19VUkk9JHtTRVJWSUNFX0ZRRE5fRlJPTlRFTkRfODA4MH0nCiAgICAgIC0gJ1BFTlBPVF9CQUNLRU5EX1VSST1odHRwOi8vcGVucG90LWJhY2tlbmQnCiAgICAgIC0gJ1BFTlBPVF9FWFBPUlRFUl9VUkk9aHR0cDovL3BlbnBvdC1leHBvcnRlcicKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1VSST1wb3N0Z3Jlc3FsOi8vcG9zdGdyZXMvJHtQT1NUR1JFU19EQjotcGVucG90fScKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICAgIC0gJ1BFTlBPVF9SRURJU19VUkk9cmVkaXM6Ly9wZW5wb3QtdmFsa2V5LzAnCiAgICAgIC0gJ1BFTlBPVF9URUxFTUVUUllfRU5BQkxFRD0ke1BFTlBPVF9URUxFTUVUUllfRU5BQkxFRDotZmFsc2V9JwogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfQkFDS0VORD1zMwogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfUzNfUkVHSU9OPXVzLWVhc3QtMQogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfUzNfQlVDS0VUPXBlbnBvdAogICAgICAtICdQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX0VORFBPSU5UPWh0dHA6Ly9taW5pbzo5MDAwJwogICAgICAtICdBV1NfQUNDRVNTX0tFWV9JRD0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ0FXU19TRUNSRVRfQUNDRVNTX0tFWT0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgICAtICdQRU5QT1RfU01UUF9ERUZBVUxUX0ZST009JHtQRU5QT1RfU01UUF9ERUZBVUxUX0ZST006LW5vLXJlcGx5QGV4YW1wbGUuY29tfScKICAgICAgLSAnUEVOUE9UX1NNVFBfREVGQVVMVF9SRVBMWV9UTz0ke1BFTlBPVF9TTVRQX0RFRkFVTFRfUkVQTFlfVE86LW5vLXJlcGx5QGV4YW1wbGUuY29tfScKICAgICAgLSAnUEVOUE9UX1NNVFBfSE9TVD0ke1BFTlBPVF9TTVRQX0hPU1Q6LW1haWxwaXR9JwogICAgICAtICdQRU5QT1RfU01UUF9QT1JUPSR7UEVOUE9UX1NNVFBfUE9SVDotMTAyNX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1VTRVJOQU1FPSR7UEVOUE9UX1NNVFBfVVNFUk5BTUU6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1BBU1NXT1JEPSR7UEVOUE9UX1NNVFBfUEFTU1dPUkQ6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1RMUz0ke1BFTlBPVF9TTVRQX1RMUzotZmFsc2V9JwogICAgICAtICdQRU5QT1RfU01UUF9TU0w9JHtQRU5QT1RfU01UUF9TU0w6LWZhbHNlfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBub2RlCiAgICAgICAgLSAnLWUnCiAgICAgICAgLSAicmVxdWlyZSgnaHR0cCcpLmdldCh7aG9zdDonMTI3LjAuMC4xJywgcG9ydDo2MDYwLCBwYXRoOicvcmVhZHl6J30sIHJlcyA9PiBwcm9jZXNzLmV4aXQocmVzLnN0YXR1c0NvZGU9PT0yMDAgPyAwIDogMSkpLm9uKCdlcnJvcicsICgpID0+IHByb2Nlc3MuZXhpdCgxKSk7IgogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiAxNQogIHBlbnBvdC1leHBvcnRlcjoKICAgIGltYWdlOiAncGVucG90YXBwL2V4cG9ydGVyOjIuMTEuMScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQRU5QT1RfUFVCTElDX1VSST0ke1NFUlZJQ0VfRlFETl9GUk9OVEVORF84MDgwfScKICAgICAgLSAnUEVOUE9UX1JFRElTX1VSST1yZWRpczovL3BlbnBvdC12YWxrZXkvMCcKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo2MDYxL3JlYWR5eicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIG1pbmlvOgogICAgaW1hZ2U6ICdnaGNyLmlvL2Nvb2xsYWJzaW8vbWluaW86UkVMRUFTRS4yMDI1LTEwLTE1VDE3LTI5LTU1WicKICAgIGNvbW1hbmQ6ICdzZXJ2ZXIgL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTUlOSU9fUk9PVF9VU0VSPSR7U0VSVklDRV9VU0VSX01JTklPfScKICAgICAgLSAnTUlOSU9fUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpsYXRlc3QnCiAgICBkZXBlbmRzX29uOgogICAgICBtaW5pbzoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgZW50cnlwb2ludDogInNoIC1jIFwiXG4gIG1jIGFsaWFzIHNldCBsb2NhbCBodHRwOi8vbWluaW86OTAwMCAke1NFUlZJQ0VfVVNFUl9NSU5JT30gJHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfSAmJlxuICBtYyBtYiAtcCBsb2NhbC9wZW5wb3QgfHwgdHJ1ZSAmJlxuICBtYyBhbm9ueW1vdXMgc2V0IHByaXZhdGUgbG9jYWwvcGVucG90XG5cIlxuIgogICAgcmVzdGFydDogJ25vJwogICAgZXhjbHVkZV9mcm9tX2hjOiB0cnVlCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE1JwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXBvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19JTklUREJfQVJHUz0tLWRhdGEtY2hlY2tzdW1zCiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1wZW5wb3R9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBlbnBvdC12YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OC4xJwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXZhbGtleS1kYXRhOi9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1ZBTEtFWV9FWFRSQV9GTEFHUz0tLW1heG1lbW9yeSAxMjhtYiAtLW1heG1lbW9yeS1wb2xpY3kgdm9sYXRpbGUtbGZ1JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd2YWxrZXktY2xpIHBpbmcgfCBncmVwIFBPTkcnCiAgICAgIGludGVydmFsOiAxcwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogM3MKICBtYWlscGl0OgogICAgaW1hZ2U6ICdheGxsZW50L21haWxwaXQ6djEuMjgnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTUFJTFBJVF84MDI1CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL21haWxwaXQKICAgICAgICAtIHJlYWR5egogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
-        "tags": [
-            "penpot",
-            "design",
-            "prototyping",
-            "figma",
-            "open",
-            "source"
-        ],
-        "category": "productivity",
-        "logo": "svgs/penpot.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-11-29T15:56:03+05:30",
-        "port": "8080"
-    },
     "penpot": {
         "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
         "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
@@ -4090,6 +4105,24 @@
         "logo": "svgs/penpot.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-11-29T17:45:19+05:30",
+        "port": "8080"
+    },
+    "penpot-with-s3": {
+        "documentation": "https://help.penpot.app/technical-guide/getting-started/#install-with-docker?utm_source=coolify.io",
+        "slogan": "Penpot is the first Open Source design and prototyping platform for product teams.",
+        "compose": "c2VydmljZXM6CiAgZnJvbnRlbmQ6CiAgICBpbWFnZTogJ3BlbnBvdGFwcC9mcm9udGVuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwZW5wb3QtYmFja2VuZDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtZXhwb3J0ZXI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9GUk9OVEVORF84MDgwCiAgICAgIC0gJ1BFTlBPVF9GTEFHUz0ke1BFTlBPVF9CQUNLRU5EX0ZMQUdTOi1lbmFibGUtbG9naW4td2l0aC1wYXNzd29yZH0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MCcKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIHBlbnBvdC1iYWNrZW5kOgogICAgaW1hZ2U6ICdwZW5wb3RhcHAvYmFja2VuZDoyLjExLjEnCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICBwZW5wb3QtdmFsa2V5OgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIG1pbmlvLWluaXQ6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2NvbXBsZXRlZF9zdWNjZXNzZnVsbHkKICAgIGVudmlyb25tZW50OgogICAgICAtICdQRU5QT1RfRkxBR1M9JHtQRU5QT1RfQkFDS0VORF9GTEFHUzotZW5hYmxlLWxvZ2luLXdpdGgtcGFzc3dvcmR9JwogICAgICAtIFBFTlBPVF9IVFRQX1NFUlZFUl9QT1JUPTYwNjAKICAgICAgLSAnUEVOUE9UX1NFQ1JFVF9LRVk9JHtTRVJWSUNFX1JFQUxCQVNFNjRfNjRfUEVOUE9UfScKICAgICAgLSAnUEVOUE9UX1BVQkxJQ19VUkk9JHtTRVJWSUNFX0ZRRE5fRlJPTlRFTkRfODA4MH0nCiAgICAgIC0gJ1BFTlBPVF9CQUNLRU5EX1VSST1odHRwOi8vcGVucG90LWJhY2tlbmQnCiAgICAgIC0gJ1BFTlBPVF9FWFBPUlRFUl9VUkk9aHR0cDovL3BlbnBvdC1leHBvcnRlcicKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1VSST1wb3N0Z3Jlc3FsOi8vcG9zdGdyZXMvJHtQT1NUR1JFU19EQjotcGVucG90fScKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1VTRVJOQU1FPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnUEVOUE9UX0RBVEFCQVNFX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU30nCiAgICAgIC0gJ1BFTlBPVF9SRURJU19VUkk9cmVkaXM6Ly9wZW5wb3QtdmFsa2V5LzAnCiAgICAgIC0gJ1BFTlBPVF9URUxFTUVUUllfRU5BQkxFRD0ke1BFTlBPVF9URUxFTUVUUllfRU5BQkxFRDotZmFsc2V9JwogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfQkFDS0VORD1zMwogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfUzNfUkVHSU9OPXVzLWVhc3QtMQogICAgICAtIFBFTlBPVF9PQkpFQ1RTX1NUT1JBR0VfUzNfQlVDS0VUPXBlbnBvdAogICAgICAtICdQRU5QT1RfT0JKRUNUU19TVE9SQUdFX1MzX0VORFBPSU5UPWh0dHA6Ly9taW5pbzo5MDAwJwogICAgICAtICdBV1NfQUNDRVNTX0tFWV9JRD0ke1NFUlZJQ0VfVVNFUl9NSU5JT30nCiAgICAgIC0gJ0FXU19TRUNSRVRfQUNDRVNTX0tFWT0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgICAtICdQRU5QT1RfU01UUF9ERUZBVUxUX0ZST009JHtQRU5QT1RfU01UUF9ERUZBVUxUX0ZST006LW5vLXJlcGx5QGV4YW1wbGUuY29tfScKICAgICAgLSAnUEVOUE9UX1NNVFBfREVGQVVMVF9SRVBMWV9UTz0ke1BFTlBPVF9TTVRQX0RFRkFVTFRfUkVQTFlfVE86LW5vLXJlcGx5QGV4YW1wbGUuY29tfScKICAgICAgLSAnUEVOUE9UX1NNVFBfSE9TVD0ke1BFTlBPVF9TTVRQX0hPU1Q6LW1haWxwaXR9JwogICAgICAtICdQRU5QT1RfU01UUF9QT1JUPSR7UEVOUE9UX1NNVFBfUE9SVDotMTAyNX0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1VTRVJOQU1FPSR7UEVOUE9UX1NNVFBfVVNFUk5BTUU6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1BBU1NXT1JEPSR7UEVOUE9UX1NNVFBfUEFTU1dPUkQ6LXBlbnBvdH0nCiAgICAgIC0gJ1BFTlBPVF9TTVRQX1RMUz0ke1BFTlBPVF9TTVRQX1RMUzotZmFsc2V9JwogICAgICAtICdQRU5QT1RfU01UUF9TU0w9JHtQRU5QT1RfU01UUF9TU0w6LWZhbHNlfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBub2RlCiAgICAgICAgLSAnLWUnCiAgICAgICAgLSAicmVxdWlyZSgnaHR0cCcpLmdldCh7aG9zdDonMTI3LjAuMC4xJywgcG9ydDo2MDYwLCBwYXRoOicvcmVhZHl6J30sIHJlcyA9PiBwcm9jZXNzLmV4aXQocmVzLnN0YXR1c0NvZGU9PT0yMDAgPyAwIDogMSkpLm9uKCdlcnJvcicsICgpID0+IHByb2Nlc3MuZXhpdCgxKSk7IgogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDMwcwogICAgICByZXRyaWVzOiAxNQogIHBlbnBvdC1leHBvcnRlcjoKICAgIGltYWdlOiAncGVucG90YXBwL2V4cG9ydGVyOjIuMTEuMScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQRU5QT1RfUFVCTElDX1VSST0ke1NFUlZJQ0VfRlFETl9GUk9OVEVORF84MDgwfScKICAgICAgLSAnUEVOUE9UX1JFRElTX1VSST1yZWRpczovL3BlbnBvdC12YWxrZXkvMCcKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovLzEyNy4wLjAuMTo2MDYxL3JlYWR5eicKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQogIG1pbmlvOgogICAgaW1hZ2U6ICdnaGNyLmlvL2Nvb2xsYWJzaW8vbWluaW86UkVMRUFTRS4yMDI1LTEwLTE1VDE3LTI5LTU1WicKICAgIGNvbW1hbmQ6ICdzZXJ2ZXIgL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnTUlOSU9fUk9PVF9VU0VSPSR7U0VSVklDRV9VU0VSX01JTklPfScKICAgICAgLSAnTUlOSU9fUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTUlOSU99JwogICAgdm9sdW1lczoKICAgICAgLSAnbWluaW8tZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBtYwogICAgICAgIC0gcmVhZHkKICAgICAgICAtIGxvY2FsCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICBtaW5pby1pbml0OgogICAgaW1hZ2U6ICdtaW5pby9tYzpsYXRlc3QnCiAgICBkZXBlbmRzX29uOgogICAgICBtaW5pbzoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgZW50cnlwb2ludDogInNoIC1jIFwiXG4gIG1jIGFsaWFzIHNldCBsb2NhbCBodHRwOi8vbWluaW86OTAwMCAke1NFUlZJQ0VfVVNFUl9NSU5JT30gJHtTRVJWSUNFX1BBU1NXT1JEX01JTklPfSAmJlxuICBtYyBtYiAtcCBsb2NhbC9wZW5wb3QgfHwgdHJ1ZSAmJlxuICBtYyBhbm9ueW1vdXMgc2V0IHByaXZhdGUgbG9jYWwvcGVucG90XG5cIlxuIgogICAgcmVzdGFydDogJ25vJwogICAgZXhjbHVkZV9mcm9tX2hjOiB0cnVlCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE1JwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXBvc3RncmVzcWwtZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBQT1NUR1JFU19JTklUREJfQVJHUz0tLWRhdGEtY2hlY2tzdW1zCiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1wZW5wb3R9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICdwZ19pc3JlYWR5IC1VICQke1BPU1RHUkVTX1VTRVJ9IC1kICQke1BPU1RHUkVTX0RCfScKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIHBlbnBvdC12YWxrZXk6CiAgICBpbWFnZTogJ3ZhbGtleS92YWxrZXk6OC4xJwogICAgdm9sdW1lczoKICAgICAgLSAncGVucG90LXZhbGtleS1kYXRhOi9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1ZBTEtFWV9FWFRSQV9GTEFHUz0tLW1heG1lbW9yeSAxMjhtYiAtLW1heG1lbW9yeS1wb2xpY3kgdm9sYXRpbGUtbGZ1JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQtU0hFTEwKICAgICAgICAtICd2YWxrZXktY2xpIHBpbmcgfCBncmVwIFBPTkcnCiAgICAgIGludGVydmFsOiAxcwogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiA1CiAgICAgIHN0YXJ0X3BlcmlvZDogM3MKICBtYWlscGl0OgogICAgaW1hZ2U6ICdheGxsZW50L21haWxwaXQ6djEuMjgnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fTUFJTFBJVF84MDI1CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gL21haWxwaXQKICAgICAgICAtIHJlYWR5egogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "penpot",
+            "design",
+            "prototyping",
+            "figma",
+            "open",
+            "source"
+        ],
+        "category": "productivity",
+        "logo": "svgs/penpot.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-11-29T15:56:03+05:30",
         "port": "8080"
     },
     "pgadmin": {
@@ -4205,6 +4238,26 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "3000"
     },
+    "pocket-id": {
+        "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
+        "slogan": "A simple and secure OIDC provider with passkey authentication",
+        "compose": "c2VydmljZXM6CiAgcG9ja2V0LWlkOgogICAgaW1hZ2U6ICdnaGNyLmlvL3BvY2tldC1pZC9wb2NrZXQtaWQ6djEuMTMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fUE9DS0VUSURfMTQxMQogICAgICAtICdBUFBfVVJMPSR7U0VSVklDRV9GUUROX1BPQ0tFVElEfScKICAgICAgLSAnVFJVU1RfUFJPWFk9JHtUUlVTVF9QUk9YWTotdHJ1ZX0nCiAgICAgIC0gJ01BWE1JTkRfTElDRU5TRV9LRVk9JHtNQVhNSU5EX0xJQ0VOU0VfS0VZfScKICAgICAgLSAnU01UUF9IT1NUPSR7U01UUF9IT1NUfScKICAgICAgLSAnU01UUF9QT1JUPSR7U01UUF9QT1JUOi01ODd9JwogICAgICAtICdTTVRQX0ZST009JHtTTVRQX0ZST019JwogICAgICAtICdTTVRQX1VTRVI9JHtTTVRQX1VTRVJ9JwogICAgICAtICdTTVRQX1BBU1NXT1JEPSR7U01UUF9QQVNTV09SRH0nCiAgICAgIC0gJ1NNVFBfVExTPSR7U01UUF9UTFM6LXN0YXJ0dGxzfScKICAgICAgLSAnU01UUF9TS0lQX0NFUlRfVkVSSUZZPSR7U01UUF9TS0lQX0NFUlRfVkVSSUZZOi1mYWxzZX0nCiAgICAgIC0gJ0VNQUlMX0xPR0lOX05PVElGSUNBVElPTl9FTkFCTEVEPSR7RU1BSUxfTE9HSU5fTk9USUZJQ0FUSU9OX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSAnRU1BSUxfT05FX1RJTUVfQUNDRVNTX0FTX0FETUlOX0VOQUJMRUQ9JHtFTUFJTF9PTkVfVElNRV9BQ0NFU1NfQVNfQURNSU5fRU5BQkxFRDotZmFsc2V9JwogICAgICAtICdFTUFJTF9BUElfS0VZX0VYUElSQVRJT05fRU5BQkxFRD0ke0VNQUlMX0FQSV9LRVlfRVhQSVJBVElPTl9FTkFCTEVEOi1mYWxzZX0nCiAgICAgIC0gJ1BVSUQ9JHtQVUlEOi0xMDAwfScKICAgICAgLSAnUEdJRD0ke1BHSUQ6LTEwMDB9JwogICAgdm9sdW1lczoKICAgICAgLSAncG9ja2V0LWlkLWRhdGE6L2FwcC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIC9hcHAvcG9ja2V0LWlkCiAgICAgICAgLSBoZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMK",
+        "tags": [
+            "identity",
+            "oidc",
+            "oauth",
+            "passkey",
+            "webauthn",
+            "authentication",
+            "sso",
+            "openid"
+        ],
+        "category": "auth",
+        "logo": "svgs/pocketid-logo.png",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-10-19T21:35:49+02:00",
+        "port": "1411"
+    },
     "pocket-id-with-postgresql": {
         "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
         "slogan": "A simple and secure OIDC provider with passkey authentication",
@@ -4224,26 +4277,6 @@
         "logo": "svgs/pocketid-logo.png",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-10-19T21:35:18+02:00",
-        "port": "1411"
-    },
-    "pocket-id": {
-        "documentation": "https://pocket-id.org/docs/setup/installation?utm_source=coolify.io",
-        "slogan": "A simple and secure OIDC provider with passkey authentication",
-        "compose": "c2VydmljZXM6CiAgcG9ja2V0LWlkOgogICAgaW1hZ2U6ICdnaGNyLmlvL3BvY2tldC1pZC9wb2NrZXQtaWQ6djEuMTMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fUE9DS0VUSURfMTQxMQogICAgICAtICdBUFBfVVJMPSR7U0VSVklDRV9GUUROX1BPQ0tFVElEfScKICAgICAgLSAnVFJVU1RfUFJPWFk9JHtUUlVTVF9QUk9YWTotdHJ1ZX0nCiAgICAgIC0gJ01BWE1JTkRfTElDRU5TRV9LRVk9JHtNQVhNSU5EX0xJQ0VOU0VfS0VZfScKICAgICAgLSAnU01UUF9IT1NUPSR7U01UUF9IT1NUfScKICAgICAgLSAnU01UUF9QT1JUPSR7U01UUF9QT1JUOi01ODd9JwogICAgICAtICdTTVRQX0ZST009JHtTTVRQX0ZST019JwogICAgICAtICdTTVRQX1VTRVI9JHtTTVRQX1VTRVJ9JwogICAgICAtICdTTVRQX1BBU1NXT1JEPSR7U01UUF9QQVNTV09SRH0nCiAgICAgIC0gJ1NNVFBfVExTPSR7U01UUF9UTFM6LXN0YXJ0dGxzfScKICAgICAgLSAnU01UUF9TS0lQX0NFUlRfVkVSSUZZPSR7U01UUF9TS0lQX0NFUlRfVkVSSUZZOi1mYWxzZX0nCiAgICAgIC0gJ0VNQUlMX0xPR0lOX05PVElGSUNBVElPTl9FTkFCTEVEPSR7RU1BSUxfTE9HSU5fTk9USUZJQ0FUSU9OX0VOQUJMRUQ6LWZhbHNlfScKICAgICAgLSAnRU1BSUxfT05FX1RJTUVfQUNDRVNTX0FTX0FETUlOX0VOQUJMRUQ9JHtFTUFJTF9PTkVfVElNRV9BQ0NFU1NfQVNfQURNSU5fRU5BQkxFRDotZmFsc2V9JwogICAgICAtICdFTUFJTF9BUElfS0VZX0VYUElSQVRJT05fRU5BQkxFRD0ke0VNQUlMX0FQSV9LRVlfRVhQSVJBVElPTl9FTkFCTEVEOi1mYWxzZX0nCiAgICAgIC0gJ1BVSUQ9JHtQVUlEOi0xMDAwfScKICAgICAgLSAnUEdJRD0ke1BHSUQ6LTEwMDB9JwogICAgdm9sdW1lczoKICAgICAgLSAncG9ja2V0LWlkLWRhdGE6L2FwcC9kYXRhJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIC9hcHAvcG9ja2V0LWlkCiAgICAgICAgLSBoZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogMzBzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDMKICAgICAgc3RhcnRfcGVyaW9kOiAxMHMK",
-        "tags": [
-            "identity",
-            "oidc",
-            "oauth",
-            "passkey",
-            "webauthn",
-            "authentication",
-            "sso",
-            "openid"
-        ],
-        "category": "auth",
-        "logo": "svgs/pocketid-logo.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-10-19T21:35:49+02:00",
         "port": "1411"
     },
     "pocketbase": {
@@ -4329,7 +4362,7 @@
     },
     "prowlarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/prowlarr?utm_source=coolify.io",
-        "slogan": "Prowlarr\u2060 is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps.",
+        "slogan": "Prowlarr⁠ is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps.",
         "compose": "c2VydmljZXM6CiAgcHJvd2xhcnI6CiAgICBpbWFnZTogJ2xzY3IuaW8vbGludXhzZXJ2ZXIvcHJvd2xhcnI6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX1BST1dMQVJSXzk2OTYKICAgICAgLSBfQVBQX1VSTD0kU0VSVklDRV9GUUROX1BST1dMQVJSCiAgICAgIC0gUFVJRD0xMDAwCiAgICAgIC0gUEdJRD0xMDAwCiAgICAgIC0gJ1RaPSR7VFo6LUFtZXJpY2EvVG9yb250b30nCiAgICB2b2x1bWVzOgogICAgICAtICdwcm93bGFyci1jb25maWc6L2NvbmZpZycKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBjdXJsCiAgICAgICAgLSAnLWYnCiAgICAgICAgLSAnaHR0cDovL2xvY2FsaG9zdDo5Njk2L3BpbmcnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
         "tags": [
             "media",
@@ -4362,9 +4395,22 @@
         "template_last_updated_at": "2026-04-06T11:35:16-05:00",
         "port": "9159"
     },
+    "pydio-cells": {
+        "documentation": "https://docs.pydio.com/?utm_source=coolify.io",
+        "slogan": "High-performance large file sharing, native no-code automation, and a collaboration-centric architecture that simplifies access control without compromising security or compliance.",
+        "compose": "c2VydmljZXM6CiAgY2VsbHM6CiAgICBpbWFnZTogJ3B5ZGlvL2NlbGxzOjQuNCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9DRUxMU184MDgwCiAgICAgIC0gJ0NFTExTX1NJVEVfRVhURVJOQUw9JHtTRVJWSUNFX0ZRRE5fQ0VMTFN9JwogICAgICAtIENFTExTX1NJVEVfTk9fVExTPTEKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2NlbGxzX2RhdGE6L3Zhci9jZWxscycKICBtYXJpYWRiOgogICAgaW1hZ2U6ICdtYXJpYWRiOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnbXlzcWxfZGF0YTovdmFyL2xpYi9teXNxbCcKICAgIGVudmlyb25tZW50OgogICAgICAtICdNWVNRTF9ST09UX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9NWVNRTFJPT1R9JwogICAgICAtICdNWVNRTF9EQVRBQkFTRT0ke01ZU1FMX0RBVEFCQVNFOi1jZWxsc30nCiAgICAgIC0gJ01ZU1FMX1VTRVI9JHtTRVJWSUNFX1VTRVJfTVlTUUx9JwogICAgICAtICdNWVNRTF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTVlTUUx9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGhlYWx0aGNoZWNrLnNoCiAgICAgICAgLSAnLS1jb25uZWN0JwogICAgICAgIC0gJy0taW5ub2RiX2luaXRpYWxpemVkJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiA1Cg==",
+        "tags": [
+            "storage"
+        ],
+        "category": "storage",
+        "logo": "svgs/cells.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "8080"
+    },
     "qbittorrent": {
         "documentation": "https://docs.linuxserver.io/images/docker-qbittorrent/?utm_source=coolify.io",
-        "slogan": "The qBittorrent project aims to provide an open-source software alternative to \u03bcTorrent.",
+        "slogan": "The qBittorrent project aims to provide an open-source software alternative to μTorrent.",
         "compose": "c2VydmljZXM6CiAgcWJpdDoKICAgIGltYWdlOiAnbHNjci5pby9saW51eHNlcnZlci9xYml0dG9ycmVudDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnV0VCVUlfUE9SVD0ke1dFQlVJX1BPUlQ6LTgwODB9JwogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgdm9sdW1lczoKICAgICAgLSAncWJpdHRvcnJlbnQtY29uZmlnOi9jb25maWcnCiAgICAgIC0gJ3FiaXR0b3JyZW50LWRvd25sb2FkczovZG93bmxvYWRzJwogICAgICAtICdxYml0dG9ycmVudC10b3JyZW50czovdG9ycmVudHMnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gd2dldAogICAgICAgIC0gJy1xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODA4MC8nCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKICB2dWV0b3JyZW50LWJhY2tlbmQ6CiAgICBpbWFnZTogJ2doY3IuaW8vdnVldG9ycmVudC92dWV0b3JyZW50LWJhY2tlbmQ6bGF0ZXN0JwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX1FCSVRPUlJFTlRfODA4MAogICAgICAtICdQT1JUPSR7V0VCVUlfUE9SVDotODA4MH0nCiAgICAgIC0gJ1FCSVRfQkFTRT0ke1NFUlZJQ0VfRlFETl9RQklUT1JSRU5UfScKICAgICAgLSAnUkVMRUFTRV9UWVBFPSR7UkVMRUFTRV9UWVBFOi1zdGFibGV9JwogICAgICAtICdVUERBVEVfVlRfQ1JPTj0ke1VQREFURV9WVF9DUk9OOi0iMCAqICogKiAqIn0nCiAgICB2b2x1bWVzOgogICAgICAtICd2dWV0b3JyZW50LWNvbmZpZzovY29uZmlnJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHdnZXQKICAgICAgICAtICctcScKICAgICAgICAtICctLXNwaWRlcicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xOjgwODAvJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "torrent",
@@ -4418,7 +4464,7 @@
     },
     "radarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/radarr?utm_source=coolify.io",
-        "slogan": "Radarr\u2060 - A fork of Sonarr to work with movies \u00e0 la Couchpotato.",
+        "slogan": "Radarr⁠ - A fork of Sonarr to work with movies à la Couchpotato.",
         "compose": "c2VydmljZXM6CiAgcmFkYXJyOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL3JhZGFycjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fUkFEQVJSXzc4NzgKICAgICAgLSBfQVBQX1VSTD0kU0VSVklDRV9GUUROX1JBREFSUgogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgICAtICdUWj0ke1RaOi1BbWVyaWNhL1Rvcm9udG99JwogICAgdm9sdW1lczoKICAgICAgLSAncmFkYXJyLWNvbmZpZzovY29uZmlnJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0Ojc4NzgvcGluZycKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
         "tags": [
             "media",
@@ -4840,22 +4886,6 @@
         "template_last_updated_at": "2025-12-09T00:35:53+03:00",
         "port": "80"
     },
-    "soketi-app-manager": {
-        "documentation": "https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io",
-        "slogan": "Manage soketi websocket server and apps with ease.",
-        "compose": "c2VydmljZXM6CiAgc29rZXRpLWFwcC1tYW5hZ2VyOgogICAgaW1hZ2U6ICdnaGNyLmlvL3JhaHVsaGFxdWUvc29rZXRpLWFwcC1tYW5hZ2VyLWZpbGFtZW50LWFscGluZTpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUl84MDgwCiAgICAgIC0gQVVUT1JVTl9FTkFCTEVEPXRydWUKICAgICAgLSAnQVVUT1JVTl9MQVJBVkVMX01JR1JBVElPTj0ke0FVVE9SVU5fTEFSQVZFTF9NSUdSQVRJT046LXRydWV9JwogICAgICAtICdBUFBfREVCVUc9JHtBUFBfREVCVUc6LWZhbHNlfScKICAgICAgLSBBUFBfVVJMPSRTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUgogICAgICAtIEFQUF9LRVk9JEFQUF9LRVkKICAgICAgLSBEQl9DT05ORUNUSU9OPSREQl9DT05ORUNUSU9OCiAgICAgIC0gREJfSE9TVD0kREJfSE9TVAogICAgICAtIERCX1BPUlQ9JERCX1BPUlQKICAgICAgLSBEQl9EQVRBQkFTRT0kREJfREFUQUJBU0UKICAgICAgLSBEQl9VU0VSTkFNRT0kREJfVVNFUk5BTUUKICAgICAgLSBEQl9QQVNTV09SRD0kREJfUEFTU1dPUkQKICAgICAgLSBQVVNIRVJfSE9TVD0kUFVTSEVSX0hPU1QKICAgICAgLSBQVVNIRVJfUE9SVD0kUFVTSEVSX1BPUlQKICAgICAgLSBQVVNIRVJfU0NIRU1FPSRQVVNIRVJfU0NIRU1FCiAgICAgIC0gUFVTSEVSX0FQUF9DTFVTVEVSPSRQVVNIRVJfQVBQX0NMVVNURVIKICAgICAgLSBTT0tFVElfREJfUkVESVNfVVNFUk5BTUU9JFNPS0VUSV9EQl9SRURJU19VU0VSTkFNRQogICAgICAtIFNPS0VUSV9EQl9SRURJU19QQVNTV09SRD0kU09LRVRJX0RCX1JFRElTX1BBU1NXT1JECiAgICAgIC0gTUVUUklDU19IT1NUPSRNRVRSSUNTX0hPU1QKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBwaHAtZnBtLWhlYWx0aGNoZWNrCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
-        "tags": [
-            "soketi",
-            "websockets",
-            "app-manager",
-            "dashboard"
-        ],
-        "category": "devtools",
-        "logo": "svgs/soketi-app-manager.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "8080"
-    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",
@@ -4872,9 +4902,25 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "6001"
     },
+    "soketi-app-manager": {
+        "documentation": "https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io",
+        "slogan": "Manage soketi websocket server and apps with ease.",
+        "compose": "c2VydmljZXM6CiAgc29rZXRpLWFwcC1tYW5hZ2VyOgogICAgaW1hZ2U6ICdnaGNyLmlvL3JhaHVsaGFxdWUvc29rZXRpLWFwcC1tYW5hZ2VyLWZpbGFtZW50LWFscGluZTpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUl84MDgwCiAgICAgIC0gQVVUT1JVTl9FTkFCTEVEPXRydWUKICAgICAgLSAnQVVUT1JVTl9MQVJBVkVMX01JR1JBVElPTj0ke0FVVE9SVU5fTEFSQVZFTF9NSUdSQVRJT046LXRydWV9JwogICAgICAtICdBUFBfREVCVUc9JHtBUFBfREVCVUc6LWZhbHNlfScKICAgICAgLSBBUFBfVVJMPSRTRVJWSUNFX0ZRRE5fU09LRVRJQVBQTUFOQUdFUgogICAgICAtIEFQUF9LRVk9JEFQUF9LRVkKICAgICAgLSBEQl9DT05ORUNUSU9OPSREQl9DT05ORUNUSU9OCiAgICAgIC0gREJfSE9TVD0kREJfSE9TVAogICAgICAtIERCX1BPUlQ9JERCX1BPUlQKICAgICAgLSBEQl9EQVRBQkFTRT0kREJfREFUQUJBU0UKICAgICAgLSBEQl9VU0VSTkFNRT0kREJfVVNFUk5BTUUKICAgICAgLSBEQl9QQVNTV09SRD0kREJfUEFTU1dPUkQKICAgICAgLSBQVVNIRVJfSE9TVD0kUFVTSEVSX0hPU1QKICAgICAgLSBQVVNIRVJfUE9SVD0kUFVTSEVSX1BPUlQKICAgICAgLSBQVVNIRVJfU0NIRU1FPSRQVVNIRVJfU0NIRU1FCiAgICAgIC0gUFVTSEVSX0FQUF9DTFVTVEVSPSRQVVNIRVJfQVBQX0NMVVNURVIKICAgICAgLSBTT0tFVElfREJfUkVESVNfVVNFUk5BTUU9JFNPS0VUSV9EQl9SRURJU19VU0VSTkFNRQogICAgICAtIFNPS0VUSV9EQl9SRURJU19QQVNTV09SRD0kU09LRVRJX0RCX1JFRElTX1BBU1NXT1JECiAgICAgIC0gTUVUUklDU19IT1NUPSRNRVRSSUNTX0hPU1QKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBwaHAtZnBtLWhlYWx0aGNoZWNrCiAgICAgIHN0YXJ0X3BlcmlvZDogMTBzCg==",
+        "tags": [
+            "soketi",
+            "websockets",
+            "app-manager",
+            "dashboard"
+        ],
+        "category": "devtools",
+        "logo": "svgs/soketi-app-manager.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
+        "port": "8080"
+    },
     "sonarr": {
         "documentation": "https://hub.docker.com/r/linuxserver/sonarr?utm_source=coolify.io",
-        "slogan": "Sonarr\u2060 (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
+        "slogan": "Sonarr⁠ (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
         "compose": "c2VydmljZXM6CiAgc29uYXJyOgogICAgaW1hZ2U6ICdsc2NyLmlvL2xpbnV4c2VydmVyL3NvbmFycjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU09OQVJSXzg5ODkKICAgICAgLSBfQVBQX1VSTD0kU0VSVklDRV9GUUROX1NPTkFSUgogICAgICAtIFBVSUQ9MTAwMAogICAgICAtIFBHSUQ9MTAwMAogICAgICAtICdUWj0ke1RaOi1BbWVyaWNhL1Rvcm9udG99JwogICAgdm9sdW1lczoKICAgICAgLSAnc29uYXJyLWNvbmZpZzovY29uZmlnJwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0Ojg5ODkvcGluZycKICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxNQo=",
         "tags": [
             "media",
@@ -5400,6 +5446,25 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8000"
     },
+    "uptime-kuma": {
+        "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
+        "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
+        "compose": "c2VydmljZXM6CiAgdXB0aW1lLWt1bWE6CiAgICBpbWFnZTogJ2xvdWlzbGFtL3VwdGltZS1rdW1hOjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fVVBUSU1FS1VNQV8zMDAxCiAgICB2b2x1bWVzOgogICAgICAtICd1cHRpbWUta3VtYS1kYXRhOi9hcHAvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSBleHRyYS9oZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "monitoring",
+            "status",
+            "performance",
+            "web",
+            "services",
+            "applications",
+            "real-time"
+        ],
+        "category": "monitoring",
+        "logo": "svgs/uptime-kuma.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2026-01-08T21:10:17+01:00",
+        "port": "3001"
+    },
     "uptime-kuma-with-mariadb": {
         "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
         "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
@@ -5436,25 +5501,6 @@
         "logo": "svgs/uptime-kuma.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2026-01-08T21:10:43+01:00",
-        "port": "3001"
-    },
-    "uptime-kuma": {
-        "documentation": "https://github.com/louislam/uptime-kuma?tab=readme-ov-file?utm_source=coolify.io",
-        "slogan": "Uptime Kuma is a monitoring tool for tracking the status and performance of your applications in real-time.",
-        "compose": "c2VydmljZXM6CiAgdXB0aW1lLWt1bWE6CiAgICBpbWFnZTogJ2xvdWlzbGFtL3VwdGltZS1rdW1hOjInCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fVVBUSU1FS1VNQV8zMDAxCiAgICB2b2x1bWVzOgogICAgICAtICd1cHRpbWUta3VtYS1kYXRhOi9hcHAvZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSBleHRyYS9oZWFsdGhjaGVjawogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAK",
-        "tags": [
-            "monitoring",
-            "status",
-            "performance",
-            "web",
-            "services",
-            "applications",
-            "real-time"
-        ],
-        "category": "monitoring",
-        "logo": "svgs/uptime-kuma.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-01-08T21:10:17+01:00",
         "port": "3001"
     },
     "usesend": {
@@ -5524,6 +5570,20 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "80"
     },
+    "vikunja": {
+        "documentation": "https://vikunja.io?utm_source=coolify.io",
+        "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
+        "compose": "c2VydmljZXM6CiAgdmlrdW5qYToKICAgIGltYWdlOiB2aWt1bmphL3Zpa3VuamEKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9WSUtVTkpBCiAgICAgIC0gVklLVU5KQV9TRVJWSUNFX1BVQkxJQ1VSTD0kU0VSVklDRV9GUUROX1ZJS1VOSkEKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfSldUU0VDUkVUPSRTRVJWSUNFX1BBU1NXT1JEX0pXVFNFQ1JFVAogICAgICAtIFZJS1VOSkFfU0VSVklDRV9FTkFCTEVSRUdJU1RSQVRJT049dHJ1ZQogICAgICAtIFZJS1VOSkFfREFUQUJBU0VfUEFUSD0vZGIvdmlrdW5qYS5kYgogICAgICAtIFZJS1VOSkFfREFUQUJBU0VfVFlQRT1zcWxpdGUKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Zpa3VuamEtZGF0YTovYXBwL3Zpa3VuamEvJwogICAgICAtICd2aWt1bmphLXNxbGl0ZS1kYXRhOi9kYicKICAgIGRlcGVuZHNfb246CiAgICAgIC0gaW5pdAogIGluaXQ6CiAgICBpbWFnZTogYnVzeWJveAogICAgcmVzdGFydDogJ25vJwogICAgdm9sdW1lczoKICAgICAgLSAndmlrdW5qYS1zcWxpdGUtZGF0YTovZGInCiAgICBjb21tYW5kOgogICAgICAtIHNoCiAgICAgIC0gJy1jJwogICAgICAtICd0b3VjaCAvZGIvdmlrdW5qYS5kYiAmJiBjaG93biAtUiAxMDAwIC9kYicK",
+        "tags": [
+            "productivity",
+            "todo"
+        ],
+        "category": "productivity",
+        "logo": "svgs/vikunja.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
+        "port": "3456"
+    },
     "vikunja-with-postgresql": {
         "documentation": "https://vikunja.io?utm_source=coolify.io",
         "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
@@ -5538,19 +5598,27 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3456"
     },
-    "vikunja": {
-        "documentation": "https://vikunja.io?utm_source=coolify.io",
-        "slogan": "The open-source, self-hostable to-do app. Organize everything, on all platforms.",
-        "compose": "c2VydmljZXM6CiAgdmlrdW5qYToKICAgIGltYWdlOiB2aWt1bmphL3Zpa3VuamEKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9WSUtVTkpBCiAgICAgIC0gVklLVU5KQV9TRVJWSUNFX1BVQkxJQ1VSTD0kU0VSVklDRV9GUUROX1ZJS1VOSkEKICAgICAgLSBWSUtVTkpBX1NFUlZJQ0VfSldUU0VDUkVUPSRTRVJWSUNFX1BBU1NXT1JEX0pXVFNFQ1JFVAogICAgICAtIFZJS1VOSkFfU0VSVklDRV9FTkFCTEVSRUdJU1RSQVRJT049dHJ1ZQogICAgICAtIFZJS1VOSkFfREFUQUJBU0VfUEFUSD0vZGIvdmlrdW5qYS5kYgogICAgICAtIFZJS1VOSkFfREFUQUJBU0VfVFlQRT1zcWxpdGUKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Zpa3VuamEtZGF0YTovYXBwL3Zpa3VuamEvJwogICAgICAtICd2aWt1bmphLXNxbGl0ZS1kYXRhOi9kYicKICAgIGRlcGVuZHNfb246CiAgICAgIC0gaW5pdAogIGluaXQ6CiAgICBpbWFnZTogYnVzeWJveAogICAgcmVzdGFydDogJ25vJwogICAgdm9sdW1lczoKICAgICAgLSAndmlrdW5qYS1zcWxpdGUtZGF0YTovZGInCiAgICBjb21tYW5kOgogICAgICAtIHNoCiAgICAgIC0gJy1jJwogICAgICAtICd0b3VjaCAvZGIvdmlrdW5qYS5kYiAmJiBjaG93biAtUiAxMDAwIC9kYicK",
+    "vvveb": {
+        "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
+        "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
+        "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9WVlZFQl84MAogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
-            "productivity",
-            "todo"
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "ecommerce",
+            "page-builder",
+            "nocode",
+            "mysql",
+            "sqlite",
+            "pgsql"
         ],
-        "category": "productivity",
-        "logo": "svgs/vikunja.svg",
+        "category": "cms",
+        "logo": "svgs/vvveb.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3456"
+        "port": "80"
     },
     "vvveb-with-mariadb": {
         "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
@@ -5578,28 +5646,6 @@
         "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
         "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
         "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9WVlZFQl84MAogICAgICAtIERCX0VOR0lORT1teXNxbGkKICAgICAgLSBEQl9IT1NUPW15c3FsCiAgICAgIC0gJ0RCX1VTRVI9JHtTRVJWSUNFX1VTRVJfVlZWRUJ9JwogICAgICAtICdEQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfVlZWRUJ9JwogICAgICAtICdEQl9OQU1FPSR7TVlTUUxfREFUQUJBU0U6LXZ2dmVifScKICAgIGRlcGVuZHNfb246CiAgICAgIG15c3FsOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gJy1mJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjEnCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTAKICBteXNxbDoKICAgIGltYWdlOiAnbXlzcWw6OC40LjInCiAgICB2b2x1bWVzOgogICAgICAtICd2dnZlYi1teXNxbC1kYXRhOi92YXIvbGliL215c3FsJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ01ZU1FMX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1JPT1R9JwogICAgICAtICdNWVNRTF9EQVRBQkFTRT0ke01ZU1FMX0RBVEFCQVNFOi12dnZlYn0nCiAgICAgIC0gJ01ZU1FMX1VTRVI9JHtTRVJWSUNFX1VTRVJfVlZWRUJ9JwogICAgICAtICdNWVNRTF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfVlZWRUJ9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIG15c3FsYWRtaW4KICAgICAgICAtIHBpbmcKICAgICAgICAtICctaCcKICAgICAgICAtIDEyNy4wLjAuMQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
-        "tags": [
-            "cms",
-            "blog",
-            "content",
-            "management",
-            "ecommerce",
-            "page-builder",
-            "nocode",
-            "mysql",
-            "sqlite",
-            "pgsql"
-        ],
-        "category": "cms",
-        "logo": "svgs/vvveb.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "80"
-    },
-    "vvveb": {
-        "documentation": "https://docs.vvveb.com?utm_source=coolify.io",
-        "slogan": "Powerful and easy to use cms to build websites, blogs or ecommerce stores.",
-        "compose": "c2VydmljZXM6CiAgdnZ2ZWI6CiAgICBpbWFnZTogJ3Z2dmViL3Z2dmViY21zOmxhdGVzdCcKICAgIHZvbHVtZXM6CiAgICAgIC0gJ3Z2dmViLWRhdGE6L3Zhci93d3cvaHRtbCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9WVlZFQl84MAogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGN1cmwKICAgICAgICAtICctZicKICAgICAgICAtICdodHRwOi8vMTI3LjAuMC4xJwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDEwCg==",
         "tags": [
             "cms",
             "blog",
@@ -5804,6 +5850,26 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "WordPress running behind OpenLiteSpeed with persistent MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9XT1JEUFJFU1NfODAKICAgICAgLSBXT1JEUFJFU1NfREJfSE9TVD1tYXJpYWRiCiAgICAgIC0gV09SRFBSRVNTX0RCX05BTUU9JHtXT1JEUFJFU1NfREJfTkFNRTotd29yZHByZXNzfQogICAgICAtIFdPUkRQUkVTU19EQl9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgICAtIFdPUkRQUkVTU19UQUJMRV9QUkVGSVg9JHtXT1JEUFJFU1NfVEFCTEVfUFJFRklYOi13cF99CiAgICAgIC0gVFo9JHtUWjotVVRDfQogICAgY29tbWFuZDoKICAgICAgLSBiYXNoCiAgICAgIC0gL3Vzci9sb2NhbC9iaW4vY29vbGlmeS13b3JkcHJlc3MtaW5pdC5zaAogICAgdm9sdW1lczoKICAgICAgLSB3b3JkcHJlc3MtZmlsZXM6L3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sCiAgICAgIC0gb3BlbmxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mCiAgICAgIC0gb3BlbmxpdGVzcGVlZC1hZG1pbi1jb25mOi91c3IvbG9jYWwvbHN3cy9hZG1pbi9jb25mCiAgICAgIC0gb3BlbmxpdGVzcGVlZC1sb2dzOi91c3IvbG9jYWwvbHN3cy9sb2dzCiAgICAgIC0gdHlwZTogYmluZAogICAgICAgIHNvdXJjZTogLi9jb29saWZ5LXdvcmRwcmVzcy1pbml0LnNoCiAgICAgICAgdGFyZ2V0OiAvdXNyL2xvY2FsL2Jpbi9jb29saWZ5LXdvcmRwcmVzcy1pbml0LnNoCiAgICAgICAgY29udGVudDogfAogICAgICAgICAgIyEvdXNyL2Jpbi9lbnYgYmFzaAogICAgICAgICAgc2V0IC1ldW8gcGlwZWZhaWwKCiAgICAgICAgICBjZCAvdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKCiAgICAgICAgICB1bnRpbCBteXNxbGFkbWluIHBpbmcgLWgiJHtXT1JEUFJFU1NfREJfSE9TVH0iIC11IiR7V09SRFBSRVNTX0RCX1VTRVJ9IiAtcCIke1dPUkRQUkVTU19EQl9QQVNTV09SRH0iIC0tc2lsZW50OyBkbwogICAgICAgICAgICBlY2hvICJXYWl0aW5nIGZvciBNYXJpYURCLi4uIgogICAgICAgICAgICBzbGVlcCAyCiAgICAgICAgICBkb25lCgogICAgICAgICAgaWYgWyAhIC1mIGluZGV4LnBocCBdOyB0aGVuCiAgICAgICAgICAgIHdwIGNvcmUgZG93bmxvYWQgLS1hbGxvdy1yb290CiAgICAgICAgICBmaQoKICAgICAgICAgIGlmIFsgISAtZiB3cC1jb25maWcucGhwIF07IHRoZW4KICAgICAgICAgICAgd3AgY29uZmlnIGNyZWF0ZSBcCiAgICAgICAgICAgICAgLS1hbGxvdy1yb290IFwKICAgICAgICAgICAgICAtLWRibmFtZT0iJHtXT1JEUFJFU1NfREJfTkFNRX0iIFwKICAgICAgICAgICAgICAtLWRidXNlcj0iJHtXT1JEUFJFU1NfREJfVVNFUn0iIFwKICAgICAgICAgICAgICAtLWRicGFzcz0iJHtXT1JEUFJFU1NfREJfUEFTU1dPUkR9IiBcCiAgICAgICAgICAgICAgLS1kYmhvc3Q9IiR7V09SRFBSRVNTX0RCX0hPU1R9IiBcCiAgICAgICAgICAgICAgLS1kYnByZWZpeD0iJHtXT1JEUFJFU1NfVEFCTEVfUFJFRklYfSIKICAgICAgICAgIGZpCiAgICBkZXBlbmRzX29uOgogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gY3VybAogICAgICAgIC0gLWYKICAgICAgICAtIGh0dHA6Ly8xMjcuMC4wLjEKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMQogICAgdm9sdW1lczoKICAgICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUk9PVAogICAgICAtIE1ZU1FMX0RBVEFCQVNFPSR7V09SRFBSRVNTX0RCX05BTUU6LXdvcmRwcmVzc30KICAgICAgLSBNWVNRTF9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gaGVhbHRoY2hlY2suc2gKICAgICAgICAtIC0tY29ubmVjdAogICAgICAgIC0gLS1pbm5vZGJfaW5pdGlhbGl6ZWQKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "template_last_updated_at": null,
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
@@ -5819,10 +5885,10 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00"
     },
-    "yamtrack-with-postgresql": {
+    "yamtrack": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",
-        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ZQU1UUkFDS184MDAwCiAgICAgIC0gJ1VSTFM9JHtTRVJWSUNFX0ZRRE5fWUFNVFJBQ0t9JwogICAgICAtICdUWj0ke1RaOi1FdXJvcGUvQmVybGlufScKICAgICAgLSAnU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9TRUNSRVR9JwogICAgICAtICdSRUdJU1RSQVRJT049JHtSRUdJU1RSQVRJT05fRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3JlZGlzOjYzNzknCiAgICAgIC0gREJfSE9TVD1wb3N0Z3JlcwogICAgICAtICdEQl9OQU1FPSR7UE9TVEdSRVNRTF9EQVRBQkFTRToteWFtdHJhY2stZGJ9JwogICAgICAtICdEQl9VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdEQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gREJfUE9SVD01NDMyCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHdnZXQKICAgICAgICAtICctLW5vLXZlcmJvc2UnCiAgICAgICAgLSAnLS10cmllcz0xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODAwMC9oZWFsdGgvJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRToteWFtdHJhY2stZGJ9JwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcG9zdGdyZXNfZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcmVkaXNfZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ZQU1UUkFDS184MDAwCiAgICAgIC0gJ1VSTFM9JHtTRVJWSUNFX0ZRRE5fWUFNVFJBQ0t9JwogICAgICAtICdUWj0ke1RaOi1FdXJvcGUvQmVybGlufScKICAgICAgLSAnU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9TRUNSRVR9JwogICAgICAtICdSRUdJU1RSQVRJT049JHtSRUdJU1RSQVRJT05fRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3JlZGlzOjYzNzknCiAgICB2b2x1bWVzOgogICAgICAtICd5YW10cmFja19kYXRhOi95YW10cmFjay9kYicKICAgIGRlcGVuZHNfb246CiAgICAgIHJlZGlzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLS1xdWlldCAtLXRyaWVzPTEgLS1zcGlkZXIgaHR0cDovLzEyNy4wLjAuMTo4MDAwL2hlYWx0aC8gfHwgZXhpdCAxJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcmVkaXNfZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "self-hosted",
             "automation",
@@ -5842,10 +5908,10 @@
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "8000"
     },
-    "yamtrack": {
+    "yamtrack-with-postgresql": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",
-        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ZQU1UUkFDS184MDAwCiAgICAgIC0gJ1VSTFM9JHtTRVJWSUNFX0ZRRE5fWUFNVFJBQ0t9JwogICAgICAtICdUWj0ke1RaOi1FdXJvcGUvQmVybGlufScKICAgICAgLSAnU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9TRUNSRVR9JwogICAgICAtICdSRUdJU1RSQVRJT049JHtSRUdJU1RSQVRJT05fRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3JlZGlzOjYzNzknCiAgICB2b2x1bWVzOgogICAgICAtICd5YW10cmFja19kYXRhOi95YW10cmFjay9kYicKICAgIGRlcGVuZHNfb246CiAgICAgIHJlZGlzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3dnZXQgLS1xdWlldCAtLXRyaWVzPTEgLS1zcGlkZXIgaHR0cDovLzEyNy4wLjAuMTo4MDAwL2hlYWx0aC8gfHwgZXhpdCAxJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcmVkaXNfZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "compose": "c2VydmljZXM6CiAgeWFtdHJhY2s6CiAgICBpbWFnZTogZ2hjci5pby9mdXp6eWdyaW0veWFtdHJhY2sKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9ZQU1UUkFDS184MDAwCiAgICAgIC0gJ1VSTFM9JHtTRVJWSUNFX0ZRRE5fWUFNVFJBQ0t9JwogICAgICAtICdUWj0ke1RaOi1FdXJvcGUvQmVybGlufScKICAgICAgLSAnU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF9TRUNSRVR9JwogICAgICAtICdSRUdJU1RSQVRJT049JHtSRUdJU1RSQVRJT05fRU5BQkxFRDotdHJ1ZX0nCiAgICAgIC0gJ1JFRElTX1VSTD1yZWRpczovL3JlZGlzOjYzNzknCiAgICAgIC0gREJfSE9TVD1wb3N0Z3JlcwogICAgICAtICdEQl9OQU1FPSR7UE9TVEdSRVNRTF9EQVRBQkFTRToteWFtdHJhY2stZGJ9JwogICAgICAtICdEQl9VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdEQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gREJfUE9SVD01NDMyCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgICByZWRpczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHdnZXQKICAgICAgICAtICctLW5vLXZlcmJvc2UnCiAgICAgICAgLSAnLS10cmllcz0xJwogICAgICAgIC0gJy0tc3BpZGVyJwogICAgICAgIC0gJ2h0dHA6Ly8xMjcuMC4wLjE6ODAwMC9oZWFsdGgvJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTUUx9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVNRTH0nCiAgICAgIC0gJ1BPU1RHUkVTX0RCPSR7UE9TVEdSRVNRTF9EQVRBQkFTRToteWFtdHJhY2stZGJ9JwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcG9zdGdyZXNfZGF0YTovdmFyL2xpYi9wb3N0Z3Jlc3FsL2RhdGEnCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLVUgJCR7UE9TVEdSRVNfVVNFUn0gLWQgJCR7UE9TVEdSRVNfREJ9JwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgcmVkaXM6CiAgICBpbWFnZTogJ3JlZGlzOjctYWxwaW5lJwogICAgdm9sdW1lczoKICAgICAgLSAneWFtdHJhY2tfcmVkaXNfZGF0YTovZGF0YScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSByZWRpcy1jbGkKICAgICAgICAtIHBpbmcKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
         "tags": [
             "self-hosted",
             "automation",
@@ -5880,51 +5946,5 @@
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "3000"
-    },
-    "convertx": {
-        "documentation": "https://github.com/C4illin/ConvertX?utm_source=coolify.io",
-        "slogan": "A self-hosted online file converter. Supports over a thousand different formats.",
-        "compose": "c2VydmljZXM6CiAgY29udmVydHg6CiAgICBpbWFnZTogJ2doY3IuaW8vYzRpbGxpbi9jb252ZXJ0eDpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fQ09OVkVSVFgKICAgICAgLSAnQUNDT1VOVF9SRUdJU1RSQVRJT049JHtBQ0NPVU5UX1JFR0lTVFJBVElPTjotZmFsc2V9JwogICAgICAtICdIVFRQX0FMTE9XRUQ9JHtIVFRQX0FMTE9XRUQ6LXRydWV9JwogICAgICAtICdBTExPV19VTkFVVEhFTlRJQ0FURUQ9JHtBTExPV19VTkFVVEhFTlRJQ0FURUQ6LWZhbHNlfScKICAgICAgLSAnQVVUT19ERUxFVEVfRVZFUllfTl9IT1VSUz0ke0FVVE9fREVMRVRFX0VWRVJZX05fSE9VUlM6LTI0fScKICAgICAgLSAnSldUX1NFQ1JFVD0ke1NFUlZJQ0VfUEFTU1dPUkRfQ09OVkVSVFhKV1RTRUNSRVR9JwogICAgdm9sdW1lczoKICAgICAgLSAnY29udmVydHhfZGF0YTovYXBwL2RhdGEnCg==",
-        "tags": [
-            "converter",
-            "file",
-            "documents",
-            "files",
-            "directories"
-        ],
-        "category": "backend",
-        "logo": "svgs/convertx.png",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "3000"
-    },
-    "marimo": {
-        "documentation": "https://marimo.io/?utm_source=coolify.io",
-        "slogan": "An open-source reactive notebook for Python \u2014 reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.",
-        "compose": "c2VydmljZXM6CiAgbWFyaW1vOgogICAgaW1hZ2U6ICdnaGNyLmlvL21hcmltby10ZWFtL21hcmltbzpsYXRlc3Qtc3FsJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX01BUklNT184MDgwCiAgICAgIC0gVE9LRU5fUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfTUFSSU1PCiAgICB2b2x1bWVzOgogICAgICAtICdtYXJpbW86L2FwcCcKICAgIGNvbW1hbmQ6CiAgICAgIC0gbWFyaW1vCiAgICAgIC0gZWRpdAogICAgICAtICctLXRva2VuLXBhc3N3b3JkJwogICAgICAtICcke1NFUlZJQ0VfUEFTU1dPUkRfTUFSSU1PfScKICAgICAgLSAnLS1wb3J0JwogICAgICAtICc4MDgwJwogICAgICAtICctLWhvc3QnCiAgICAgIC0gMC4wLjAuMAogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIHV2eAogICAgICAgIC0gJy0td2l0aCcKICAgICAgICAtICdodHRweFtjbGldJwogICAgICAgIC0gaHR0cHgKICAgICAgICAtICdodHRwOi8vbG9jYWxob3N0OjgwODAvaGVhbHRoJwogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMwo=",
-        "tags": [
-            "notebook",
-            "python",
-            "data",
-            "analysis"
-        ],
-        "category": "devtools",
-        "logo": "svgs/marimo.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2025-08-17T18:23:57+02:00",
-        "port": "8080"
-    },
-    "pydio-cells": {
-        "documentation": "https://docs.pydio.com/?utm_source=coolify.io",
-        "slogan": "High-performance large file sharing, native no-code automation, and a collaboration-centric architecture that simplifies access control without compromising security or compliance.",
-        "compose": "c2VydmljZXM6CiAgY2VsbHM6CiAgICBpbWFnZTogJ3B5ZGlvL2NlbGxzOjQuNCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9DRUxMU184MDgwCiAgICAgIC0gJ0NFTExTX1NJVEVfRVhURVJOQUw9JHtTRVJWSUNFX0ZRRE5fQ0VMTFN9JwogICAgICAtIENFTExTX1NJVEVfTk9fVExTPTEKICAgIHZvbHVtZXM6CiAgICAgIC0gJ2NlbGxzX2RhdGE6L3Zhci9jZWxscycKICBtYXJpYWRiOgogICAgaW1hZ2U6ICdtYXJpYWRiOjExJwogICAgdm9sdW1lczoKICAgICAgLSAnbXlzcWxfZGF0YTovdmFyL2xpYi9teXNxbCcKICAgIGVudmlyb25tZW50OgogICAgICAtICdNWVNRTF9ST09UX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9NWVNRTFJPT1R9JwogICAgICAtICdNWVNRTF9EQVRBQkFTRT0ke01ZU1FMX0RBVEFCQVNFOi1jZWxsc30nCiAgICAgIC0gJ01ZU1FMX1VTRVI9JHtTRVJWSUNFX1VTRVJfTVlTUUx9JwogICAgICAtICdNWVNRTF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfTVlTUUx9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIGhlYWx0aGNoZWNrLnNoCiAgICAgICAgLSAnLS1jb25uZWN0JwogICAgICAgIC0gJy0taW5ub2RiX2luaXRpYWxpemVkJwogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiA1Cg==",
-        "tags": [
-            "storage"
-        ],
-        "category": "storage",
-        "logo": "svgs/cells.svg",
-        "minversion": "0.0.0",
-        "template_last_updated_at": "2026-04-06T11:35:16-05:00",
-        "port": "8080"
     }
 }


### PR DESCRIPTION
## Summary

Adds a new WordPress + OpenLiteSpeed service template.

The template includes:

- OpenLiteSpeed using the official `litespeedtech/openlitespeed` image
- MariaDB 11 as the database
- persistent WordPress files under `/var/www/vhosts/localhost/html`
- persistent MariaDB data under `/var/lib/mysql`
- Coolify proxy integration through the standard service URL variable
- generated service template metadata updates

## Why

Closes #8264.

/claim #8264

This provides a reusable WordPress + OpenLiteSpeed stack that follows the existing Coolify service template pattern and keeps both application files and database data persistent across restarts.

## Testing

- Verified the compose template structure statically.
- Verified the generated `service-templates-latest.json` entry keeps `SERVICE_URL_WORDPRESS_80`.
- Verified the generated `service-templates.json` entry converts it to `SERVICE_FQDN_WORDPRESS_80`.
- Could not run the full Coolify generator locally because PHP is not installed in this environment.
- Could not run `docker compose config` locally because Docker is not installed in this environment.
