### PR TITLE
fix: keep manual webhook URLs visible for GitLab App sources

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1541,7 +1541,14 @@ function generateDeployWebhook($resource)
 function generateGitManualWebhook($resource, $type)
 {
     if ($resource->source_id !== 0 && ! is_null($resource->source_id)) {
-        return null;
+        // GitHub Apps register webhooks at the app level (hook_attributes in
+        // the app manifest), so there is nothing to configure per repository.
+        // Other Git App providers (GitLab) have no app-level webhook
+        // registration and Coolify never creates their project webhooks, so
+        // the manual endpoint must stay visible for them.
+        if ($resource->source_type === GithubApp::class) {
+            return null;
+        }
     }
     if ($resource->getMorphClass() === Application::class) {
         $baseUrl = base_url();

--- a/resources/views/livewire/project/shared/webhooks.blade.php
+++ b/resources/views/livewire/project/shared/webhooks.blade.php
@@ -46,7 +46,7 @@
                 <form wire:submit.prevent="submit" class="application-settings-form flex flex-col">
                     <x-unsaved-bar action="submit" />
                     <x-application.settings-section id="manual-git-webhooks-section" title="Manual Git webhooks"
-                        helper="Configure these endpoints when the repository is not connected through an official Git App." flush>
+                        helper="Configure these endpoints when the repository is not connected through an official Git App. GitLab App sources always need this - Coolify does not create GitLab webhooks automatically." flush>
                         <x-slot:actions>
                             @if (filled($resource?->gitWebhook))
                                 <a class="button" href="{{ $resource->gitWebhook }}" target="_blank"

--- a/tests/Unit/GitManualWebhookVisibilityTest.php
+++ b/tests/Unit/GitManualWebhookVisibilityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Application;
+use App\Models\GithubApp;
+use App\Models\GitlabApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    DB::table('instance_settings')->insert([
+        'id' => 0,
+        'fqdn' => 'https://coolify.example.com',
+    ]);
+});
+
+it('hides manual webhooks for github app sources (app-level webhook registration)', function () {
+    $application = new Application(['source_id' => 1, 'source_type' => GithubApp::class]);
+
+    expect(generateGitManualWebhook($application, 'github'))->toBeNull()
+        ->and(generateGitManualWebhook($application, 'gitlab'))->toBeNull();
+});
+
+it('shows manual webhooks for gitlab app sources (no app-level webhook registration)', function () {
+    $application = new Application(['source_id' => 1, 'source_type' => GitlabApp::class]);
+
+    expect(generateGitManualWebhook($application, 'gitlab'))
+        ->toBe('https://coolify.example.com/webhooks/source/gitlab/events/manual');
+});
+
+it('keeps showing manual webhooks when no git app source is connected', function () {
+    $application = new Application(['source_id' => null, 'source_type' => null]);
+
+    expect(generateGitManualWebhook($application, 'gitlab'))
+        ->toBe('https://coolify.example.com/webhooks/source/gitlab/events/manual');
+});


### PR DESCRIPTION
## Changes

- The webhooks settings page hid the manual webhook section for any repository connected through a Git App. That is correct for GitHub Apps (webhooks are registered at the app level via the manifest), but GitLab Apps have no app-level webhook registration and Coolify never creates GitLab project hooks, so GitLab App sources lost the only webhook mechanism available to them. The manual GitLab webhook endpoint itself already works for these sources; the UI was just hiding it.
- The visibility helper now hides the manual section only for GitHub App sources. GitLab App and other non-GitHub sources see the manual webhook URL and per-app secret again.
- The manual section helper text now notes that GitLab App sources always need manual setup.
- Added a unit test covering GitHub App, GitLab App, and no-Git-App source configurations.

## Issues

- Fixes #11602

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: breken (AI support engineer, breken.ai)
- How extensively: root-cause analysis, the fix, and the tests were produced by AI from the reporter's trace and the current codebase.

## Testing

Added unit tests covering the helper for all three source configurations (GitHub App hidden, GitLab App visible, no Git App visible). Not yet run against a full local Coolify development instance.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

> Built by breken, your AI support engineer - breken.ai - this one's on us.