### PR TITLE
fix(api): allow opting out of forced HTTP/1.1 for git operations

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1684,6 +1684,10 @@ class Application extends BaseModel
 
     private function withGitHttpTransportConfig(?string $gitConfigOptions = null): string
     {
+        if (env('COOLIFY_DISABLE_GIT_HTTP11', false)) {
+            return trim($gitConfigOptions ?? '');
+        }
+
         return trim(($gitConfigOptions ? "{$gitConfigOptions} " : '').'-c http.version=HTTP/1.1');
     }
 

--- a/tests/Feature/GitHttpTransportCommandsTest.php
+++ b/tests/Feature/GitHttpTransportCommandsTest.php
@@ -134,3 +134,29 @@ it('applies http 1 transport to custom bitbucket pull request checkout', functio
     expect($result['commands'])
         ->toContain("git -c http.version=HTTP/1.1 checkout 'abc123def456abc123def456abc123def456abc1'");
 });
+
+it('omits http 1 transport when COOLIFY_DISABLE_GIT_HTTP11 is set', function () {
+    putenv('COOLIFY_DISABLE_GIT_HTTP11=true');
+    try {
+        $application = applicationWithGitSettings();
+
+        $source = new GithubApp;
+        $source->forceFill([
+            'html_url' => 'https://github.com',
+            'api_url' => 'https://api.github.com',
+            'is_public' => true,
+        ]);
+        $application->setRelation('source', $source);
+
+        $result = $application->generateGitImportCommands(
+            deployment_uuid: 'test-deployment',
+            exec_in_docker: false,
+        );
+
+        expect($result['commands'])
+            ->not->toContain('http.version=HTTP/1.1')
+            ->toContain("git clone --depth=1 -b 'main' 'https://github.com/coollabsio/private-app' '/artifacts/test-deployment'");
+    } finally {
+        putenv('COOLIFY_DISABLE_GIT_HTTP11');
+    }
+});


### PR DESCRIPTION
## Changes

WithGitHttpTransportConfig() unconditionally forces HTTP/1.1 on every HTTPS git operation (added in #10528 for #5251). On servers running git 2.55+ this makes GitHub answer 401 and non-interactive clones die with a credential-prompt fatal error, so Docker Compose deployments fail with "Failed to read the Docker Compose file from the repository" (repro and analysis in #11579).

This adds an opt-out: when the environment variable COOLIFY_DISABLE_GIT_HTTP11 is set, the forced transport config is omitted and clones use the default protocol. Default behavior is unchanged.

## Issues

- Fixes #11579

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: omp coding agent (GLM).
- How extensively: analysis and draft; verified by me on a live self-hosted instance (repro commands run multiple times; deployment completed end-to-end after the change).

## Testing

Manually verified on the affected server (git 2.55.0): the generated clone command fails with the forced config and succeeds without it; after applying the change the previously failing deployment completed end-to-end. Feature test added; suite runs via CI.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
