### PR TITLE
fix(deployments): retry helper startup after name conflict

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2304,7 +2304,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->graceful_shutdown_container($this->deployment_uuid, skipRemove: true);
         $this->execute_remote_command(
             [
-                $runCommand,
+                dockerRunWithNameConflictRetryCommand($runCommand, $this->deployment_uuid),
                 'hidden' => true,
             ],
             [
@@ -2316,13 +2316,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function restart_builder_container_with_actual_commit()
     {
-        // Stop the current helper container (no need for rm -f as it was started with --rm)
-        $this->graceful_shutdown_container($this->deployment_uuid, skipRemove: true);
-
-        // Clear cached env_args to force regeneration with actual SOURCE_COMMIT value
         $this->env_args = null;
-
-        // Restart the helper container with updated environment variables (including actual SOURCE_COMMIT)
         $this->prepare_builder_image(firstTry: false);
     }
 

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -274,6 +274,15 @@ function dockerRemoveCommandWithTimeout(string $container, int $timeout = 60, in
     return 'bash -c '.escapeShellValue($script);
 }
 
+function dockerRunWithNameConflictRetryCommand(string $command, string $container, int $timeout = 60): string
+{
+    $conflict = escapeShellValue('is already in use by container');
+    $message = escapeShellValue("Timed out waiting to start container {$container} after name conflicts.");
+    $retry = "while true; do output=\$({$command} 2>&1); exit_code=\$?; if [ \"\$exit_code\" -eq 0 ]; then exit 0; fi; case \"\$output\" in *{$conflict}*) if [ \"\$SECONDS\" -ge \"{$timeout}\" ]; then printf '%s\\n' {$message} >&2; exit 124; fi; sleep 0.1 ;; *) printf '%s\\n' \"\$output\" >&2; exit \$exit_code ;; esac; done";
+
+    return 'bash -c '.escapeShellValue($retry);
+}
+
 function dockerRemoveCommand(string $container): string
 {
     $command = 'docker rm -f '.escapeShellValue($container);

--- a/tests/Unit/DockerRemoveWithTimeoutTest.php
+++ b/tests/Unit/DockerRemoveWithTimeoutTest.php
@@ -36,6 +36,111 @@ it('preserves bounded cleanup when commands are adapted for non-root servers', f
         ->toContain('__COOLIFY_CONTAINER_REMOVE_TIMEOUT__');
 });
 
+it('preserves bounded helper startup retries for non-root servers', function () {
+    $server = Mockery::mock(Server::class)->makePartial();
+    $server->shouldReceive('getAttribute')->with('user')->andReturn('ubuntu');
+    $server->shouldReceive('setAttribute')->andReturnSelf();
+    $server->user = 'ubuntu';
+
+    $command = parseLineForSudo(
+        dockerRunWithNameConflictRetryCommand('docker run --name container-name image', 'container-name'),
+        $server
+    );
+
+    expect($command)
+        ->toStartWith("sudo bash -c '")
+        ->toContain('$SECONDS')
+        ->toContain('sudo docker run --name container-name image')
+        ->not->toContain('sudo exit');
+});
+
+it('retries helper startup until Docker releases the container name', function () {
+    $directory = sys_get_temp_dir().'/coolify-docker-run-'.bin2hex(random_bytes(4));
+    $countFile = $directory.'/count';
+    $captureFile = $directory.'/arguments';
+    $secret = "a'b \$c;d";
+    $runCommand = 'docker run --name container-name -e SECRET='.escapeshellarg($secret).' image';
+    mkdir($directory);
+    file_put_contents($directory.'/docker', "#!/bin/sh\ncount=0\nif [ -f \"\$COUNT_FILE\" ]; then count=\$(cat \"\$COUNT_FILE\"); fi\ncount=\$((count + 1))\nprintf '%s' \"\$count\" > \"\$COUNT_FILE\"\nprintf '%s\\n' \"\$@\" > \"\$CAPTURE_FILE\"\nif [ \"\$count\" -lt 3 ]; then echo 'Error response from daemon: Conflict. The container name is already in use by container' >&2; exit 125; fi\necho container-id\n");
+    chmod($directory.'/docker', 0755);
+
+    $process = new Process(['/bin/sh', '-c', dockerRunWithNameConflictRetryCommand($runCommand, 'container-name', 2)], env: [
+        'PATH' => $directory.':'.getenv('PATH'),
+        'COUNT_FILE' => $countFile,
+        'CAPTURE_FILE' => $captureFile,
+    ]);
+    $process->run();
+
+    expect($process->isSuccessful())->toBeTrue()
+        ->and(file_get_contents($countFile))->toBe('3')
+        ->and(file_get_contents($captureFile))->toBe("run\n--name\ncontainer-name\n-e\nSECRET={$secret}\nimage\n");
+
+    unlink($countFile);
+    unlink($captureFile);
+    unlink($directory.'/docker');
+    rmdir($directory);
+});
+
+it('does not apply the conflict deadline to a successful start', function () {
+    $process = new Process(['/bin/sh', '-c', dockerRunWithNameConflictRetryCommand('sleep 2', 'container-name', 1)]);
+    $process->run();
+
+    expect($process->isSuccessful())->toBeTrue();
+});
+
+it('times out while Docker keeps the container name reserved', function () {
+    $directory = sys_get_temp_dir().'/coolify-docker-run-'.bin2hex(random_bytes(4));
+    mkdir($directory);
+    file_put_contents($directory.'/docker', "#!/bin/sh\necho 'Error response from daemon: Conflict. The container name is already in use by container' >&2\nexit 125\n");
+    chmod($directory.'/docker', 0755);
+
+    $process = new Process(['/bin/sh', '-c', dockerRunWithNameConflictRetryCommand('docker run --name container-name image', 'container-name', 1)], env: [
+        'PATH' => $directory.':'.getenv('PATH'),
+    ]);
+    $process->run();
+
+    expect($process->getExitCode())->toBe(124)
+        ->and($process->getErrorOutput())->toContain('Timed out waiting to start container container-name after name conflicts.');
+
+    unlink($directory.'/docker');
+    rmdir($directory);
+});
+
+it('does not retry unrelated Docker errors', function () {
+    $directory = sys_get_temp_dir().'/coolify-docker-run-'.bin2hex(random_bytes(4));
+    $countFile = $directory.'/count';
+    mkdir($directory);
+    file_put_contents($directory.'/docker', "#!/bin/sh\nprintf x >> \"\$COUNT_FILE\"\necho 'Cannot connect to the Docker daemon' >&2\nexit 1\n");
+    chmod($directory.'/docker', 0755);
+
+    $process = new Process(['/bin/sh', '-c', dockerRunWithNameConflictRetryCommand('docker run --name container-name image', 'container-name', 2)], env: [
+        'PATH' => $directory.':'.getenv('PATH'),
+        'COUNT_FILE' => $countFile,
+    ]);
+    $process->run();
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getErrorOutput())->toContain('Cannot connect to the Docker daemon')
+        ->and(file_get_contents($countFile))->toBe('x');
+
+    unlink($countFile);
+    unlink($directory.'/docker');
+    rmdir($directory);
+});
+
+it('stops the helper before retrying startup with the same name', function () {
+    $source = file_get_contents(dirname(__DIR__, 2).'/app/Jobs/ApplicationDeploymentJob.php');
+    $start = strpos($source, 'private function prepare_builder_image');
+    $end = strpos($source, 'private function restart_builder_container_with_actual_commit');
+    $prepareBuilderImage = substr($source, $start, $end - $start);
+
+    $stop = strpos($prepareBuilderImage, '$this->graceful_shutdown_container($this->deployment_uuid, skipRemove: true);');
+    $run = strpos($prepareBuilderImage, 'dockerRunWithNameConflictRetryCommand($runCommand, $this->deployment_uuid)');
+
+    expect($stop)->toBeInt()
+        ->and($run)->toBeInt()->toBeGreaterThan($stop);
+});
+
 it('escapes container names in bounded removal commands', function () {
     $containerName = "container'; reboot; '";
     $directory = sys_get_temp_dir().'/coolify-docker-remove-'.bin2hex(random_bytes(4));


### PR DESCRIPTION
## Changes

- Build-secret helper restarts can fail with `container name ... is already in use` after resolving `SOURCE_COMMIT`.
- I retry the same `docker run` for 60 seconds only on that conflict; other failures return immediately. This tests the reservation itself because Docker removes a container from its list before releasing its name. I also removed the duplicate stop.

## Issues

- Fixes #9363

## Category

- [x] Bug fix

## Preview

Not applicable.

## AI Assistance

- [ ] AI was NOT used
- [x] AI was used

- Tools used: OpenAI Codex
- How extensively: I used Codex for investigation, implementation, tests, and adversarial review.

## Testing

- `php artisan test --compact tests/Unit/DockerRemoveWithTimeoutTest.php tests/Unit/ApplicationDeploymentJobCommitResolutionTest.php`: 22 passed, 56 assertions.
- Docker 29.7.2: delayed name release started the replacement; persistent conflict returned 124 and preserved the original.
- `vendor/bin/pint --dirty --format agent`: passed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
