### PR TITLE
fix(api): return task execution duration as float

### DIFF
--- a/app/Models/ScheduledTaskExecution.php
+++ b/app/Models/ScheduledTaskExecution.php
@@ -39,7 +39,7 @@ class ScheduledTaskExecution extends BaseModel
             'started_at' => 'datetime',
             'finished_at' => 'datetime',
             'retry_count' => 'integer',
-            'duration' => 'decimal:2',
+            'duration' => 'float',
         ];
     }
 

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -1047,14 +1047,15 @@ it('creates ScheduledTaskExecution with all fillable attributes', function () {
         'finished_at' => now()->toISOString(),
         'started_at' => now()->subMinute()->toISOString(),
         'retry_count' => 0,
-        'duration' => 60,
+        'duration' => 60.25,
         'error_details' => null,
     ]);
 
     expect($execution->exists)->toBeTrue();
     expect($execution->scheduled_task_id)->toBe($task->id);
     expect($execution->status)->toBe('success');
-    expect((float) $execution->duration)->toBe(60.0);
+    expect($execution->duration)->toBe(60.25);
+    expect($execution->toArray()['duration'])->toBe(60.25);
     expect($execution->retry_count)->toBe(0);
 });
 

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -1047,7 +1047,7 @@ it('creates ScheduledTaskExecution with all fillable attributes', function () {
         'finished_at' => now()->toISOString(),
         'started_at' => now()->subMinute()->toISOString(),
         'retry_count' => 0,
-        'duration' => 60.25,
+        'duration' => '60.25',
         'error_details' => null,
     ]);
 


### PR DESCRIPTION
## Summary

- Return scheduled task execution `duration` values as JSON numbers so the CLI can parse execution listings.
- Add regression coverage for fractional durations and serialized output types.

fixes #11616

---

Fixes #11616