### PR TITLE
fix: build notification and deployment log links from the instance url

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2362,12 +2362,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 destination: $destination,
                 no_questions_asked: true,
             );
-            $this->application_deployment_queue->addLogEntry("Deployment to {$server->name}. Logs: ".route('project.application.deployment.show', [
-                'project_uuid' => data_get($this->application, 'environment.project.uuid'),
-                'application_uuid' => data_get($this->application, 'uuid'),
-                'deployment_uuid' => $deployment_uuid,
-                'environment_uuid' => data_get($this->application, 'environment.uuid'),
-            ]));
+            $deployment_url = base_url().'/project/'.data_get($this->application, 'environment.project.uuid').'/environment/'.data_get($this->application, 'environment.uuid').'/application/'.data_get($this->application, 'uuid')."/deployment/{$deployment_uuid}";
+            $this->application_deployment_queue->addLogEntry("Deployment to {$server->name}. Logs: {$deployment_url}");
         }
     }
 

--- a/app/Jobs/RegenerateSslCertJob.php
+++ b/app/Jobs/RegenerateSslCertJob.php
@@ -66,7 +66,10 @@ class RegenerateSslCertJob implements ShouldBeEncrypted, ShouldQueue
                     caCert: $caCert->ssl_certificate,
                     caKey: $caCert->ssl_private_key,
                 );
-                $regenerated->push($certificate);
+                $resource = $certificate->database;
+                if ($resource) {
+                    $regenerated->push($resource);
+                }
             } catch (\Exception $e) {
                 Log::error('Failed to regenerate SSL certificate: '.$e->getMessage());
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -621,32 +621,6 @@ class Application extends BaseModel
             && $this->restart_limit_reached === true;
     }
 
-    public function taskLink($task_uuid)
-    {
-        if (data_get($this, 'environment.project.uuid')) {
-            $route = route('project.application.scheduled-tasks', [
-                'project_uuid' => data_get($this, 'environment.project.uuid'),
-                'environment_uuid' => data_get($this, 'environment.uuid'),
-                'application_uuid' => data_get($this, 'uuid'),
-                'task_uuid' => $task_uuid,
-            ]);
-            $settings = instanceSettings();
-            if (data_get($settings, 'fqdn')) {
-                $url = Url::fromString($route);
-                $url = $url->withPort(null);
-                $fqdn = data_get($settings, 'fqdn');
-                $fqdn = str_replace(['http://', 'https://'], '', $fqdn);
-                $url = $url->withHost($fqdn);
-
-                return $url->__toString();
-            }
-
-            return $route;
-        }
-
-        return null;
-    }
-
     public function settings()
     {
         return $this->hasOne(ApplicationSetting::class);

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use OpenApi\Attributes as OA;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Url\Url;
 use Symfony\Component\Yaml\Yaml;
 
 #[OA\Schema(
@@ -1458,32 +1457,6 @@ class Service extends BaseModel
                 'environment_uuid' => data_get($this, 'environment.uuid'),
                 'service_uuid' => data_get($this, 'uuid'),
             ]);
-        }
-
-        return null;
-    }
-
-    public function taskLink($task_uuid)
-    {
-        if (data_get($this, 'environment.project.uuid')) {
-            $route = route('project.service.scheduled-tasks', [
-                'project_uuid' => data_get($this, 'environment.project.uuid'),
-                'environment_uuid' => data_get($this, 'environment.uuid'),
-                'service_uuid' => data_get($this, 'uuid'),
-                'task_uuid' => $task_uuid,
-            ]);
-            $settings = InstanceSettings::get();
-            if (data_get($settings, 'fqdn')) {
-                $url = Url::fromString($route);
-                $url = $url->withPort(null);
-                $fqdn = data_get($settings, 'fqdn');
-                $fqdn = str_replace(['http://', 'https://'], '', $fqdn);
-                $url = $url->withHost($fqdn);
-
-                return $url->__toString();
-            }
-
-            return $route;
         }
 
         return null;

--- a/app/Notifications/ApiTokenExpiringNotification.php
+++ b/app/Notifications/ApiTokenExpiringNotification.php
@@ -21,7 +21,7 @@ class ApiTokenExpiringNotification extends CustomEmailNotification
         $this->onQueue('high');
         $this->tokenName = $token->name;
         $this->expiresAt = $token->expires_at?->format('Y-m-d H:i:s') ?? '';
-        $this->manageUrl = route('security.api-tokens');
+        $this->manageUrl = base_url().'/security/api-tokens';
     }
 
     public function via(object $notifiable): array

--- a/app/Notifications/Application/RestartLimitReached.php
+++ b/app/Notifications/Application/RestartLimitReached.php
@@ -2,8 +2,11 @@
 
 namespace App\Notifications\Application;
 
+use App\Models\Application;
 use App\Models\ApplicationPreview;
 use App\Models\BaseModel;
+use App\Models\ServiceApplication;
+use App\Models\ServiceDatabase;
 use App\Notifications\CustomEmailNotification;
 use App\Notifications\Dto\DiscordMessage;
 use App\Notifications\Dto\PushoverMessage;
@@ -49,14 +52,19 @@ class RestartLimitReached extends CustomEmailNotification
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
         }
-        $service = data_get($resource, 'service');
-        $this->resource_url = match (true) {
-            method_exists($this->resource, 'link') => $this->resource->link(),
-            $resource instanceof ApplicationPreview => $resource->application->link(),
-            is_object($service) && method_exists($service, 'link') => $service->link(),
-            default => null,
+        $this->resource_url = $this->resolveResourceUrl($resource);
+    }
+
+    private function resolveResourceUrl(BaseModel $resource): string
+    {
+        [$type, $uuid] = match (true) {
+            $resource instanceof Application => ['application', $resource->uuid],
+            $resource instanceof ApplicationPreview => ['application', $resource->application->uuid],
+            $resource instanceof ServiceApplication, $resource instanceof ServiceDatabase => ['service', $resource->service->uuid],
+            default => ['database', $resource->uuid],
         };
-        $this->resource_url ??= base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}";
+
+        return base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/{$type}/{$uuid}";
     }
 
     public function via(object $notifiable): array

--- a/app/Notifications/ScheduledTask/TaskFailed.php
+++ b/app/Notifications/ScheduledTask/TaskFailed.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\ScheduledTask;
 
+use App\Models\Application;
 use App\Models\ScheduledTask;
 use App\Notifications\CustomEmailNotification;
 use App\Notifications\Dto\DiscordMessage;
@@ -16,10 +17,10 @@ class TaskFailed extends CustomEmailNotification
     public function __construct(public ScheduledTask $task, public string $output)
     {
         $this->onQueue('high');
-        if ($task->application) {
-            $this->url = $task->application->taskLink($task->uuid);
-        } elseif ($task->service) {
-            $this->url = $task->service->taskLink($task->uuid);
+        $resource = $task->application ?? $task->service;
+        if ($resource) {
+            $type = $resource instanceof Application ? 'application' : 'service';
+            $this->url = base_url().'/project/'.data_get($resource, 'environment.project.uuid').'/environment/'.data_get($resource, 'environment.uuid')."/{$type}/{$resource->uuid}/tasks/{$task->uuid}";
         }
     }
 

--- a/app/Notifications/ScheduledTask/TaskSuccess.php
+++ b/app/Notifications/ScheduledTask/TaskSuccess.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\ScheduledTask;
 
+use App\Models\Application;
 use App\Models\ScheduledTask;
 use App\Notifications\CustomEmailNotification;
 use App\Notifications\Dto\DiscordMessage;
@@ -16,10 +17,10 @@ class TaskSuccess extends CustomEmailNotification
     public function __construct(public ScheduledTask $task, public string $output)
     {
         $this->onQueue('high');
-        if ($task->application) {
-            $this->url = $task->application->taskLink($task->uuid);
-        } elseif ($task->service) {
-            $this->url = $task->service->taskLink($task->uuid);
+        $resource = $task->application ?? $task->service;
+        if ($resource) {
+            $type = $resource instanceof Application ? 'application' : 'service';
+            $this->url = base_url().'/project/'.data_get($resource, 'environment.project.uuid').'/environment/'.data_get($resource, 'environment.uuid')."/{$type}/{$resource->uuid}/tasks/{$task->uuid}";
         }
     }
 

--- a/app/Notifications/SslExpirationNotification.php
+++ b/app/Notifications/SslExpirationNotification.php
@@ -7,7 +7,6 @@ use App\Notifications\Dto\PushoverMessage;
 use App\Notifications\Dto\SlackMessage;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Collection;
-use Spatie\Url\Url;
 
 class SslExpirationNotification extends CustomEmailNotification
 {
@@ -19,39 +18,9 @@ class SslExpirationNotification extends CustomEmailNotification
     {
         $this->onQueue('high');
         $this->resources = collect($resources);
-
-        // Collect URLs for each resource
-        $this->resources->each(function ($resource) {
-            if (data_get($resource, 'environment.project.uuid')) {
-                $routeName = match ($resource->type()) {
-                    'application' => 'project.application.configuration',
-                    'database' => 'project.database.configuration',
-                    'service' => 'project.service.configuration',
-                    default => null
-                };
-
-                if ($routeName) {
-                    $route = route($routeName, [
-                        'project_uuid' => data_get($resource, 'environment.project.uuid'),
-                        'environment_uuid' => data_get($resource, 'environment.uuid'),
-                        $resource->type().'_uuid' => data_get($resource, 'uuid'),
-                    ]);
-
-                    $settings = instanceSettings();
-                    if (data_get($settings, 'fqdn')) {
-                        $url = Url::fromString($route);
-                        $url = $url->withPort(null);
-                        $fqdn = data_get($settings, 'fqdn');
-                        $fqdn = str_replace(['http://', 'https://'], '', $fqdn);
-                        $url = $url->withHost($fqdn);
-
-                        $this->urls[$resource->name] = $url->__toString();
-                    } else {
-                        $this->urls[$resource->name] = $route;
-                    }
-                }
-            }
-        });
+        $this->urls = $this->resources->mapWithKeys(fn ($resource) => [
+            $resource->name => base_url().'/project/'.data_get($resource, 'environment.project.uuid').'/environment/'.data_get($resource, 'environment.uuid')."/database/{$resource->uuid}",
+        ])->all();
     }
 
     public function via(object $notifiable): array

--- a/tests/Feature/ApiTokenExpirationWarningTest.php
+++ b/tests/Feature/ApiTokenExpirationWarningTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Jobs\ApiTokenExpirationWarningJob;
+use App\Models\InstanceSettings;
 use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Notification;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
     $this->team->members()->attach($this->user->id, ['role' => 'owner']);
@@ -136,5 +138,16 @@ describe('ApiTokenExpirationWarningJob', function () {
 
         Notification::assertNothingSent();
         expect($token->fresh()->api_token_expiration_warning_sent_at)->toBeNull();
+    });
+
+    test('manage url uses the instance fqdn when configured', function () {
+        InstanceSettings::query()->update(['fqdn' => 'https://coolify.example.com']);
+        $token = createTokenExpiring($this->user, $this->team, Carbon::now()->addHours(12));
+
+        $notification = new ApiTokenExpiringNotification($token);
+
+        expect($notification->toSlack()->description)
+            ->toContain('https://coolify.example.com/security/api-tokens')
+            ->not->toContain('localhost');
     });
 });

--- a/tests/Feature/ApplicationStoppedAfterRestartLimitTest.php
+++ b/tests/Feature/ApplicationStoppedAfterRestartLimitTest.php
@@ -6,9 +6,20 @@ use App\Jobs\ApplicationDeploymentJob;
 use App\Models\Application;
 use App\Models\ApplicationPreview;
 use App\Models\BaseModel;
+use App\Models\InstanceSettings;
 use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use App\Models\StandalonePostgresql;
 use App\Notifications\Application\RestartLimitReached;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery\MockInterface;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0, 'fqdn' => 'https://coolify.test']);
+});
 
 function applicationWithRestartState(array $attributes = []): Application
 {
@@ -161,14 +172,8 @@ it('preserves restart-limit applications only while their exited container exist
         ->and($sentinelJob)->toContain('if ($application->stoppedAfterRestartLimit() && $containerStatuses->every(');
 });
 
-it('uses the application link for restart limit notifications', function () {
-    $application = new class extends Application
-    {
-        public function link()
-        {
-            return 'https://coolify.test/project/link-from-model';
-        }
-    };
+it('builds restart limit notification urls from the instance base url', function () {
+    $application = new Application;
     $application->forceFill([
         'name' => 'crashy-app',
         'uuid' => 'application-uuid',
@@ -183,7 +188,33 @@ it('uses the application link for restart limit notifications', function () {
 
     $notification = new RestartLimitReached($application);
 
-    expect($notification->resource_url)->toBe('https://coolify.test/project/link-from-model');
+    expect($notification->resource_url)->toBe('https://coolify.test/project/project-uuid/environment/environment-uuid/application/application-uuid');
+});
+
+it('links preview, service resource and database restart limit notifications to their pages', function () {
+    $environment = (object) ['uuid' => 'environment-uuid', 'name' => 'production', 'project' => (object) ['uuid' => 'project-uuid']];
+
+    $application = new Application;
+    $application->forceFill(['name' => 'app', 'uuid' => 'application-uuid']);
+    $application->setRelation('environment', $environment);
+    $preview = new ApplicationPreview;
+    $preview->forceFill(['uuid' => 'preview-uuid', 'pull_request_id' => 42, 'restart_count' => 2, 'max_restart_count' => 2]);
+    $preview->setRelation('application', $application);
+
+    $service = new Service;
+    $service->forceFill(['uuid' => 'service-uuid']);
+    $service->setRelation('environment', $environment);
+    $serviceApplication = new ServiceApplication;
+    $serviceApplication->forceFill(['name' => 'database', 'uuid' => 'service-application-uuid', 'restart_count' => 2, 'max_restart_count' => 2]);
+    $serviceApplication->setRelation('service', $service);
+
+    $database = new StandalonePostgresql;
+    $database->forceFill(['name' => 'postgres', 'uuid' => 'database-uuid', 'restart_count' => 2, 'max_restart_count' => 2]);
+    $database->setRelation('environment', $environment);
+
+    expect((new RestartLimitReached($preview))->resource_url)->toBe('https://coolify.test/project/project-uuid/environment/environment-uuid/application/application-uuid')
+        ->and((new RestartLimitReached($serviceApplication))->resource_url)->toBe('https://coolify.test/project/project-uuid/environment/environment-uuid/service/service-uuid')
+        ->and((new RestartLimitReached($database))->resource_url)->toBe('https://coolify.test/project/project-uuid/environment/environment-uuid/database/database-uuid');
 });
 
 it('uses the resolved environment project name in Slack restart limit notifications', function () {


### PR DESCRIPTION
## Changes

- fix(notifications): build api token expiry notification link from the instance url
- fix(notifications): build restart limit links from the instance url
- fix(notifications): urls for ssl renewal notifications
- fix(deployments): build deployment log links from the instance url
- refactor(notifications): build scheduled task links from the instance url and remove taskLink() helpers

### Superseeds

- https://github.com/coollabsio/coolify/pull/11537
