### PR TITLE
fix(profile): show status message when 2FA is enabled

### DIFF
--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -261,6 +261,11 @@
                     </div>
                 @elseif (request()->user()->two_factor_confirmed_at)
                     <div class="flex flex-col gap-4">
+                        <x-callout type="success" title="Two-factor authentication is enabled">
+                            Enabled {{ \Carbon\Carbon::parse(request()->user()->two_factor_confirmed_at)->diffForHumans() }}. A code from your
+                            authenticator app is required at every sign-in. Keep your recovery codes somewhere safe -
+                            they are the only way in if you lose the device.
+                        </x-callout>
                         <div class="flex flex-wrap items-center justify-end gap-2">
                             <form action="/user/two-factor-recovery-codes" method="POST">
                                 @csrf
@@ -274,11 +279,16 @@
                         </div>
                         @if (session('status') === 'two-factor-authentication-confirmed'
                                 || session('status') === 'recovery-codes-generated')
-                            <div
-                                class="grid gap-2 rounded-lg border border-neutral-200 bg-neutral-50 p-4 font-mono text-xs text-neutral-700 sm:grid-cols-2 dark:border-white/[0.07] dark:bg-white/[0.025] dark:text-fg-dim">
-                                @foreach (request()->user()->recoveryCodes() as $code)
-                                    <div>{{ $code }}</div>
-                                @endforeach
+                            <div class="space-y-2">
+                                <p class="text-xs text-neutral-500 dark:text-fg-dim">
+                                    Recovery codes - each one can be used once. Regenerating invalidates the old codes.
+                                </p>
+                                <div
+                                    class="grid gap-2 rounded-lg border border-neutral-200 bg-neutral-50 p-4 font-mono text-xs text-neutral-700 sm:grid-cols-2 dark:border-white/[0.07] dark:bg-white/[0.025] dark:text-fg-dim">
+                                    @foreach (request()->user()->recoveryCodes() as $code)
+                                        <div>{{ $code }}</div>
+                                    @endforeach
+                                </div>
                             </div>
                         @endif
                     </div>

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -262,9 +262,8 @@
                 @elseif (request()->user()->two_factor_confirmed_at)
                     <div class="flex flex-col gap-4">
                         <x-callout type="success" title="Two-factor authentication is enabled">
-                            Enabled {{ \Carbon\Carbon::parse(request()->user()->two_factor_confirmed_at)->diffForHumans() }}. A code from your
-                            authenticator app is required at every sign-in. Keep your recovery codes somewhere safe -
-                            they are the only way in if you lose the device.
+                            Enabled {{ \Carbon\Carbon::parse(request()->user()->two_factor_confirmed_at)->diffForHumans() }}.
+                            Keep your recovery codes somewhere safe - they are the only way in if you lose the device.
                         </x-callout>
                         <div class="flex flex-wrap items-center justify-end gap-2">
                             <form action="/user/two-factor-recovery-codes" method="POST">


### PR DESCRIPTION
## Changes

Added a status message displaying that the 2FA is enabled, along with a note to users to keep their recovery codes safe.

## Issues

Addresses this discussion: https://github.com/coollabsio/coolify/discussions/11655

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="1369" height="975" alt="chrome_fElBfMeOBf" src="https://github.com/user-attachments/assets/6580fae5-fc13-4b55-8d1a-6749efdc7255" />

<img width="1369" height="975" alt="chrome_ofyOuSnERZ" src="https://github.com/user-attachments/assets/40461677-21e2-497f-a68e-b2ff44012b27" />

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Only asked it to find the exact file in which the 2FA section exists, so I could move quicker.

## Testing

Setup a local Coolify instance on docker just as the `DEVELOPMENT.md` file instructed.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
