### PR TITLE
fix(ui): render persistent storage PR suffix dropdown outside the volumes table

### DIFF
--- a/resources/views/livewire/project/shared/storages/all.blade.php
+++ b/resources/views/livewire/project/shared/storages/all.blade.php
@@ -166,7 +166,7 @@
                             @if ($supportsPreviewSuffix)
                                 <div class="volumes-col-pr min-w-0">
                                     <span class="volumes-mobile-label volumes-field-label">PR suffix</span>
-                                    <x-forms.listbox id="forms.{{ $id }}.isPreviewSuffixEnabled" :options="[
+                                    <x-forms.listbox id="forms.{{ $id }}.isPreviewSuffixEnabled" portal :options="[
                                         ['value' => true, 'label' => 'Add suffix'],
                                         ['value' => false, 'label' => 'Share volume'],
                                     ]" />

--- a/resources/views/livewire/project/shared/storages/show.blade.php
+++ b/resources/views/livewire/project/shared/storages/show.blade.php
@@ -116,7 +116,7 @@
             @if ($supportsPreviewSuffix)
                 <div class="volumes-col-pr min-w-0">
                     <span class="volumes-mobile-label volumes-field-label">PR suffix</span>
-                    <x-forms.listbox id="isPreviewSuffixEnabled" onChange="instantSave" :options="[
+                    <x-forms.listbox id="isPreviewSuffixEnabled" onChange="instantSave" portal :options="[
                         ['value' => true, 'label' => 'Add suffix'],
                         ['value' => false, 'label' => 'Share volume'],
                     ]" />


### PR DESCRIPTION
## Changes

The "PR suffix" dropdown in Persistent Storage opened inside the volumes table instead of on top of it, so it got clipped and the table grew a scrollbar.

`.data-table` sets `overflow-x: auto`, which makes the browser compute `overflow-y` as `auto` too, so the table clips on every side. The dropdown panel is `position: absolute` and opens past the bottom edge. The listbox component already has a `portal` prop that renders the panel `position: fixed` instead, and the domain tables already use it. The volumes table did not.

Two lines, two files.

## Issues

Fixes #11605

## Category

Bug fix.

## Preview

![PR suffix dropdown clipped by the volumes table](https://raw.githubusercontent.com/Inspiractus01/coolify/1bba5a22dabd63e3a8e9d24195aa43ec9d018099/pr-suffix-dropdown-clipped.png)

## AI Assistance

AI was used. I found the bug in the UI myself, then used an AI assistant to search the codebase and pin down the CSS rule behind it and the one-word change that fixes it.

## Testing

Reproduced the clipping in a standalone page built from the shipped `.data-table` (`resources/css/app.css:2155`) and `.listbox-panel` (`resources/css/app.css:1925`) rules: with `position: absolute` the panel is clipped and the table scrolls, with `position: fixed` it overflows correctly. The change matches how `domain-row.blade.php` and `domain-table.blade.php` already do it.

## Contributor Agreement

I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). I have searched existing issues and pull requests, including closed ones, to make sure this is not a duplicate. I have not yet verified the change on a local development instance.
