### PR TITLE
fix(previews): generate a preview domain for every application domain

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -5,12 +5,14 @@ namespace App\Jobs;
 use App\Enums\ProcessStatus;
 use App\Models\Application;
 use App\Models\ApplicationPreview;
+use App\Support\ValidationPatterns;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Url\Url;
 
 class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -112,6 +114,16 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             return ! empty($links) ? implode(' | ', $links).' | ' : '';
         }
 
-        return $this->preview->fqdn ? "[Open Preview]({$this->preview->fqdn}) | " : '';
+        $fqdns = collect(ValidationPatterns::applicationDomainList($this->preview->fqdn));
+        if ($fqdns->isEmpty()) {
+            return '';
+        }
+        if ($fqdns->count() === 1) {
+            return "[Open Preview]({$fqdns->first()}) | ";
+        }
+
+        return $fqdns
+            ->map(fn (string $domain) => '[Open Preview ('.Url::fromString($domain)->getHost().")]({$domain})")
+            ->implode(' | ').' | ';
     }
 }

--- a/app/Livewire/Project/Application/PreviewDomains.php
+++ b/app/Livewire/Project/Application/PreviewDomains.php
@@ -141,7 +141,7 @@ class PreviewDomains extends Component
                 }
             }
         } else {
-            $this->preview->generate_preview_fqdn(generateWithoutApplicationDomain: true);
+            $this->preview->generate_preview_fqdn(generateWithoutApplicationDomain: true, force: true);
         }
         $this->refreshDomains();
         $this->dispatch('success', 'Domain generated.');

--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -128,8 +128,15 @@ class ApplicationPreview extends BaseModel
         return $this->morphMany(LocalPersistentVolume::class, 'resource');
     }
 
-    public function generate_preview_fqdn(bool $generateWithoutApplicationDomain = false)
+    public function generate_preview_fqdn(bool $generateWithoutApplicationDomain = false, bool $force = false)
     {
+        // Domains already on the preview are kept: they may have been added or
+        // edited in the preview domains UI, and every deployment calls this.
+        // Only an explicit regeneration overwrites them.
+        if (filled($this->fqdn) && ! $force) {
+            return $this;
+        }
+
         $applicationFqdn = $this->application->fqdn;
         if (! $applicationFqdn && $generateWithoutApplicationDomain) {
             $applicationFqdn = generateUrl(
@@ -138,17 +145,24 @@ class ApplicationPreview extends BaseModel
             );
         }
 
-        if ($applicationFqdn) {
-            $sourceDomain = str($applicationFqdn)->contains(',')
-                ? str($applicationFqdn)->explode(',')[0]
-                : $applicationFqdn;
-            $generated = $this->generatedPreviewDomain((string) $sourceDomain);
-            $this->fqdn = $generated['url'];
-            $this->domain_port_overrides = filled($generated['port'])
-                ? [$generated['url'] => $generated['port']]
-                : null;
-            $this->save();
+        $sourceDomains = ValidationPatterns::applicationDomainList($applicationFqdn);
+        if ($sourceDomains === []) {
+            return $this;
         }
+
+        $previewDomains = [];
+        $previewPortOverrides = [];
+        foreach ($sourceDomains as $sourceDomain) {
+            $generated = $this->generatedPreviewDomain($sourceDomain);
+            $previewDomains[] = $generated['url'];
+            if (filled($generated['port'])) {
+                $previewPortOverrides[$generated['url']] = $generated['port'];
+            }
+        }
+
+        $this->fqdn = collect($previewDomains)->unique()->implode(',');
+        $this->domain_port_overrides = $previewPortOverrides ?: null;
+        $this->save();
 
         return $this;
     }

--- a/app/Notifications/Application/DeploymentFailed.php
+++ b/app/Notifications/Application/DeploymentFailed.php
@@ -30,6 +30,8 @@ class DeploymentFailed extends CustomEmailNotification
 
     public ?string $fqdn = null;
 
+    public ?string $preview_fqdn = null;
+
     public function __construct(Application $application, string $deployment_uuid, ?ApplicationPreview $preview = null)
     {
         $this->onQueue('high');
@@ -43,6 +45,10 @@ class DeploymentFailed extends CustomEmailNotification
         $this->fqdn = data_get($application, 'fqdn');
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->preview_fqdn = data_get($preview, 'fqdn');
+        if (str($this->preview_fqdn)->explode(',')->count() > 1) {
+            $this->preview_fqdn = str($this->preview_fqdn)->explode(',')->first();
         }
         $this->deployment_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->application->uuid}/deployment/{$this->deployment_uuid}";
     }
@@ -60,7 +66,7 @@ class DeploymentFailed extends CustomEmailNotification
         if ($pull_request_id === 0) {
             $mail->subject('Coolify: Deployment failed of '.$this->application_name.'.');
         } else {
-            $fqdn = $this->preview->fqdn;
+            $fqdn = $this->preview_fqdn;
             $mail->subject('Coolify: Deployment failed of pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.'.');
         }
         $mail->view('emails.application-deployment-failed', [
@@ -117,7 +123,7 @@ class DeploymentFailed extends CustomEmailNotification
     public function toTelegram(): array
     {
         if ($this->preview) {
-            $message = 'Coolify: Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' ('.$this->preview->fqdn.') deployment failed: ';
+            $message = 'Coolify: Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' ('.$this->preview_fqdn.') deployment failed: ';
         } else {
             $message = 'Coolify: Deployment failed of '.$this->application_name.' ('.$this->fqdn.'): ';
         }
@@ -164,8 +170,8 @@ class DeploymentFailed extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} deployment failed";
             $description = "Pull request deployment failed for {$this->application_name}";
-            if ($this->preview->fqdn) {
-                $description .= "\nPreview URL: {$this->preview->fqdn}";
+            if ($this->preview_fqdn) {
+                $description .= "\nPreview URL: {$this->preview_fqdn}";
             }
         } else {
             $title = 'Deployment failed';

--- a/app/Notifications/Application/DeploymentSuccess.php
+++ b/app/Notifications/Application/DeploymentSuccess.php
@@ -30,6 +30,8 @@ class DeploymentSuccess extends CustomEmailNotification
 
     public ?string $fqdn;
 
+    public ?string $preview_fqdn = null;
+
     public function __construct(Application $application, string $deployment_uuid, ?ApplicationPreview $preview = null)
     {
         $this->onQueue('high');
@@ -43,6 +45,10 @@ class DeploymentSuccess extends CustomEmailNotification
         $this->fqdn = data_get($application, 'fqdn');
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->preview_fqdn = data_get($preview, 'fqdn');
+        if (str($this->preview_fqdn)->explode(',')->count() > 1) {
+            $this->preview_fqdn = str($this->preview_fqdn)->explode(',')->first();
         }
         $this->deployment_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->application->uuid}/deployment/{$this->deployment_uuid}";
     }
@@ -60,7 +66,7 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($pull_request_id === 0) {
             $mail->subject("Coolify: New version is deployed of {$this->application_name}");
         } else {
-            $fqdn = $this->preview->fqdn;
+            $fqdn = $this->preview_fqdn;
             $mail->subject("Coolify: Pull request #{$pull_request_id} of {$this->application_name} deployed successfully");
         }
         $mail->view('emails.application-deployment-success', [
@@ -82,8 +88,8 @@ class DeploymentSuccess extends CustomEmailNotification
                 color: DiscordMessage::successColor(),
             );
 
-            if ($this->preview->fqdn) {
-                $message->addField('Application', '[Link]('.$this->preview->fqdn.')');
+            if ($this->preview_fqdn) {
+                $message->addField('Application', '[Link]('.$this->preview_fqdn.')');
             }
 
             $message->addField('Project', data_get($this->application, 'environment.project.name'), true);
@@ -115,10 +121,10 @@ class DeploymentSuccess extends CustomEmailNotification
     {
         if ($this->preview) {
             $message = 'Coolify: New PR'.$this->preview->pull_request_id.' version successfully deployed of '.$this->application_name.'';
-            if ($this->preview->fqdn) {
+            if ($this->preview_fqdn) {
                 $buttons[] = [
                     'text' => 'Open Application',
-                    'url' => $this->preview->fqdn,
+                    'url' => $this->preview_fqdn,
                 ];
             }
         } else {
@@ -148,10 +154,10 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} successfully deployed";
             $message = 'New PR'.$this->preview->pull_request_id.' version successfully deployed of '.$this->application_name.'';
-            if ($this->preview->fqdn) {
+            if ($this->preview_fqdn) {
                 $buttons[] = [
                     'text' => 'Open Application',
-                    'url' => $this->preview->fqdn,
+                    'url' => $this->preview_fqdn,
                 ];
             }
         } else {
@@ -184,8 +190,8 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} successfully deployed";
             $description = "New version successfully deployed for {$this->application_name}";
-            if ($this->preview->fqdn) {
-                $description .= "\nPreview URL: {$this->preview->fqdn}";
+            if ($this->preview_fqdn) {
+                $description .= "\nPreview URL: {$this->preview_fqdn}";
             }
         } else {
             $title = 'New version successfully deployed';

--- a/resources/views/components/applications/links.blade.php
+++ b/resources/views/components/applications/links.blade.php
@@ -96,14 +96,16 @@
                 @else
                     @foreach (data_get($application, 'previews') as $preview)
                         @if (data_get($preview, 'fqdn'))
-                            <a class="{{ $linkItemClasses }}" target="_blank"
-                                href="{{ getFqdnWithoutPort(data_get($preview, 'fqdn')) }}">
-                                <span
-                                    class="shrink-0 rounded-md bg-coollabs/10 px-1.5 py-0.5 text-[10px] font-semibold text-coollabs ring-1 ring-coollabs/20 dark:bg-warning/10 dark:text-warning dark:ring-warning/20">
-                                    PR #{{ data_get($preview, 'pull_request_id') }}
-                                </span>
-                                <span class="min-w-0 truncate">{{ getFqdnWithoutPort(data_get($preview, 'fqdn')) }}</span>
-                            </a>
+                            @foreach (str(data_get($preview, 'fqdn'))->explode(',')->map(fn($domain) => trim($domain))->filter() as $previewFqdn)
+                                <a class="{{ $linkItemClasses }}" target="_blank"
+                                    href="{{ getFqdnWithoutPort($previewFqdn) }}">
+                                    <span
+                                        class="shrink-0 rounded-md bg-coollabs/10 px-1.5 py-0.5 text-[10px] font-semibold text-coollabs ring-1 ring-coollabs/20 dark:bg-warning/10 dark:text-warning dark:ring-warning/20">
+                                        PR #{{ data_get($preview, 'pull_request_id') }}
+                                    </span>
+                                    <span class="min-w-0 truncate">{{ getFqdnWithoutPort($previewFqdn) }}</span>
+                                </a>
+                            @endforeach
                         @endif
                     @endforeach
                 @endif

--- a/tests/Feature/ApplicationPreviewFqdnTest.php
+++ b/tests/Feature/ApplicationPreviewFqdnTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makePreviewForApplication(array $applicationAttributes, int $pullRequestId = 42): ApplicationPreview
+{
+    $application = Application::factory()->create($applicationAttributes);
+
+    return ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => $pullRequestId,
+        'pull_request_html_url' => "https://github.com/example/repo/pull/{$pullRequestId}",
+    ]);
+}
+
+it('generates the preview fqdn from the application domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.example.com');
+});
+
+it('generates one preview fqdn per application domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://app.example.com,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.app.example.com,https://42.api.example.com');
+});
+
+it('preserves scheme and path per domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'http://app.example.com/api,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('http://42.app.example.com/api,https://42.api.example.com');
+});
+
+it('records a port override per generated domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'http://app.example.com:3000,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+    $preview->refresh();
+
+    expect($preview->fqdn)->toBe('http://42.app.example.com,https://42.api.example.com')
+        ->and($preview->domain_port_overrides)->toBe(['http://42.app.example.com' => 3000]);
+});
+
+it('deduplicates preview fqdns when the template drops the source domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://app.example.com,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.preview.example.com',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.preview.example.com');
+});
+
+it('keeps domains added to the preview when a deployment regenerates', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->fqdn = 'https://first.example.com,https://second.example.com';
+    $preview->save();
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://first.example.com,https://second.example.com');
+});
+
+it('overwrites the preview fqdn when regeneration is forced', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->fqdn = 'https://custom.example.com';
+    $preview->save();
+
+    $preview->generate_preview_fqdn(force: true);
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.example.com');
+});


### PR DESCRIPTION
## Changes


- `\App\Models\ApplicationPreview::generate_preview_fqdn`: extrapolate every FQDN in the application's list instead of only the first, reusing `generatedPreviewDomain()` and building the port-override map the same way `generate_preview_fqdn_compose` already does
- `\App\Models\ApplicationPreview::generate_preview_fqdn`: keep FQDNs already stored on the preview unless regeneration is forced; `\App\Livewire\Project\Application\PreviewDomains::generateDomain` passes `force: true`
- `\App\Jobs\ApplicationPullRequestUpdateJob::getPreviewLinks`: explode the list and return a link per FQDN
- `\App\Notifications\Application\DeploymentSuccess` and `DeploymentFailed`: only send the first preview URL
- `resources/views/components/applications/links.blade.php`: one link per preview domain

## Issues

- Fixes #6536 and #9399 for non-compose applications
- Fixes the preview-domain half of #7915 (the `COOLIFY_URL`/`COOLIFY_FQDN` half was fixed by #11527)

Compose previews are still rebuilt from the application's `docker_compose_domains` on every deployment. Giving `generate_preview_fqdn_compose()` the same preservation semantics is a larger change because it also reconciles per-service domain slots, so it is not part of this PR.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. The preview domains UI already supports several domains per preview; this makes generation, redeploys and the link surfaces agree with it.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: implementation and tests, reviewed by hand.

## Testing

Verified on a local dev instance (`docker-compose.dev.yml`, v4.3.15, seeded), running the same script against this branch and against an unmodified `next` in the same instance. Seeded `Dockerfile Example`, domains `http://app.127.0.0.1.sslip.io,http://api.127.0.0.1.sslip.io:8080`, template `{{pr_id}}.{{domain}}`, PR 42.

**A. generating a preview domain for an application with two domains**

```
next:        fqdn = http://42.app.127.0.0.1.sslip.io                                    (1 host)
             domain_port_overrides = null
this branch: fqdn = http://42.app.127.0.0.1.sslip.io,http://42.api.127.0.0.1.sslip.io   (2 hosts)
             domain_port_overrides = {"http://42.api.127.0.0.1.sslip.io":8080}
```

The second application domain is dropped on `next`, and its port override is lost with it.

**B. a domain added to the preview, then a deployment regenerates**

Stored as the preview domains UI leaves it, on both:

```
fqdn = http://manual-one.127.0.0.1.sslip.io,http://manual-two.127.0.0.1.sslip.io
domain_port_overrides = {"http://manual-two.127.0.0.1.sslip.io":9000}
```

After `generate_preview_fqdn()`, which is what every deployment calls:

```
next:        fqdn = http://42.app.127.0.0.1.sslip.io    domain_port_overrides = null
this branch: fqdn = http://manual-one...,http://manual-two...    domain_port_overrides = {"...manual-two...":9000}
```

So on `next` a redeploy discards every domain added to the preview along with its port overrides.

`tests/Feature/ApplicationPreviewFqdnTest.php` is new: 7 cases covering per-domain generation, scheme/path preservation, the port-override map, de-duplication when the template drops `{{domain}}`, preservation across a redeploy, and forced regeneration.

```
./vendor/bin/pest tests/Feature/ApplicationPreviewFqdnTest.php
Tests: 7 passed (8 assertions)
```

Also run: `vendor/bin/pint --dirty` (clean), plus `ComposePreviewFqdnTest`, `ApplicationDeploymentCoolifyUrlDomainsTest`, `PreviewDeploymentPortTest`, `PreviewDomainPortOverridesTest`, `PreviewStatusSummaryTest`, `PreviewEnvVarFallbackTest`, `ApplicationPreviewImageNameTest` and `ModelFillableCreationTest` — 76 passed, no regressions. The failures I see in `ApplicationDomainsTest`, `DomainChipsComponentTest` and `ServiceDomainsTest` reproduce identically on an unmodified `next` here.

Not covered: no live container deployment; the `testing-host` image does not build in my environment, so `generate_preview_fqdn()` was invoked directly rather than through a real deployment.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
