### PR TITLE
fix(terminal): preserve PATH for SSH proxy commands

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -4,7 +4,7 @@ return [
     'coolify' => [
         'version' => env('COOLIFY_VERSION') ?: '4.3.18',
         'helper_version' => '1.0.16',
-        'realtime_version' => '1.0.18',
+        'realtime_version' => '1.0.19',
         'railpack_version' => '0.23.0',
         'self_hosted' => env('SELF_HOSTED', true),
         'autoupdate' => env('AUTOUPDATE'),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,7 +62,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: '${REGISTRY_URL:-docker.io}/coollabsio/coolify-realtime:1.0.18'
+    image: '${REGISTRY_URL:-docker.io}/coollabsio/coolify-realtime:1.0.19'
     ports:
       - "${SOKETI_PORT:-6001}:6001"
       - "6002:6002"

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -97,7 +97,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.18'
+    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.19'
     pull_policy: always
     container_name: coolify-realtime
     restart: always

--- a/docker/coolify-realtime/terminal-server.js
+++ b/docker/coolify-realtime/terminal-server.js
@@ -8,6 +8,7 @@ import {
     extractSshArgs,
     extractTargetHost,
     extractTimeout,
+    getTerminalProcessEnv,
     getTerminalSessionTimeout,
     isAuthorizedTargetHost,
     sanitizeSshArgs,
@@ -401,7 +402,7 @@ async function handleCommand(ws, command, userId) {
         cols: 80,
         rows: 30,
         cwd: process.env.HOME,
-        env: {},
+        env: getTerminalProcessEnv(),
     };
 
     // NOTE: - Initiates a process within the Terminal container

--- a/docker/coolify-realtime/terminal-utils.js
+++ b/docker/coolify-realtime/terminal-utils.js
@@ -1,5 +1,13 @@
 export const MAX_TERMINAL_SESSION_TIMEOUT_SECONDS = 8 * 60 * 60;
 
+const DEFAULT_TERMINAL_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+
+export function getTerminalProcessEnv(environment = process.env) {
+    return {
+        PATH: environment.PATH || DEFAULT_TERMINAL_PATH,
+    };
+}
+
 export function getTerminalSessionTimeout() {
     return MAX_TERMINAL_SESSION_TIMEOUT_SECONDS;
 }

--- a/docker/coolify-realtime/terminal-utils.test.js
+++ b/docker/coolify-realtime/terminal-utils.test.js
@@ -4,12 +4,22 @@ import {
     MAX_TERMINAL_SESSION_TIMEOUT_SECONDS,
     extractSshArgs,
     extractTargetHost,
+    getTerminalProcessEnv,
     getTerminalSessionTimeout,
     isAuthorizedTargetHost,
     normalizeHostForAuthorization,
     sanitizeSshArgs,
     validateSshArgs,
 } from './terminal-utils.js';
+
+test('getTerminalProcessEnv preserves the PATH needed by SSH proxy commands', () => {
+    assert.deepEqual(getTerminalProcessEnv({
+        PATH: '/usr/local/bin:/usr/bin:/bin',
+        APP_KEY: 'must-not-be-inherited',
+    }), {
+        PATH: '/usr/local/bin:/usr/bin:/bin',
+    });
+});
 
 test('extractTargetHost normalizes quoted IPv4 hosts from generated ssh commands', () => {
     const sshArgs = extractSshArgs(

--- a/docker/coolify-realtime/terminal-utils.test.js
+++ b/docker/coolify-realtime/terminal-utils.test.js
@@ -21,6 +21,23 @@ test('getTerminalProcessEnv preserves the PATH needed by SSH proxy commands', ()
     });
 });
 
+test('getTerminalProcessEnv uses the default PATH when PATH is absent', () => {
+    assert.deepEqual(getTerminalProcessEnv({
+        APP_KEY: 'must-not-be-inherited',
+    }), {
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    });
+});
+
+test('getTerminalProcessEnv uses the default PATH when PATH is empty', () => {
+    assert.deepEqual(getTerminalProcessEnv({
+        PATH: '',
+        APP_KEY: 'must-not-be-inherited',
+    }), {
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    });
+});
+
 test('extractTargetHost normalizes quoted IPv4 hosts from generated ssh commands', () => {
     const sshArgs = extractSshArgs(
         "timeout 3600 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=20 -o ConnectTimeout=10 'root'@'10.0.0.5' 'bash -se' << \\\\$abc\necho hi\nabc"


### PR DESCRIPTION
## Summary

- Preserve the terminal process `PATH` so SSH proxy commands such as `cloudflared` remain available when opening server and container terminals.
- Update the Coolify Realtime image to `1.0.19` for production and Windows deployments.
- Add regression coverage for passing `PATH` without exposing unrelated environment variables.

fixes #11611

---

Fixes #11611