### PR TITLE
feat(service): add Zammad one-click service template

### DIFF
--- a/public/svgs/zammad.svg
+++ b/public/svgs/zammad.svg
@@ -1,0 +1,20 @@
+<svg width="42" height="38" viewBox="0 0 42 38" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28.7946 13.1578L38.7344 10.1067L32.8468 13.849L28.7946 13.1578Z" fill="#CA2317"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M34.8491 20.5948L32.8468 13.849L38.7344 10.1067L36.9705 16.1612L34.8491 20.5948Z" fill="#E84F83"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M41.6424 8.27124L40.5459 10.1067L36.9705 16.1611L38.7344 10.1067L41.6424 8.27124Z" fill="#CA2317"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M42 9.46313L39.235 12.2997L40.546 10.1067L42 9.46313Z" fill="#E54011"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.3905 11.2747L37.5188 10.4642L31.8695 12.2043L29.3905 11.2747Z" fill="#E54011"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.7003 15.8751L32.8467 13.849L34.849 20.5947L33.8002 22.74L29.7003 15.8751Z" fill="#CA2317"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.0045 23.8842L23.5028 5.53003L33.8002 22.74L25.0045 23.8842Z" fill="#B7DFF2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20.7378 28.5801L25.0045 23.8843L33.8002 22.7401L20.7378 28.5801Z" fill="#E54011"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 37.8048L20.7378 28.5801L25.0045 23.8843L18.235 23.193L0 37.8048Z" fill="#FFCE33"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.786621 30.2724L11.4416 28.6515L14.7548 25.9818L13.134 25.2667L0.786621 30.2724Z" fill="#D6B12D"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.62427 21.572L14.7548 25.9818L18.2349 23.1929L4.62427 21.572Z" fill="#FFDE85"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.7401 12.1804L21.4529 12.3949L18.235 23.1929L21.7151 20.9999L22.7401 12.1804Z" fill="#009EC6"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.6231 19.1407L21.7151 21L23.5028 5.53003L24.6231 19.1407Z" fill="#5EAFCE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.6345 13.6345L22.7401 12.1805L23.1453 8.58118L13.6345 13.6345Z" fill="#045972"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.6572 5.19641L20.571 9.96372L23.1453 8.5812L23.2168 8.08063L12.6572 5.19641Z" fill="#5A8591"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M14.2065 0L21.4052 7.58002L23.2168 8.08059L23.5028 5.53008L14.2065 0Z" fill="#009EC6"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.235 23.193L24.6232 19.1407L25.0046 23.8842L18.235 23.193Z" fill="#F39804"/>
+</svg>
+

--- a/templates/compose/zammad.yaml
+++ b/templates/compose/zammad.yaml
@@ -1,0 +1,261 @@
+# documentation: https://docs.zammad.org/en/latest/install/docker-compose.html
+# slogan: A web-based, open-source helpdesk and customer support platform.
+# category: helpdesk
+# tags: zammad,helpdesk,ticketing,customer-support,customer-service,support
+# logo: svgs/zammad.svg
+# port: 8080
+---
+x-shared:
+  zammad-service: &zammad-service
+    environment: &zammad-environment
+      MEMCACHE_SERVERS: ${MEMCACHE_SERVERS:-zammad-memcached:11211}
+      POSTGRESQL_DB: ${POSTGRES_DB:-zammad_production}
+      POSTGRESQL_HOST: ${POSTGRES_HOST:-zammad-postgresql}
+      POSTGRESQL_USER: ${POSTGRES_USER:-zammad}
+      POSTGRESQL_PASS: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRESQL_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRESQL_OPTIONS: ${POSTGRESQL_OPTIONS:-?pool=50}
+      POSTGRESQL_DB_CREATE: ${POSTGRESQL_DB_CREATE:-}
+
+      # Redis standalone
+      REDIS_URL: ${REDIS_URL:-redis://zammad-redis:6379}
+      # Redis sentinel
+      REDIS_SENTINELS: ${REDIS_SENTINELS:-}
+      REDIS_SENTINEL_NAME: ${REDIS_SENTINEL_NAME:-}
+      REDIS_USERNAME: ${REDIS_USERNAME:-}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_SENTINEL_USERNAME: ${REDIS_SENTINEL_USERNAME:-}
+      REDIS_SENTINEL_PASSWORD: ${REDIS_SENTINEL_PASSWORD:-}
+
+      S3_URL:
+      # Backup settings
+      BACKUP_DIR: "${BACKUP_DIR:-/var/tmp/zammad}"
+      BACKUP_TIME: "${BACKUP_TIME:-03:00}"
+      BACKUP_ON_START: "${BACKUP_ON_START:-false}"
+      HOLD_DAYS: "${HOLD_DAYS:-10}"
+      TZ: "${TZ:-Europe/Berlin}"
+      # Allow passing in these variables via .env:
+      AUTOWIZARD_JSON: ${AUTOWIZARD_JSON:-}
+      AUTOWIZARD_RELATIVE_PATH: ${AUTOWIZARD_RELATIVE_PATH:-}
+      ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-true}
+      ELASTICSEARCH_SCHEMA: ${ELASTICSEARCH_SCHEMA:-http}
+      ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST:-zammad-elasticsearch}
+      ELASTICSEARCH_PORT: ${ELASTICSEARCH_PORT:-9200}
+      ELASTICSEARCH_USER: ${ELASTICSEARCH_USER:-elastic}
+      ELASTICSEARCH_PASS: ${ELASTICSEARCH_PASS:-zammad}
+      ELASTICSEARCH_NAMESPACE: ${ELASTICSEARCH_NAMESPACE:-zammad}
+      ELASTICSEARCH_REINDEX: ${ELASTICSEARCH_REINDEX:-true}
+      NGINX_PORT: ${NGINX_PORT:-8080}
+      NGINX_CLIENT_MAX_BODY_SIZE: ${NGINX_CLIENT_MAX_BODY_SIZE:-50M}
+      NGINX_SERVER_NAME: ${NGINX_SERVER_NAME:-_}
+      NGINX_SERVER_SCHEME: ${NGINX_SERVER_SCHEME:-http}
+      RAILS_TRUSTED_PROXIES: ${RAILS_TRUSTED_PROXIES:-172.16.0.0/12}
+      ZAMMAD_HTTP_TYPE: ${ZAMMAD_HTTP_TYPE:-https}
+      ZAMMAD_FQDN: ${SERVICE_FQDN_ZAMMAD}
+      ZAMMAD_WEB_CONCURRENCY: ${ZAMMAD_WEB_CONCURRENCY:-}
+      ZAMMAD_MANAGE_SESSIONS_JOBS_WORKERS: ${ZAMMAD_MANAGE_SESSIONS_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_SESSIONS_JOBS_WORKERS: ${ZAMMAD_PROCESS_SESSIONS_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_SCHEDULED_JOBS_WORKERS: ${ZAMMAD_PROCESS_SCHEDULED_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_DELAYED_JOBS_WORKERS: ${ZAMMAD_PROCESS_DELAYED_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_DELAYED_JOBS_WORKER_THREADS: ${ZAMMAD_PROCESS_DELAYED_JOBS_WORKER_THREADS:-}
+      ZAMMAD_PROCESS_DELAYED_AI_JOBS_WORKERS: ${ZAMMAD_PROCESS_DELAYED_AI_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_DELAYED_AI_JOBS_WORKER_THREADS: ${ZAMMAD_PROCESS_DELAYED_AI_JOBS_WORKER_THREADS:-}
+      ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_WORKERS: ${ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_WORKERS:-}
+      ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_WORKER_THREADS: ${ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_WORKER_THREADS:-}
+      ZAMMAD_OTRS_IMPORT_READ_TIMEOUT: ${ZAMMAD_OTRS_IMPORT_READ_TIMEOUT:-}
+      ZAMMAD_OTRS_IMPORT_TOTAL_TIMEOUT: ${ZAMMAD_OTRS_IMPORT_TOTAL_TIMEOUT:-}
+      ZAMMAD_HTTP_OPEN_TIMEOUT: ${ZAMMAD_HTTP_OPEN_TIMEOUT:-30}
+      ZAMMAD_HTTP_READ_TIMEOUT: ${ZAMMAD_HTTP_READ_TIMEOUT:-60}
+      ZAMMAD_HTTP_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_TOTAL_TIMEOUT:-60}
+      ZAMMAD_HTTP_AI_READ_TIMEOUT: ${ZAMMAD_HTTP_AI_READ_TIMEOUT:-}
+      ZAMMAD_HTTP_AI_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_AI_TOTAL_TIMEOUT:-}
+      ZAMMAD_HTTP_ELASTICSEARCH_READ_TIMEOUT: ${ZAMMAD_HTTP_ELASTICSEARCH_READ_TIMEOUT:-}
+      ZAMMAD_HTTP_ELASTICSEARCH_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_ELASTICSEARCH_TOTAL_TIMEOUT:-}
+      ZAMMAD_HTTP_ELASTICSEARCH_REINDEX_READ_TIMEOUT: ${ZAMMAD_HTTP_ELASTICSEARCH_REINDEX_READ_TIMEOUT:-}
+      ZAMMAD_HTTP_ELASTICSEARCH_REINDEX_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_ELASTICSEARCH_REINDEX_TOTAL_TIMEOUT:-}
+      ZAMMAD_HTTP_IMPORT_ATTACHMENT_READ_TIMEOUT: ${ZAMMAD_HTTP_IMPORT_ATTACHMENT_READ_TIMEOUT:-}
+      ZAMMAD_HTTP_IMPORT_ATTACHMENT_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_IMPORT_ATTACHMENT_TOTAL_TIMEOUT:-}
+      ZAMMAD_HTTP_WEBHOOK_READ_TIMEOUT: ${ZAMMAD_HTTP_WEBHOOK_READ_TIMEOUT:-}
+      ZAMMAD_HTTP_WEBHOOK_TOTAL_TIMEOUT: ${ZAMMAD_HTTP_WEBHOOK_TOTAL_TIMEOUT:-}
+
+      # Allow disabling individual background services in the scheduler container.
+      ZAMMAD_PROCESS_SESSIONS_JOBS_DISABLE: ${ZAMMAD_PROCESS_SESSIONS_JOBS_DISABLE:-}
+      ZAMMAD_MANAGE_SESSIONS_JOBS_DISABLE: ${ZAMMAD_MANAGE_SESSIONS_JOBS_DISABLE:-}
+      ZAMMAD_PROCESS_SCHEDULED_JOBS_DISABLE: ${ZAMMAD_PROCESS_SCHEDULED_JOBS_DISABLE:-}
+      ZAMMAD_PROCESS_DELAYED_JOBS_DISABLE: ${ZAMMAD_PROCESS_DELAYED_JOBS_DISABLE:-}
+      ZAMMAD_PROCESS_DELAYED_AI_JOBS_DISABLE: ${ZAMMAD_PROCESS_DELAYED_AI_JOBS_DISABLE:-}
+      ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_DISABLE: ${ZAMMAD_PROCESS_DELAYED_COMMUNICATION_INBOUND_JOBS_DISABLE:-}
+
+      ZAMMAD_GRAPHQL_INTROSPECTION: ${ZAMMAD_GRAPHQL_INTROSPECTION:-false}
+      ZAMMAD_AI_API_URL: ${ZAMMAD_AI_API_URL:-}
+      ZAMMAD_AI_TOKEN: ${ZAMMAD_AI_TOKEN:-}
+      ZAMMAD_UI_BULK_BACKGROUND_UPDATE_THRESHOLD: ${ZAMMAD_UI_BULK_BACKGROUND_UPDATE_THRESHOLD:-}
+      ZAMMAD_SETTING_TTL: ${ZAMMAD_SETTING_TTL:-}
+      ZAMMAD_SAFE_MODE: ${ZAMMAD_SAFE_MODE:-}
+      ZAMMAD_WEBSOCKET_SESSION_STORE_FORCE_FS_BACKEND: ${ZAMMAD_WEBSOCKET_SESSION_STORE_FORCE_FS_BACKEND:-}
+      ZAMMAD_RAILSSERVER_PORT: ${ZAMMAD_RAILSSERVER_PORT:-3000}
+
+      # ZAMMAD_SESSION_JOBS_CONCURRENT is deprecated, please use ZAMMAD_PROCESS_SESSIONS_JOBS_WORKERS instead.
+      ZAMMAD_SESSION_JOBS_CONCURRENT: ${ZAMMAD_SESSION_JOBS_CONCURRENT:-}
+      # Variables used by ngingx-proxy container for reverse proxy creations
+      # for docs refer to https://github.com/nginx-proxy/nginx-proxy
+      VIRTUAL_HOST: ${VIRTUAL_HOST:-}
+      VIRTUAL_PORT: ${VIRTUAL_PORT:-}
+      # Variables used by acme-companion for retrieval of LetsEncrypt certificate
+      # for docs refer to https://github.com/nginx-proxy/acme-companion
+      LETSENCRYPT_HOST: ${LETSENCRYPT_HOST:-}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-}
+
+    image: ghcr.io/zammad/zammad:7.1.3-0006
+    init: true
+    restart: always
+    volumes:
+      - zammad-backup:/var/tmp/zammad:ro # needed for waiting on restore operations
+      - zammad-storage:/opt/zammad/storage
+    depends_on:
+      zammad-memcached:
+        condition: service_healthy
+      zammad-postgresql:
+        condition: service_healthy
+      zammad-redis:
+        condition: service_healthy
+
+services:
+  zammad-backup:
+    <<: *zammad-service
+    command: ["zammad-backup"]
+    volumes:
+      - zammad-backup:/var/tmp/zammad
+      - zammad-storage:/opt/zammad/storage
+    user: 0:0
+    healthcheck:
+      test: ["CMD", "pgrep", "-f", "backup.sh"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+
+  zammad-elasticsearch:
+    image: elasticsearch:9.5.2
+    restart: always
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: ${ELASTICSEARCH_JAVA_OPTS:--Xms1g -Xmx1g}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:9200/_cluster/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 120s
+      retries: 5
+
+  zammad-init:
+    <<: *zammad-service
+    command: ["zammad-init"]
+    exclude_from_hc: true
+    restart: on-failure
+    user: 0:0
+
+  zammad-memcached:
+    command: memcached -m 256M
+    image: memcached:1.6.45-alpine
+    restart: always
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "11211"]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
+
+  zammad:
+    <<: *zammad-service
+    environment:
+      <<: *zammad-environment
+      NGINX_PORT: "8080"
+      NGINX_SERVER_SCHEME: "https"
+      SERVICE_URL_ZAMMAD_8080:
+    command: ["zammad-nginx"]
+    init: false
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    depends_on:
+      zammad-railsserver:
+        condition: service_healthy
+
+  zammad-postgresql:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-zammad_production}
+      POSTGRES_USER: ${POSTGRES_USER:-zammad}
+      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+    image: postgres:17.11-alpine
+    restart: always
+    volumes:
+      - postgresql-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      start_period: 60s
+      retries: 5
+
+  zammad-railsserver:
+    <<: *zammad-service
+    command: ["zammad-railsserver"]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:${ZAMMAD_RAILSSERVER_PORT:-3000}"]
+      interval: 30s
+      timeout: 5s
+      start_period: 120s
+      retries: 3
+
+  zammad-redis:
+    image: redis:8.10.1-alpine
+    restart: always
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
+
+  zammad-scheduler:
+    <<: *zammad-service
+    command: ["zammad-scheduler"]
+    healthcheck:
+      test: ["CMD", "pgrep", "-f", "background-worker"]
+      interval: 30s
+      timeout: 5s
+      start_period: 120s
+      retries: 3
+
+  zammad-websocket:
+    <<: *zammad-service
+    command: ["zammad-websocket"]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/6042"]
+      interval: 30s
+      timeout: 5s
+      start_period: 120s
+      retries: 3
+
+volumes:
+  elasticsearch-data:
+    driver: local
+  postgresql-data:
+    driver: local
+  redis-data:
+    driver: local
+  zammad-backup:
+    driver: local
+  zammad-storage:
+    driver: local

--- a/tests/Unit/ZammadServiceTemplateTest.php
+++ b/tests/Unit/ZammadServiceTemplateTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+it('includes a production-ready Zammad one-click service template', function () {
+    $source = file_get_contents(__DIR__.'/../../templates/compose/zammad.yaml');
+    $compose = Yaml::parse($source);
+    $services = $compose['services'];
+    $sharedEnvironment = $compose['x-shared']['zammad-service']['environment'];
+    $zammad = $services['zammad'];
+
+    expect($source)
+        ->toContain('# documentation: https://docs.zammad.org/en/latest/install/docker-compose.html')
+        ->toContain('# category: helpdesk')
+        ->toContain('# logo: svgs/zammad.svg')
+        ->toContain('# port: 8080')
+        ->and(array_keys($services))->toBe([
+            'zammad-backup',
+            'zammad-elasticsearch',
+            'zammad-init',
+            'zammad-memcached',
+            'zammad',
+            'zammad-postgresql',
+            'zammad-railsserver',
+            'zammad-redis',
+            'zammad-scheduler',
+            'zammad-websocket',
+        ])
+        ->and($services['zammad-backup']['image'])->toBe('ghcr.io/zammad/zammad:7.1.3-0006')
+        ->and($services['zammad-elasticsearch']['image'])->toBe('elasticsearch:9.5.2')
+        ->and($services['zammad-memcached']['image'])->toBe('memcached:1.6.45-alpine')
+        ->and($services['zammad-postgresql']['image'])->toBe('postgres:17.11-alpine')
+        ->and($services['zammad-redis']['image'])->toBe('redis:8.10.1-alpine')
+        ->and($services['zammad-init']['exclude_from_hc'])->toBeTrue()
+        ->and($services['zammad-init']['restart'])->toBe('on-failure')
+        ->and($zammad['expose'])->toBe(['8080'])
+        ->and($zammad)->not->toHaveKey('ports')
+        ->and($zammad['environment'])->toHaveKey('SERVICE_URL_ZAMMAD_8080', null)
+        ->and($zammad['healthcheck']['test'])->toBe(['CMD', 'curl', '-sf', 'http://127.0.0.1:8080/'])
+        ->and($sharedEnvironment['ZAMMAD_FQDN'])->toBe('${SERVICE_FQDN_ZAMMAD}')
+        ->and($sharedEnvironment)->toHaveKey('S3_URL', null)
+        ->and($sharedEnvironment['POSTGRESQL_PASS'])->toBe('${SERVICE_PASSWORD_POSTGRES}')
+        ->and($services['zammad-postgresql']['environment']['POSTGRES_PASSWORD'])->toBe('${SERVICE_PASSWORD_POSTGRES}')
+        ->and(array_keys($compose['volumes']))->toBe([
+            'elasticsearch-data',
+            'postgresql-data',
+            'redis-data',
+            'zammad-backup',
+            'zammad-storage',
+        ]);
+});
+
+it('health checks every long-running Zammad container', function () {
+    $compose = Yaml::parse(file_get_contents(__DIR__.'/../../templates/compose/zammad.yaml'));
+
+    /** The one-shot initializer exits after migrating, so it is excluded instead of health checked. */
+    $longRunning = array_diff(array_keys($compose['services']), ['zammad-init']);
+
+    $missing = array_values(array_filter(
+        $longRunning,
+        fn (string $name): bool => blank($compose['services'][$name]['healthcheck']['test'] ?? null),
+    ));
+
+    expect($missing)->toBe([]);
+
+    expect($compose['services']['zammad-backup']['healthcheck']['test'])->toBe(['CMD', 'pgrep', '-f', 'backup.sh'])
+        ->and($compose['services']['zammad-scheduler']['healthcheck']['test'])->toBe(['CMD', 'pgrep', '-f', 'background-worker'])
+        ->and($compose['services']['zammad-websocket']['healthcheck']['test'])->toBe(['CMD', 'bash', '-c', 'exec 3<>/dev/tcp/127.0.0.1/6042'])
+        ->and($compose['services']['zammad-elasticsearch']['healthcheck']['test'])->toBe(['CMD', 'curl', '-sf', 'http://127.0.0.1:9200/_cluster/health']);
+});
+
+it('ships the official Zammad service icon', function () {
+    $document = new DOMDocument;
+
+    expect($document->load(__DIR__.'/../../public/svgs/zammad.svg', LIBXML_NONET))->toBeTrue()
+        ->and($document->documentElement?->getAttribute('viewBox'))->toBe('0 0 42 38');
+});


### PR DESCRIPTION
## Changes

- Added Zammad as a new one-click service, based on the official release at https://github.com/zammad/zammad-docker-compose.
- Coolify-specific changes: renamed the public nginx service to `zammad` so the generated domain attaches to it; pinned every image tag; PostgreSQL credentials and the domain come from Coolify magic variables; the one-shot init container is excluded from health aggregation; dropped the nginx-proxy and acme-companion variables, since Coolify's proxy handles that.
- Added healthchecks to the four containers upstream leaves bare (Elasticsearch, websocket, scheduler, backup), so the service reports a real status instead of "unknown".
- Added the official Zammad logo and a template unit test.

## Issues

- Addresses https://github.com/coollabsio/coolify/discussions/3869

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Opus 5
- How extensively: template tests and the local deployment runs. All code and tests reviewed by me before committing.

## Testing

Deployed end to end on a local Coolify dev instance:

- Card and logo render in the one-click list, no console errors.
- Creates 7 applications and 3 databases with 88 environment variables, none missing.
- All 10 containers reach their expected state: init exits 0, every long-running container reports healthy, and PostgreSQL ends up with 128 tables.
- The generated domain serves the Zammad setup wizard through the Coolify proxy, and a redeploy comes back healthy with data intact.
- The new unit test and the existing service-template tests pass.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
