### PR TITLE
feat(env-vars): bulk edit build time and runtime availability

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -62,6 +62,10 @@ class All extends Component
      */
     public bool $readyToLoad = false;
 
+    public const SELECTION_RESET_EVENT = 'environment-variable-selection-reset';
+
+    private const BULK_AVAILABILITY_FIELDS = ['is_buildtime', 'is_runtime'];
+
     protected $listeners = [
         'saveKey' => 'submit',
         'refreshEnvs',
@@ -86,6 +90,8 @@ class All extends Component
         unset($this->environmentVariableRowCount);
         unset($this->environmentVariableLastPage);
         unset($this->currentEnvironmentVariablePage);
+
+        $this->dispatch(self::SELECTION_RESET_EVENT);
     }
 
     public function mount()
@@ -428,6 +434,91 @@ class All extends Component
         $this->environmentFilter = 'all';
         $this->page = 1;
         $this->clearEnvironmentVariableCaches();
+    }
+
+    public function bulkUpdateAvailability(string $field, bool $value, array $ids): void
+    {
+        try {
+            $this->authorize('manageEnvironment', $this->resource);
+
+            if (! in_array($field, self::BULK_AVAILABILITY_FIELDS, true)) {
+                throw new \InvalidArgumentException('Only build time and runtime availability can be changed in bulk.');
+            }
+
+            $ids = collect($ids)
+                ->filter(fn (mixed $id): bool => is_int($id) || (is_string($id) && ctype_digit($id)))
+                ->map(fn (int|string $id): int => (int) $id)
+                ->unique()
+                ->values();
+
+            if ($ids->isEmpty()) {
+                $this->dispatch('error', 'Select at least one environment variable first.');
+
+                return;
+            }
+
+            $this->ensureEnvironmentVariablesLoaded();
+
+            $updatedIds = EnvironmentVariable::query()
+                ->where('resourceable_type', $this->resource->getMorphClass())
+                ->where('resourceable_id', $this->resource->id)
+                ->whereIn('id', $ids->all())
+                ->get()
+                ->reject(fn (EnvironmentVariable $environmentVariable): bool => $this->isAvailabilityLocked($environmentVariable))
+                ->filter(fn (EnvironmentVariable $environmentVariable): bool => (bool) $environmentVariable->{$field} !== $value)
+                ->each(function (EnvironmentVariable $environmentVariable) use ($field, $value): void {
+                    $environmentVariable->{$field} = $value;
+                    $environmentVariable->save();
+                })
+                ->map(fn (EnvironmentVariable $environmentVariable): int => (int) $environmentVariable->id)
+                ->values()
+                ->all();
+
+            $this->clearEnvironmentVariableCaches();
+
+            if ($updatedIds === []) {
+                $this->dispatch('info', 'The selected environment variables already have this availability.');
+
+                return;
+            }
+
+            if ($this->updatedRowsRemainVisible($updatedIds)) {
+                $this->dispatch('refreshEnvs')->to(Show::class);
+            }
+
+            $label = $field === 'is_buildtime' ? 'Build time' : 'Runtime';
+            $count = count($updatedIds);
+            $this->dispatch('success', sprintf(
+                '%s availability updated for %d %s.',
+                $label,
+                $count,
+                Str::plural('environment variable', $count),
+            ));
+            $this->dispatch('envsUpdated');
+            $this->dispatch('configurationChanged');
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+    }
+
+    private function isAvailabilityLocked(EnvironmentVariable $environmentVariable): bool
+    {
+        if (str($environmentVariable->key)->startsWith(['SERVICE_FQDN', 'SERVICE_URL', 'SERVICE_NAME'])) {
+            return true;
+        }
+
+        return $this->resource->type() === 'standalone-redis'
+            && in_array($environmentVariable->key, ['REDIS_PASSWORD', 'REDIS_USERNAME'], true);
+    }
+
+    private function updatedRowsRemainVisible(array $updatedIds): bool
+    {
+        $visibleIds = $this->environmentVariablePageRows
+            ->filter(fn (array $row): bool => $row['kind'] === 'managed')
+            ->map(fn (array $row): int => (int) $row['environmentVariable']->id)
+            ->all();
+
+        return array_intersect($updatedIds, $visibleIds) !== [];
     }
 
     public function getServiceFilterOptionsProperty(): array

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -24,6 +24,8 @@ class Show extends Component
 {
     public bool $showEnvironmentType = true;
 
+    public bool $selectable = false;
+
     use AuthorizesRequests, EnvironmentVariableAnalyzer, EnvironmentVariableProtection, HasSecretManagerAutocomplete;
 
     protected function secretManagerResource(): ?Model

--- a/app/Livewire/Project/Shared/EnvironmentVariable/ShowHardcoded.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/ShowHardcoded.php
@@ -9,6 +9,8 @@ class ShowHardcoded extends Component
 {
     public bool $showEnvironmentType = true;
 
+    public bool $selectable = false;
+
     public array $env;
 
     public string $key;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2276,6 +2276,18 @@ input[type="search"]::-webkit-search-results-decoration {
     grid-template-columns: minmax(14rem, 2.5fr) 4.8rem 4rem 4.5rem 4.8rem 4.2rem 3rem;
 }
 
+.env-table-grid.env-table-grid-selectable {
+    grid-template-columns: 1.125rem minmax(14rem, 2.5fr) 4.8rem 6rem 4rem 4.5rem 4.8rem 4.2rem 3rem;
+}
+
+.env-table-grid.env-table-grid-no-type.env-table-grid-selectable {
+    grid-template-columns: 1.125rem minmax(14rem, 2.5fr) 4.8rem 4rem 4.5rem 4.8rem 4.2rem 3rem;
+}
+
+.environment-table-scroll .env-table-grid.env-table-grid-selectable {
+    min-width: 55.25rem;
+}
+
 @media (max-width: 768px) {
     .environment-table-scroll .env-table-grid {
         min-width: 0;
@@ -2298,6 +2310,18 @@ input[type="search"]::-webkit-search-results-decoration {
     .data-table-row.env-table-grid > :last-child {
         display: block;
         justify-self: end;
+    }
+
+    .environment-table-scroll .env-table-grid.env-table-grid-selectable {
+        min-width: 0;
+    }
+
+    .data-table-row.env-table-grid.env-table-grid-selectable {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
+
+    .data-table-row.env-table-grid.env-table-grid-selectable > :nth-child(2) {
+        display: flex;
     }
 }
 

--- a/resources/views/components/table/checkbox.blade.php
+++ b/resources/views/components/table/checkbox.blade.php
@@ -1,0 +1,17 @@
+@props(['label' => 'Select row'])
+
+<span class="group relative flex size-[18px] shrink-0 cursor-pointer">
+    <input type="checkbox" aria-label="{{ $label }}"
+        {{ $attributes->class(['peer absolute inset-0 z-10 m-0 h-full w-full cursor-pointer appearance-none opacity-0']) }} />
+    <span
+        class="pointer-events-none absolute inset-0 rounded-[5px] border border-neutral-300 bg-white shadow-[inset_0_1px_1px_rgb(0_0_0/0.04)] transition-colors group-hover:border-neutral-400 peer-checked:border-coollabs peer-checked:bg-coollabs peer-indeterminate:border-coollabs peer-indeterminate:bg-coollabs peer-focus-visible:ring-2 peer-focus-visible:ring-coollabs/25 peer-focus-visible:ring-offset-2 dark:border-white/[0.14] dark:bg-white/[0.045] dark:shadow-none dark:group-hover:border-white/[0.22] dark:peer-checked:border-warning dark:peer-checked:bg-warning dark:peer-indeterminate:border-warning dark:peer-indeterminate:bg-warning dark:peer-focus-visible:ring-warning/30 dark:peer-focus-visible:ring-offset-base"></span>
+    <svg class="pointer-events-none absolute inset-0 m-auto size-3 scale-75 text-white opacity-0 transition-[opacity,transform] peer-checked:scale-100 peer-checked:opacity-100 dark:text-black"
+        viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="m2.25 6.15 2.35 2.3 5.15-5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+            stroke-linejoin="round" />
+    </svg>
+    <svg class="pointer-events-none absolute inset-0 m-auto size-3 text-white opacity-0 transition-opacity peer-indeterminate:opacity-100 dark:text-black"
+        viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M2.75 6h6.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+    </svg>
+</span>

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -11,8 +11,38 @@
         $activeFilterLabels->push(str($environmentFilter)->headline()->toString());
     }
     $activeFilterText = $activeFilterLabels->implode(', ');
+    $canBulkEdit = auth()->user()?->can('manageEnvironment', $resource) ?? false;
 @endphp
-<div class="flex flex-col gap-4" wire:init="loadEnvironmentVariables">
+<div class="flex flex-col gap-4" wire:init="loadEnvironmentVariables"
+    x-data="{
+        selectedIds: [],
+        pageIds() {
+            return Array.from(this.$root.querySelectorAll('[data-env-select-id]'), (el) => Number(el.dataset.envSelectId));
+        },
+        get allSelected() {
+            const ids = this.pageIds();
+            return ids.length > 0 && ids.every((id) => this.selectedIds.includes(id));
+        },
+        get someSelected() {
+            return this.selectedIds.length > 0 && !this.allSelected;
+        },
+        isSelected(id) {
+            return this.selectedIds.includes(id);
+        },
+        toggleSelected(id) {
+            this.selectedIds = this.isSelected(id)
+                ? this.selectedIds.filter((selectedId) => selectedId !== id)
+                : [...this.selectedIds, id];
+        },
+        toggleAll() {
+            this.selectedIds = this.allSelected ? [] : this.pageIds();
+        },
+        applyAvailability(field, value) {
+            if (this.selectedIds.length === 0) return;
+            this.$wire.bulkUpdateAvailability(field, value, this.selectedIds);
+        },
+    }"
+    x-on:environment-variable-selection-reset.window="selectedIds = []">
     <x-application.settings-section id="environment-variables-section" title="Environment variables"
         helper="Environment variables (secrets) for this resource.">
         @can('manageEnvironment', $resource)
@@ -158,6 +188,39 @@
                         @endforeach
             </x-table.sort>
                 @can('manageEnvironment', $resource)
+                    <div class="table-availability">
+                        <x-table.dropdown panel-class="w-60!">
+                            <x-slot:trigger>
+                                <button type="button" aria-haspopup="listbox" :aria-expanded="open"
+                                    x-bind:disabled="selectedIds.length === 0"
+                                    x-bind:class="{ 'button-highlighted': selectedIds.length > 0 }"
+                                    x-bind:title="selectedIds.length > 0
+                                        ? `Change build time / runtime availability of ${selectedIds.length} selected ${selectedIds.length === 1 ? 'variable' : 'variables'}`
+                                        : 'Select environment variables to change their availability'"
+                                    class="button">
+                                    <x-reicon name="sliders" class="size-3.5 shrink-0" />
+                                    <span>Availability</span>
+                                    <span x-show="selectedIds.length > 0" x-text="selectedIds.length"
+                                        class="shrink-0 rounded-full bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-500 dark:bg-white/[0.07] dark:text-fg-dim"></span>
+                                </button>
+                            </x-slot:trigger>
+                            <span class="block px-2 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-fg-faint">Build time</span>
+                            <button type="button" class="listbox-option" @click="applyAvailability('is_buildtime', true); open = false">
+                                <span>Available during build</span>
+                            </button>
+                            <button type="button" class="listbox-option" @click="applyAvailability('is_buildtime', false); open = false">
+                                <span>Not available during build</span>
+                            </button>
+                            <div class="my-1 border-t border-neutral-200 dark:border-white/10"></div>
+                            <span class="block px-2 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-fg-faint">Runtime</span>
+                            <button type="button" class="listbox-option" @click="applyAvailability('is_runtime', true); open = false">
+                                <span>Available in the container</span>
+                            </button>
+                            <button type="button" class="listbox-option" @click="applyAvailability('is_runtime', false); open = false">
+                                <span>Not available in the container</span>
+                            </button>
+                        </x-table.dropdown>
+                    </div>
                     {{-- Do not disable Add based on readyToLoad: modal-input uses wire:ignore, so a
                          disabled attribute painted on first load would never re-enable. --}}
                     <x-modal-input title="New Environment Variable" :closeOutside="false">
@@ -199,8 +262,13 @@
                         <div class="environment-table-scroll relative">
                             <div class="transition-all"
                                 wire:loading.class="pointer-events-none opacity-40 blur-[2px]"
-                                wire:target="toggleVariableFilter,toggleServiceFilter,clearFilters,setEnvironmentFilter,setTableSort,setEnvironmentVariablePage,previousEnvironmentVariablePage,nextEnvironmentVariablePage">
-                            <div class="data-table-header env-table-grid {{ $showEnvironmentType ? '' : 'env-table-grid-no-type' }}">
+                                wire:target="toggleVariableFilter,toggleServiceFilter,clearFilters,setEnvironmentFilter,setTableSort,setEnvironmentVariablePage,previousEnvironmentVariablePage,nextEnvironmentVariablePage,bulkUpdateAvailability">
+                            <div class="data-table-header env-table-grid {{ $showEnvironmentType ? '' : 'env-table-grid-no-type' }} {{ $canBulkEdit ? 'env-table-grid-selectable' : '' }}">
+                            @if ($canBulkEdit)
+                                <x-table.checkbox label="Select all environment variables on this page"
+                                    x-bind:checked="allSelected" x-effect="$el.indeterminate = someSelected"
+                                    x-on:change="toggleAll()" />
+                            @endif
                             <span>Name</span>
                             <span class="text-center">Managed</span>
                             @if ($showEnvironmentType)
@@ -215,17 +283,19 @@
                             @foreach ($this->environmentVariablePageRows as $row)
                             @if ($row['kind'] === 'managed')
                                 <livewire:project.shared.environment-variable.show wire:key="{{ $row['id'] }}"
-                                    :env="$row['environmentVariable']" :type="$resource->type()" :showEnvironmentType="$showEnvironmentType" />
+                                    :env="$row['environmentVariable']" :type="$resource->type()" :showEnvironmentType="$showEnvironmentType"
+                                    :selectable="$canBulkEdit" />
                             @else
                                 <livewire:project.shared.environment-variable.show-hardcoded
                                     wire:key="{{ $row['id'] }}" :env="$row['environmentVariable']"
                                     :isPreview="$row['scope'] === 'preview'" :showEnvironmentType="$showEnvironmentType"
-                                    :resourceableType="get_class($resource)" :resourceableId="$resource->id" />
+                                    :resourceableType="get_class($resource)" :resourceableId="$resource->id"
+                                    :selectable="$canBulkEdit" />
                             @endif
                             @endforeach
                             </div>
                             <x-table.loading
-                                target="toggleVariableFilter,toggleServiceFilter,clearFilters,setEnvironmentFilter,setTableSort,setEnvironmentVariablePage,previousEnvironmentVariablePage,nextEnvironmentVariablePage"
+                                target="toggleVariableFilter,toggleServiceFilter,clearFilters,setEnvironmentFilter,setTableSort,setEnvironmentVariablePage,previousEnvironmentVariablePage,nextEnvironmentVariablePage,bulkUpdateAvailability"
                                 text="Loading environment variables..." />
                         </div>
                         <x-table-pagination :from="$firstVisibleRow" :to="$lastVisibleRow" :total="$totalRows"

--- a/resources/views/livewire/project/shared/environment-variable/show-hardcoded.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show-hardcoded.blade.php
@@ -1,6 +1,9 @@
 <div class="env-table-item"
     x-show="typeof envFilter === 'undefined' || envFilter === 'all' || envFilter === '{{ $isPreview ? 'preview' : 'production' }}'">
-    <div class="data-table-row env-table-grid {{ $showEnvironmentType ? '' : 'env-table-grid-no-type' }}">
+    <div class="data-table-row env-table-grid {{ $showEnvironmentType ? '' : 'env-table-grid-no-type' }} {{ $selectable ? 'env-table-grid-selectable' : '' }}">
+        @if ($selectable)
+            <span></span>
+        @endif
         <div class="flex min-w-0 items-center gap-2">
             <button type="button" data-env-name-trigger
                 class="env-key-label min-w-0 truncate text-left font-mono text-[13px] text-black dark:text-fg"

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -7,12 +7,21 @@
     $showInterpolation = !$is_redis_credential && !$isMagicVariable && !$isSharedVariable;
     $showBuildtime = !$is_redis_credential && !$isMagicVariable && !$isSharedVariable;
     $showRuntime = !$is_redis_credential && !$isMagicVariable && !$isSharedVariable;
+    $isSelectable = $selectable && $canUpdate && $showBuildtime && $showRuntime;
 @endphp
 <div class="env-table-item"
     @if ($isSharedVariable) :style="`order: ${sharedSort === 'alphabetical' ? {{ $tableAlphabeticalOrder }} : {{ $tableCreationOrder }}}`" @endif
     x-show="(typeof envFilter === 'undefined' || envFilter === 'all' || envFilter === '{{ $rowScope }}')
         && (typeof sharedSearch === 'undefined' || @js(mb_strtolower($env->key . ' ' . ($comment ?? '') . ' ' . $rowScopeLabel)).includes(sharedSearch.trim().toLowerCase()))">
-    <div class="data-table-row {{ $isSharedVariable ? 'env-table-grid-shared' : 'env-table-grid' }} {{ ! $isSharedVariable && ! $showEnvironmentType ? 'env-table-grid-no-type' : '' }}">
+    <div class="data-table-row {{ $isSharedVariable ? 'env-table-grid-shared' : 'env-table-grid' }} {{ ! $isSharedVariable && ! $showEnvironmentType ? 'env-table-grid-no-type' : '' }} {{ $selectable ? 'env-table-grid-selectable' : '' }}">
+        @if ($selectable)
+            @if ($isSelectable)
+                <x-table.checkbox label="Select {{ $env->key }}" data-env-select-id="{{ $env->id }}"
+                    x-bind:checked="isSelected({{ $env->id }})" x-on:change="toggleSelected({{ $env->id }})" />
+            @else
+                <span></span>
+            @endif
+        @endif
         <div class="flex min-w-0 items-center gap-2">
             @if ($isLocked)
                 <svg class="size-3.5 shrink-0 text-neutral-400 dark:text-fg-faint" viewBox="0 0 24 24"

--- a/tests/Feature/EnvironmentVariableBulkAvailabilityTest.php
+++ b/tests/Feature/EnvironmentVariableBulkAvailabilityTest.php
@@ -1,0 +1,277 @@
+<?php
+
+use App\Livewire\Project\Shared\EnvironmentVariable\All;
+use App\Livewire\Project\Shared\EnvironmentVariable\Show;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function createBulkAvailabilityApplication(Team $team): Application
+{
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'build_pack' => 'dockerfile',
+    ]);
+
+    EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $application->id)
+        ->delete();
+
+    return $application;
+}
+
+function createBulkAvailabilityVariable(Application $application, string $key, array $attributes = []): EnvironmentVariable
+{
+    $variable = EnvironmentVariable::create(array_merge([
+        'key' => $key,
+        'value' => 'value',
+        'is_preview' => false,
+        'is_buildtime' => true,
+        'is_runtime' => true,
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $application->id,
+    ], $attributes));
+
+    EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $application->id)
+        ->where('is_preview', true)
+        ->delete();
+
+    return $variable->fresh();
+}
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->team = Team::factory()->create();
+
+    $this->admin = User::factory()->create();
+    $this->admin->teams()->attach($this->team, ['role' => 'admin']);
+
+    $this->member = User::factory()->create();
+    $this->member->teams()->attach($this->team, ['role' => 'member']);
+
+    $this->application = createBulkAvailabilityApplication($this->team);
+
+    $this->first = createBulkAvailabilityVariable($this->application, 'FIRST_VAR');
+    $this->second = createBulkAvailabilityVariable($this->application, 'SECOND_VAR');
+    $this->third = createBulkAvailabilityVariable($this->application, 'THIRD_VAR');
+
+    $this->actingAs($this->admin);
+    session(['currentTeam' => $this->team]);
+});
+
+it('turns build time availability off for the selected variables only', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_buildtime', false, [$this->first->id, (string) $this->second->id])
+        ->assertDispatched('success', 'Build time availability updated for 2 environment variables.')
+        ->assertDispatched('refreshEnvs')
+        ->assertDispatched('envsUpdated')
+        ->assertDispatched('configurationChanged')
+        ->assertDispatched(All::SELECTION_RESET_EVENT);
+
+    expect($this->first->fresh()->is_buildtime)->toBeFalse()
+        ->and($this->second->fresh()->is_buildtime)->toBeFalse()
+        ->and($this->third->fresh()->is_buildtime)->toBeTrue()
+        ->and($this->first->fresh()->is_runtime)->toBeTrue();
+});
+
+it('turns runtime availability on for selected variables that were switched off', function () {
+    $this->first->update(['is_runtime' => false]);
+    $this->second->update(['is_runtime' => false]);
+
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_runtime', true, [$this->first->id, $this->third->id])
+        ->assertDispatched('success', 'Runtime availability updated for 1 environment variable.');
+
+    expect($this->first->fresh()->is_runtime)->toBeTrue()
+        ->and($this->second->fresh()->is_runtime)->toBeFalse()
+        ->and($this->third->fresh()->is_runtime)->toBeTrue();
+});
+
+it('reports when the selected variables already have the requested availability', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_buildtime', true, [$this->first->id])
+        ->assertDispatched('info')
+        ->assertNotDispatched('success')
+        ->assertNotDispatched('configurationChanged');
+});
+
+it('ignores variables that belong to another resource', function () {
+    $otherTeam = Team::factory()->create();
+    $otherApplication = createBulkAvailabilityApplication($otherTeam);
+    $foreign = createBulkAvailabilityVariable($otherApplication, 'FOREIGN_VAR');
+
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_buildtime', false, [$foreign->id, $this->first->id])
+        ->assertDispatched('success', 'Build time availability updated for 1 environment variable.');
+
+    expect($foreign->fresh()->is_buildtime)->toBeTrue()
+        ->and($this->first->fresh()->is_buildtime)->toBeFalse();
+});
+
+it('skips generated service variables', function () {
+    $generated = createBulkAvailabilityVariable($this->application, 'SERVICE_FQDN_APP');
+
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_runtime', false, [$generated->id])
+        ->assertDispatched('info');
+
+    expect($generated->fresh()->is_runtime)->toBeTrue();
+});
+
+it('rejects flags other than build time and runtime', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_literal', true, [$this->first->id])
+        ->assertDispatched('error')
+        ->assertNotDispatched('success');
+
+    expect((bool) $this->first->fresh()->is_literal)->toBeFalse();
+});
+
+it('requires a selection', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_buildtime', false, ['abc', null])
+        ->assertDispatched('error')
+        ->assertNotDispatched('success');
+
+    expect($this->first->fresh()->is_buildtime)->toBeTrue();
+});
+
+it('does not let members change availability in bulk', function () {
+    $this->actingAs($this->member);
+
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('bulkUpdateAvailability', 'is_buildtime', false, [$this->first->id])
+        ->assertDispatched('error')
+        ->assertNotDispatched('success');
+
+    expect($this->first->fresh()->is_buildtime)->toBeTrue();
+});
+
+it('does not refresh rows that the build time filter hides after the update', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('toggleVariableFilter', 'buildtime')
+        ->call('bulkUpdateAvailability', 'is_buildtime', false, [$this->first->id, $this->second->id])
+        ->assertDispatched('success')
+        ->assertNotDispatched('refreshEnvs');
+
+    expect($this->first->fresh()->is_buildtime)->toBeFalse()
+        ->and($this->second->fresh()->is_buildtime)->toBeFalse();
+});
+
+it('refreshes rows that stay visible under an active flag filter', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables')
+        ->call('toggleVariableFilter', 'buildtime')
+        ->call('bulkUpdateAvailability', 'is_runtime', false, [$this->first->id])
+        ->assertDispatched('success')
+        ->assertDispatched('refreshEnvs');
+});
+
+it('tells the browser to drop the selection whenever the row set changes', function () {
+    $component = Livewire::test(All::class, ['resource' => $this->application])
+        ->call('loadEnvironmentVariables');
+
+    foreach ([
+        ['toggleVariableFilter', ['runtime']],
+        ['setTableSort', ['name_desc']],
+        ['setEnvironmentVariablePage', [1]],
+        ['clearFilters', []],
+    ] as [$method, $arguments]) {
+        $component->call($method, ...$arguments)->assertDispatched(All::SELECTION_RESET_EVENT);
+    }
+
+    $component->set('search', 'FIRST')->assertDispatched(All::SELECTION_RESET_EVENT);
+});
+
+it('renders a selection checkbox only for selectable rows that the user may edit', function () {
+    $checkbox = 'data-env-select-id="'.$this->first->id.'"';
+
+    Livewire::test(Show::class, ['env' => $this->first, 'type' => 'application', 'selectable' => true])
+        ->assertSeeHtml($checkbox)
+        ->assertSeeHtml('toggleSelected('.$this->first->id.')');
+
+    Livewire::test(Show::class, ['env' => $this->first, 'type' => 'application'])
+        ->assertDontSeeHtml($checkbox)
+        ->assertDontSeeHtml('env-table-grid-selectable');
+
+    $generated = createBulkAvailabilityVariable($this->application, 'SERVICE_URL_APP');
+
+    Livewire::test(Show::class, ['env' => $generated, 'type' => 'application', 'selectable' => true])
+        ->assertSeeHtml('env-table-grid-selectable')
+        ->assertDontSeeHtml('data-env-select-id="'.$generated->id.'"');
+
+    $this->actingAs($this->member);
+
+    Livewire::test(Show::class, ['env' => $this->first, 'type' => 'application', 'selectable' => true])
+        ->assertDontSeeHtml($checkbox);
+});
+
+it('wires the bulk availability controls into the environment variables table', function () {
+    $all = file_get_contents(resource_path('views/livewire/project/shared/environment-variable/all.blade.php'));
+    $show = file_get_contents(resource_path('views/livewire/project/shared/environment-variable/show.blade.php'));
+    $hardcoded = file_get_contents(resource_path('views/livewire/project/shared/environment-variable/show-hardcoded.blade.php'));
+    $checkbox = file_get_contents(resource_path('views/components/table/checkbox.blade.php'));
+    $css = file_get_contents(resource_path('css/app.css'));
+
+    expect($all)
+        ->toContain('x-on:'.All::SELECTION_RESET_EVENT.'.window="selectedIds = []"')
+        ->toContain('$canBulkEdit = auth()->user()?->can(\'manageEnvironment\', $resource) ?? false;')
+        ->toContain('this.$wire.bulkUpdateAvailability(field, value, this.selectedIds)')
+        ->toContain('<x-table.checkbox label="Select all environment variables on this page"')
+        ->toContain('x-effect="$el.indeterminate = someSelected"')
+        ->toContain('<span>Availability</span>')
+        ->toContain("applyAvailability('is_buildtime', true)")
+        ->toContain("applyAvailability('is_buildtime', false)")
+        ->toContain("applyAvailability('is_runtime', true)")
+        ->toContain("applyAvailability('is_runtime', false)")
+        ->toContain('x-bind:disabled="selectedIds.length === 0"')
+        ->toContain(':selectable="$canBulkEdit"')
+        ->toContain('nextEnvironmentVariablePage,bulkUpdateAvailability"');
+
+    expect($show)
+        ->toContain('$isSelectable = $selectable && $canUpdate && $showBuildtime && $showRuntime;')
+        ->toContain('<x-table.checkbox label="Select {{ $env->key }}" data-env-select-id="{{ $env->id }}"')
+        ->toContain("{{ \$selectable ? 'env-table-grid-selectable' : '' }}");
+
+    expect($hardcoded)
+        ->toContain("{{ \$selectable ? 'env-table-grid-selectable' : '' }}")
+        ->toMatch('/@if \(\$selectable\)\s*<span><\/span>\s*@endif/');
+
+    expect($checkbox)
+        ->toContain('type="checkbox"')
+        ->not->toContain('<label')
+        ->toContain('peer-checked:bg-coollabs')
+        ->toContain('dark:peer-checked:bg-warning')
+        ->toContain('peer-indeterminate:opacity-100');
+
+    expect($css)
+        ->toContain('.env-table-grid.env-table-grid-selectable {')
+        ->toContain('grid-template-columns: 1.125rem minmax(14rem, 2.5fr) 4.8rem 6rem 4rem 4.5rem 4.8rem 4.2rem 3rem;')
+        ->toContain('grid-template-columns: 1.125rem minmax(14rem, 2.5fr) 4.8rem 4rem 4.5rem 4.8rem 4.2rem 3rem;')
+        ->toContain('.data-table-row.env-table-grid.env-table-grid-selectable > :nth-child(2)')
+        ->toMatch('/@media \(max-width: 768px\) \{[\s\S]*?\.environment-table-scroll \.env-table-grid\.env-table-grid-selectable \{\s*min-width: 0;/');
+});


### PR DESCRIPTION
## Changes

- Adds a selection column to the resource environment variables table: a checkbox per editable row and a select-all checkbox in the header (current page, with indeterminate state).
- Adds an "Availability" dropdown to the table toolbar that sets build time or runtime availability for every selected variable at once. The options mirror the edit modal wording (available / not available during build, available / not available in the container).
- The bulk action only touches variables of the current resource, requires `manageEnvironment`, and skips generated `SERVICE_*` variables and Redis credentials. Rows that stay visible are refreshed through a scoped `refreshEnvs` event to the row components; rows hidden by an active Buildtime/Runtime filter are not refreshed, so there is no snapshot race.
- The selection lives client side (Alpine) and is cleared whenever the row set changes (page, search, filter, sort, add/delete, after applying).
- New `x-table.checkbox` component with the same 18px anatomy as `x-forms.checkbox` for dense tables. Rows without edit rights (members, generated variables, Compose hard-coded rows) render no checkbox and members do not get the column at all.

## Issues

- None

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
<img width="1116" height="648" alt="image" src="https://github.com/user-attachments/assets/39a76145-cbad-45ef-aa0b-06dad1a80e0e" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Planning and review was done by claude code. Coding by a human being :)

## Testing

- New Pest tests in `tests/Feature/EnvironmentVariableBulkAvailabilityTest.php` (13 tests): admin bulk update of build time and runtime flags, cross-resource IDs are ignored, generated variables are skipped, unsupported fields and empty selections are rejected, members get an error, filter interaction (no refresh for rows hidden by the filter), selection reset events, row rendering with and without the selection column, markup and CSS wiring.
- Manually verified on a local dev instance: selecting rows, select all, applying both flags, the Buildtime filter case where updated rows disappear, light and dark mode, and a 640px wide viewport (no horizontal overflow, checkbox aligned with the name).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
