### PR TITLE
feat(auth): add generic OpenID Connect provider (production backport)

### DIFF
--- a/app/Auth/Oidc/Exceptions/OidcDiscoveryException.php
+++ b/app/Auth/Oidc/Exceptions/OidcDiscoveryException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Auth\Oidc\Exceptions;
+
+class OidcDiscoveryException extends OidcException {}

--- a/app/Auth/Oidc/Exceptions/OidcException.php
+++ b/app/Auth/Oidc/Exceptions/OidcException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Auth\Oidc\Exceptions;
+
+use RuntimeException;
+
+class OidcException extends RuntimeException {}

--- a/app/Auth/Oidc/Exceptions/OidcJwksException.php
+++ b/app/Auth/Oidc/Exceptions/OidcJwksException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Auth\Oidc\Exceptions;
+
+class OidcJwksException extends OidcException {}

--- a/app/Auth/Oidc/Exceptions/OidcSigningKeyNotFoundException.php
+++ b/app/Auth/Oidc/Exceptions/OidcSigningKeyNotFoundException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Auth\Oidc\Exceptions;
+
+class OidcSigningKeyNotFoundException extends OidcTokenException {}

--- a/app/Auth/Oidc/Exceptions/OidcTokenException.php
+++ b/app/Auth/Oidc/Exceptions/OidcTokenException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Auth\Oidc\Exceptions;
+
+class OidcTokenException extends OidcException {}

--- a/app/Auth/Oidc/OidcConfig.php
+++ b/app/Auth/Oidc/OidcConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Auth\Oidc;
+
+use App\Models\OauthSetting;
+
+final readonly class OidcConfig
+{
+    /**
+     * @param  array<int, string>  $scopes
+     */
+    public function __construct(
+        public string $issuerUrl,
+        public string $clientId,
+        public string $clientSecret,
+        public string $redirectUri,
+        public array $scopes = ['openid', 'email', 'profile'],
+        public bool $usePkce = true,
+        public int $clockSkewSeconds = 60,
+    ) {}
+
+    public static function fromOauthSetting(OauthSetting $setting): self
+    {
+        return new self(
+            issuerUrl: rtrim((string) $setting->base_url, '/'),
+            clientId: (string) $setting->client_id,
+            clientSecret: (string) $setting->client_secret,
+            redirectUri: filled($setting->redirect_uri) ? $setting->redirect_uri : route('auth.callback', 'oidc'),
+            scopes: $setting->scopeList(),
+            usePkce: $setting->use_pkce ?? true,
+            clockSkewSeconds: $setting->clock_skew_seconds ?? 60,
+        );
+    }
+}

--- a/app/Auth/Oidc/OidcDiscoveryDocument.php
+++ b/app/Auth/Oidc/OidcDiscoveryDocument.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Auth\Oidc;
+
+use App\Auth\Oidc\Exceptions\OidcDiscoveryException;
+
+final readonly class OidcDiscoveryDocument
+{
+    /**
+     * @param  array<int, string>  $supportedScopes
+     * @param  array<int, string>  $supportedClaims
+     * @param  array<int, string>  $idTokenSigningAlgValuesSupported
+     */
+    public function __construct(
+        public string $issuer,
+        public string $authorizationEndpoint,
+        public string $tokenEndpoint,
+        public string $userinfoEndpoint,
+        public string $jwksUri,
+        public ?string $endSessionEndpoint = null,
+        public array $supportedScopes = [],
+        public array $supportedClaims = [],
+        public array $idTokenSigningAlgValuesSupported = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        foreach (['issuer', 'authorization_endpoint', 'token_endpoint', 'userinfo_endpoint', 'jwks_uri'] as $field) {
+            if (! is_string($payload[$field] ?? null) || trim($payload[$field]) === '') {
+                throw new OidcDiscoveryException("Discovery document is missing required field: {$field}");
+            }
+        }
+
+        return new self(
+            issuer: $payload['issuer'],
+            authorizationEndpoint: $payload['authorization_endpoint'],
+            tokenEndpoint: $payload['token_endpoint'],
+            userinfoEndpoint: $payload['userinfo_endpoint'],
+            jwksUri: $payload['jwks_uri'],
+            endSessionEndpoint: is_string($payload['end_session_endpoint'] ?? null) ? $payload['end_session_endpoint'] : null,
+            supportedScopes: self::stringList($payload['scopes_supported'] ?? []),
+            supportedClaims: self::stringList($payload['claims_supported'] ?? []),
+            idTokenSigningAlgValuesSupported: self::stringList($payload['id_token_signing_alg_values_supported'] ?? []),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map('strval', $value));
+    }
+}

--- a/app/Auth/Oidc/OidcDiscoveryService.php
+++ b/app/Auth/Oidc/OidcDiscoveryService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Auth\Oidc;
+
+use App\Auth\Oidc\Exceptions\OidcDiscoveryException;
+use App\Auth\Oidc\Exceptions\OidcJwksException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class OidcDiscoveryService
+{
+    public function discover(string $issuerUrl): OidcDiscoveryDocument
+    {
+        $this->assertHttpsUrl($issuerUrl, new OidcDiscoveryException('Issuer URL must be an absolute HTTPS URL.'));
+
+        $issuerUrl = rtrim($issuerUrl, '/');
+        $cacheKey = 'oidc:discovery:'.hash('sha256', $issuerUrl);
+
+        return Cache::remember($cacheKey, 3600, function () use ($issuerUrl): OidcDiscoveryDocument {
+            $url = $issuerUrl.'/.well-known/openid-configuration';
+
+            try {
+                $response = Http::timeout(5)->connectTimeout(3)->acceptJson()->get($url);
+            } catch (Throwable $e) {
+                throw new OidcDiscoveryException("Failed to fetch discovery document: {$e->getMessage()}", previous: $e);
+            }
+
+            if ($response->failed()) {
+                throw new OidcDiscoveryException("Discovery endpoint returned HTTP {$response->status()}");
+            }
+
+            $json = $response->json();
+            if (! is_array($json) || $json === []) {
+                throw new OidcDiscoveryException('Discovery endpoint returned invalid JSON.');
+            }
+
+            $discovery = OidcDiscoveryDocument::fromArray($json);
+            if (rtrim($discovery->issuer, '/') !== $issuerUrl) {
+                throw new OidcDiscoveryException('Discovery issuer does not match the configured issuer URL.');
+            }
+
+            return $discovery;
+        });
+    }
+
+    /**
+     * Fetch the JWKS for the given URI.
+     *
+     * When $forceRefresh is true the cached document is bypassed so freshly
+     * rotated signing keys become visible immediately. A short cooldown still
+     * prevents a flood of upstream requests if many logins miss the same kid.
+     *
+     * @return array<string, mixed>
+     */
+    public function jwks(string $jwksUri, bool $forceRefresh = false): array
+    {
+        $this->assertHttpsUrl($jwksUri, new OidcJwksException('JWKS URI must be an absolute HTTPS URL.'));
+
+        $cacheKey = 'oidc:jwks:'.hash('sha256', $jwksUri);
+
+        if ($forceRefresh) {
+            $cooldownKey = $cacheKey.':refresh';
+            if (Cache::add($cooldownKey, true, 60)) {
+                Cache::forget($cacheKey);
+            }
+        }
+
+        return Cache::remember($cacheKey, 21600, function () use ($jwksUri): array {
+            try {
+                $response = Http::timeout(5)->connectTimeout(3)->acceptJson()->get($jwksUri);
+            } catch (Throwable $e) {
+                throw new OidcJwksException("Failed to fetch JWKS: {$e->getMessage()}", previous: $e);
+            }
+
+            if ($response->failed()) {
+                throw new OidcJwksException("JWKS endpoint returned HTTP {$response->status()}");
+            }
+
+            $json = $response->json();
+            if (! is_array($json) || ! is_array($json['keys'] ?? null)) {
+                throw new OidcJwksException("JWKS endpoint returned an invalid payload without 'keys'.");
+            }
+
+            return $json;
+        });
+    }
+
+    private function assertHttpsUrl(string $url, Throwable $exception): void
+    {
+        $parts = parse_url($url);
+
+        if (($parts['scheme'] ?? null) !== 'https' || ! is_string($parts['host'] ?? null) || $parts['host'] === '') {
+            throw $exception;
+        }
+    }
+}

--- a/app/Auth/Oidc/OidcTokenValidator.php
+++ b/app/Auth/Oidc/OidcTokenValidator.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace App\Auth\Oidc;
+
+use App\Auth\Oidc\Exceptions\OidcSigningKeyNotFoundException;
+use App\Auth\Oidc\Exceptions\OidcTokenException;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Throwable;
+
+class OidcTokenValidator
+{
+    /**
+     * Algorithms we accept for id_token signatures. RS256 only — this is the
+     * OIDC baseline and a strict allowlist prevents algorithm-confusion and
+     * "none" attacks.
+     */
+    private const ALLOWED_ALGORITHM = 'RS256';
+
+    /**
+     * @param  array<string, mixed>  $jwks
+     * @return array<string, mixed>
+     */
+    public function validate(
+        string $idToken,
+        OidcDiscoveryDocument $discovery,
+        array $jwks,
+        string $clientId,
+        ?string $expectedNonce = null,
+        int $clockSkewSeconds = 60,
+    ): array {
+        $kid = $this->extractKid($idToken);
+
+        try {
+            $keys = JWK::parseKeySet($this->signingKeysOnly($jwks), self::ALLOWED_ALGORITHM);
+        } catch (Throwable $e) {
+            throw new OidcTokenException("Unable to parse JWKS: {$e->getMessage()}", previous: $e);
+        }
+
+        // Surface an unknown signing key distinctly so the caller can refresh
+        // the JWKS once (key rotation) before giving up.
+        if (! array_key_exists($kid, $keys)) {
+            throw new OidcSigningKeyNotFoundException('No matching JWKS key found for id_token kid.');
+        }
+
+        $previousLeeway = JWT::$leeway;
+        JWT::$leeway = $clockSkewSeconds;
+
+        try {
+            // Validates signature, header alg against the key alg (RS256),
+            // exp, nbf and iat. Throws on any failure.
+            $claims = (array) JWT::decode($idToken, $keys);
+        } catch (OidcTokenException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw new OidcTokenException("id_token validation failed: {$e->getMessage()}", previous: $e);
+        } finally {
+            JWT::$leeway = $previousLeeway;
+        }
+
+        $this->assertExpiry($claims);
+        $this->assertIssuer($claims, $discovery->issuer);
+        $this->assertAudience($claims, $clientId);
+        $this->assertNonce($claims, $expectedNonce);
+        $this->assertSubject($claims);
+
+        return $claims;
+    }
+
+    /**
+     * Drop JWKS entries explicitly marked for anything other than signing
+     * (e.g. "use":"enc") so they can never verify an id_token signature.
+     * firebase/php-jwt does not honour the "use" parameter on its own.
+     *
+     * @param  array<string, mixed>  $jwks
+     * @return array<string, mixed>
+     */
+    private function signingKeysOnly(array $jwks): array
+    {
+        $keys = array_values(array_filter(
+            $jwks['keys'] ?? [],
+            fn ($jwk): bool => is_array($jwk) && (! isset($jwk['use']) || $jwk['use'] === 'sig'),
+        ));
+
+        return ['keys' => $keys];
+    }
+
+    /**
+     * Decode just the JWT header to read the kid before signature
+     * verification, so an unknown key can be reported as a rotation miss.
+     */
+    private function extractKid(string $idToken): string
+    {
+        $segments = explode('.', $idToken);
+        if (count($segments) !== 3) {
+            throw new OidcTokenException('Malformed id_token.');
+        }
+
+        $header = json_decode($this->base64UrlDecode($segments[0]), true);
+        if (! is_array($header)) {
+            throw new OidcTokenException('id_token header contains invalid JSON.');
+        }
+
+        if (($header['alg'] ?? null) !== self::ALLOWED_ALGORITHM) {
+            throw new OidcTokenException('id_token uses a disallowed algorithm.');
+        }
+
+        $kid = $header['kid'] ?? null;
+        if (! is_string($kid) || $kid === '') {
+            throw new OidcTokenException('id_token header is missing kid.');
+        }
+
+        return $kid;
+    }
+
+    private function base64UrlDecode(string $value): string
+    {
+        $remainder = strlen($value) % 4;
+        if ($remainder !== 0) {
+            $value .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+        if ($decoded === false) {
+            throw new OidcTokenException('Invalid base64url value in id_token header.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function assertExpiry(array $claims): void
+    {
+        // Firebase enforces the exp window when present; OIDC requires it to exist.
+        if (! is_numeric($claims['exp'] ?? null)) {
+            throw new OidcTokenException('id_token is missing the exp claim.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function assertSubject(array $claims): void
+    {
+        $subject = $claims['sub'] ?? null;
+        if (! is_string($subject) || $subject === '') {
+            throw new OidcTokenException('id_token subject is missing or invalid.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function assertIssuer(array $claims, string $expectedIssuer): void
+    {
+        if (($claims['iss'] ?? null) !== $expectedIssuer) {
+            throw new OidcTokenException('id_token issuer does not match discovery issuer.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function assertAudience(array $claims, string $clientId): void
+    {
+        $audience = $claims['aud'] ?? null;
+        if (is_string($audience)) {
+            $audience = [$audience];
+        }
+
+        if (! is_array($audience) || ! in_array($clientId, $audience, true)) {
+            throw new OidcTokenException('id_token audience does not include configured client id.');
+        }
+
+        if (count($audience) > 1 && (! isset($claims['azp']) || $claims['azp'] !== $clientId)) {
+            throw new OidcTokenException('id_token azp is required when aud contains multiple values and must match configured client id.');
+        }
+
+        if (isset($claims['azp']) && $claims['azp'] !== $clientId) {
+            throw new OidcTokenException('id_token azp does not match configured client id.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function assertNonce(array $claims, ?string $expectedNonce): void
+    {
+        if ($expectedNonce === null) {
+            return;
+        }
+
+        if (($claims['nonce'] ?? null) !== $expectedNonce) {
+            throw new OidcTokenException('id_token nonce does not match.');
+        }
+    }
+}

--- a/app/Auth/Oidc/OidcUser.php
+++ b/app/Auth/Oidc/OidcUser.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Auth\Oidc;
+
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+class OidcUser extends SocialiteUser
+{
+    public ?string $issuer = null;
+
+    public ?string $subject = null;
+
+    public bool $emailVerified = false;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $idTokenClaims = [];
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    public function setIdTokenClaims(array $claims): self
+    {
+        $this->idTokenClaims = $claims;
+        $this->issuer = is_string($claims['iss'] ?? null) ? $claims['iss'] : null;
+        $this->subject = is_string($claims['sub'] ?? null) ? $claims['sub'] : null;
+        $this->emailVerified = ($claims['email_verified'] ?? false) === true;
+
+        return $this;
+    }
+}

--- a/app/Auth/Oidc/Socialite/OidcProvider.php
+++ b/app/Auth/Oidc/Socialite/OidcProvider.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace App\Auth\Oidc\Socialite;
+
+use App\Auth\Oidc\Exceptions\OidcException;
+use App\Auth\Oidc\Exceptions\OidcSigningKeyNotFoundException;
+use App\Auth\Oidc\OidcConfig;
+use App\Auth\Oidc\OidcDiscoveryDocument;
+use App\Auth\Oidc\OidcDiscoveryService;
+use App\Auth\Oidc\OidcTokenValidator;
+use App\Auth\Oidc\OidcUser;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Laravel\Socialite\Two\AbstractProvider;
+use Laravel\Socialite\Two\InvalidStateException;
+use Laravel\Socialite\Two\ProviderInterface;
+
+class OidcProvider extends AbstractProvider implements ProviderInterface
+{
+    private const int OIDC_FLOW_TTL_MINUTES = 10;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $scopes = ['openid', 'email', 'profile'];
+
+    protected $scopeSeparator = ' ';
+
+    protected ?OidcConfig $oidcConfig = null;
+
+    protected ?OidcDiscoveryDocument $discovery = null;
+
+    public function __construct(
+        Request $request,
+        protected OidcDiscoveryService $discoveryService,
+        protected OidcTokenValidator $tokenValidator,
+        string $clientId,
+        string $clientSecret,
+        string $redirectUrl,
+    ) {
+        parent::__construct($request, $clientId, $clientSecret, $redirectUrl);
+    }
+
+    public function setConfig(OidcConfig $config): self
+    {
+        $this->oidcConfig = $config;
+        $this->clientId = $config->clientId;
+        $this->clientSecret = $config->clientSecret;
+        $this->redirectUrl = $config->redirectUri;
+        $this->scopes = $config->scopes;
+        $this->discovery = null;
+
+        return $this;
+    }
+
+    public function getConfig(): OidcConfig
+    {
+        if ($this->oidcConfig === null) {
+            throw new OidcException('OIDC provider config is not set.');
+        }
+
+        return $this->oidcConfig;
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        $config = $this->getConfig();
+        $nonce = Str::random(40);
+        $this->putOidcFlowValue($this->nonceSessionKey($state), $nonce);
+
+        $extra = ['nonce' => $nonce];
+        if ($config->usePkce) {
+            $verifier = $this->generateCodeVerifier();
+            $this->putOidcFlowValue($this->verifierSessionKey($state), $verifier);
+            $extra['code_challenge'] = $this->codeChallenge($verifier);
+            $extra['code_challenge_method'] = 'S256';
+        }
+
+        return $this->buildAuthUrlFromBase($this->resolveDiscovery()->authorizationEndpoint, $state)
+            .'&'.http_build_query($extra, '', '&', $this->encodingType);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return $this->resolveDiscovery()->tokenEndpoint;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getUserByToken($token): array
+    {
+        $response = $this->getHttpClient()->get($this->resolveDiscovery()->userinfoEndpoint, [
+            RequestOptions::HEADERS => [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+            RequestOptions::CONNECT_TIMEOUT => 5,
+            RequestOptions::TIMEOUT => 10,
+        ]);
+
+        $decoded = json_decode((string) $response->getBody(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $user
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new OidcUser)->setRaw($user)->map([
+            'id' => $user['sub'] ?? null,
+            'nickname' => $user['preferred_username'] ?? null,
+            'name' => $this->resolveName($user),
+            'email' => $user['email'] ?? null,
+            'avatar' => $user['picture'] ?? null,
+        ]);
+    }
+
+    public function user()
+    {
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidStateException;
+        }
+
+        $tokenResponse = $this->getAccessTokenResponse($this->getCode());
+        $accessToken = Arr::get($tokenResponse, 'access_token');
+        $idToken = Arr::get($tokenResponse, 'id_token');
+
+        if (! is_string($accessToken) || $accessToken === '' || ! is_string($idToken) || $idToken === '') {
+            throw new OidcException('OIDC token endpoint did not return required tokens.');
+        }
+
+        $discovery = $this->resolveDiscovery();
+        $config = $this->getConfig();
+        $expectedNonce = $this->pullOidcFlowValue($this->nonceSessionKey((string) $this->request->input('state')));
+        if ($expectedNonce === null) {
+            throw new OidcException('OIDC login session expired. Please try again.');
+        }
+
+        $claims = $this->validateIdToken($idToken, $discovery, $config, $expectedNonce);
+
+        $userinfo = $this->getUserByToken($accessToken);
+
+        // OIDC core §5.3.2: the userinfo sub MUST match the id_token sub.
+        // Reject the response rather than trust unsigned userinfo claims.
+        $userinfoSub = $userinfo['sub'] ?? null;
+        if (is_string($userinfoSub) && $userinfoSub !== '' && $userinfoSub !== ($claims['sub'] ?? null)) {
+            throw new OidcException('OIDC userinfo subject does not match the id_token subject.');
+        }
+
+        $merged = array_merge($userinfo, $claims);
+
+        /** @var OidcUser $user */
+        $user = $this->mapUserToObject($merged);
+        $user->setIdTokenClaims($claims)
+            ->setToken($accessToken)
+            ->setRefreshToken(Arr::get($tokenResponse, 'refresh_token'))
+            ->setExpiresIn(Arr::get($tokenResponse, 'expires_in'));
+
+        return $this->user = $user;
+    }
+
+    /**
+     * Validate the id_token, retrying once against a freshly fetched JWKS when
+     * the signing key is unknown. This keeps logins working immediately after
+     * the IdP rotates keys instead of failing until the JWKS cache expires.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validateIdToken(
+        string $idToken,
+        OidcDiscoveryDocument $discovery,
+        OidcConfig $config,
+        ?string $expectedNonce,
+    ): array {
+        foreach ([false, true] as $forceRefresh) {
+            try {
+                return $this->tokenValidator->validate(
+                    idToken: $idToken,
+                    discovery: $discovery,
+                    jwks: $this->discoveryService->jwks($discovery->jwksUri, $forceRefresh),
+                    clientId: $config->clientId,
+                    expectedNonce: $expectedNonce,
+                    clockSkewSeconds: $config->clockSkewSeconds,
+                );
+            } catch (OidcSigningKeyNotFoundException $e) {
+                if ($forceRefresh) {
+                    throw $e;
+                }
+            }
+        }
+
+        throw new OidcSigningKeyNotFoundException('No matching JWKS key found for id_token kid.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAccessTokenResponse($code)
+    {
+        $fields = $this->getTokenFields($code);
+        if ($this->getConfig()->usePkce) {
+            $verifier = $this->pullOidcFlowValue($this->verifierSessionKey((string) $this->request->input('state')));
+            if ($verifier === null) {
+                throw new OidcException('OIDC login session expired. Please try again.');
+            }
+
+            $fields['code_verifier'] = $verifier;
+        }
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::FORM_PARAMS => $fields,
+            RequestOptions::CONNECT_TIMEOUT => 5,
+            RequestOptions::TIMEOUT => 10,
+        ]);
+
+        $decoded = json_decode((string) $response->getBody(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    protected function resolveDiscovery(): OidcDiscoveryDocument
+    {
+        return $this->discovery ??= $this->discoveryService->discover($this->getConfig()->issuerUrl);
+    }
+
+    protected function generateCodeVerifier(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(64)), '+/', '-_'), '=');
+    }
+
+    protected function codeChallenge(string $verifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    }
+
+    /**
+     * @param  array<string, mixed>  $user
+     */
+    protected function resolveName(array $user): ?string
+    {
+        if (is_string($user['name'] ?? null) && $user['name'] !== '') {
+            return $user['name'];
+        }
+
+        $name = trim(((string) ($user['given_name'] ?? '')).' '.((string) ($user['family_name'] ?? '')));
+
+        return $name === '' ? null : $name;
+    }
+
+    protected function putOidcFlowValue(string $key, string $value): void
+    {
+        $this->request->session()->put($key, [
+            'value' => $value,
+            'expires_at' => now()->addMinutes(self::OIDC_FLOW_TTL_MINUTES)->timestamp,
+        ]);
+    }
+
+    protected function pullOidcFlowValue(string $key): ?string
+    {
+        $entry = $this->request->session()->pull($key);
+
+        if (! is_array($entry)) {
+            return null;
+        }
+
+        $value = $entry['value'] ?? null;
+        $expiresAt = $entry['expires_at'] ?? null;
+
+        if (! is_string($value) || $value === '' || ! is_int($expiresAt)) {
+            return null;
+        }
+
+        if ($expiresAt < now()->timestamp) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    protected function nonceSessionKey(string $state): string
+    {
+        return "oidc.nonce.{$state}";
+    }
+
+    protected function verifierSessionKey(string $state): string
+    {
+        return "oidc.code_verifier.{$state}";
+    }
+}

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,9 +18,13 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.client_secret"] = 'nullable';
-            $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable|string|max:2048';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
-            $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable|string|max:2048';
+            $carry["oauth_settings_map.$setting->provider.custom_label"] = 'nullable|string|max:255';
+            $carry["oauth_settings_map.$setting->provider.scopes"] = 'nullable|string|max:1000';
+            $carry["oauth_settings_map.$setting->provider.use_pkce"] = 'boolean';
+            $carry["oauth_settings_map.$setting->provider.clock_skew_seconds"] = 'nullable|integer|min:0|max:600';
 
             return $carry;
         }, []);
@@ -32,16 +36,7 @@ class SettingsOauth extends Component
             return redirect()->route('home');
         }
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
-            $carry[$setting->provider] = [
-                'id' => $setting->id,
-                'provider' => $setting->provider,
-                'enabled' => $setting->enabled,
-                'client_id' => $setting->client_id,
-                'client_secret' => $setting->client_secret,
-                'redirect_uri' => $setting->redirect_uri,
-                'tenant' => $setting->tenant,
-                'base_url' => $setting->base_url,
-            ];
+            $carry[$setting->provider] = $this->oauthSettingToArray($setting);
 
             return $carry;
         }, []);
@@ -57,32 +52,20 @@ class SettingsOauth extends Component
                 throw new \Exception('OAuth setting for '.$provider.' not found. It may have been deleted.');
             }
 
-            $oauth->fill([
-                'enabled' => $oauthData['enabled'],
-                'client_id' => $oauthData['client_id'],
-                'client_secret' => $oauthData['client_secret'],
-                'redirect_uri' => $oauthData['redirect_uri'],
-                'tenant' => $oauthData['tenant'],
-                'base_url' => $oauthData['base_url'],
-            ]);
+            $this->fillOauthSetting($oauth, $oauthData);
 
             if ($oauthData['enabled'] && ! $oauth->couldBeEnabled()) {
                 $oauth->update(['enabled' => false]);
                 throw new \Exception('OAuth settings are not complete for '.$oauth->provider.'.<br/>Please fill in all required fields.');
             }
-            $oauth->save();
 
-            // Update the array with fresh data
-            $this->oauth_settings_map[$provider] = [
-                'id' => $oauth->id,
-                'provider' => $oauth->provider,
-                'enabled' => $oauth->enabled,
-                'client_id' => $oauth->client_id,
-                'client_secret' => $oauth->client_secret,
-                'redirect_uri' => $oauth->redirect_uri,
-                'tenant' => $oauth->tenant,
-                'base_url' => $oauth->base_url,
-            ];
+            if ($oauthData['enabled'] && $oauth->isOidc() && ! in_array('openid', $oauth->scopeList(), true)) {
+                $oauth->update(['enabled' => false]);
+                throw new \Exception("OIDC scopes must include 'openid'.");
+            }
+
+            $oauth->save();
+            $this->oauth_settings_map[$provider] = $this->oauthSettingToArray($oauth);
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
         } else {
@@ -96,39 +79,71 @@ class SettingsOauth extends Component
                     continue;
                 }
 
-                $oauth->fill([
-                    'enabled' => $settingData['enabled'],
-                    'client_id' => $settingData['client_id'],
-                    'client_secret' => $settingData['client_secret'],
-                    'redirect_uri' => $settingData['redirect_uri'],
-                    'tenant' => $settingData['tenant'],
-                    'base_url' => $settingData['base_url'],
-                ]);
+                $this->fillOauthSetting($oauth, $settingData);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
                     $oauth->enabled = false;
                     $errors[] = "OAuth settings are incomplete for '{$oauth->provider}'. Required fields are missing. The provider has been disabled.";
                 }
 
-                $oauth->save();
+                if ($oauth->enabled && $oauth->isOidc() && ! in_array('openid', $oauth->scopeList(), true)) {
+                    $oauth->enabled = false;
+                    $errors[] = "OIDC scopes must include 'openid'. The provider has been disabled.";
+                }
 
-                // Update the array with fresh data
-                $this->oauth_settings_map[$oauth->provider] = [
-                    'id' => $oauth->id,
-                    'provider' => $oauth->provider,
-                    'enabled' => $oauth->enabled,
-                    'client_id' => $oauth->client_id,
-                    'client_secret' => $oauth->client_secret,
-                    'redirect_uri' => $oauth->redirect_uri,
-                    'tenant' => $oauth->tenant,
-                    'base_url' => $oauth->base_url,
-                ];
+                $oauth->save();
+                $this->oauth_settings_map[$oauth->provider] = $this->oauthSettingToArray($oauth);
             }
 
             if (! empty($errors)) {
                 $this->dispatch('error', implode('<br/>', $errors));
             }
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function fillOauthSetting(OauthSetting $oauth, array $data): void
+    {
+        $oauth->fill([
+            'enabled' => (bool) ($data['enabled'] ?? false),
+            'client_id' => $data['client_id'] ?? null,
+            'client_secret' => $data['client_secret'] ?? null,
+            'redirect_uri' => $data['redirect_uri'] ?? null,
+            'tenant' => $data['tenant'] ?? null,
+            'base_url' => $data['base_url'] ?? null,
+        ]);
+
+        if ($oauth->isOidc()) {
+            $oauth->fill([
+                'custom_label' => $data['custom_label'] ?? null,
+                'scopes' => $data['scopes'] ?? null,
+                'use_pkce' => (bool) ($data['use_pkce'] ?? true),
+                'clock_skew_seconds' => (int) ($data['clock_skew_seconds'] ?? 60),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function oauthSettingToArray(OauthSetting $setting): array
+    {
+        return [
+            'id' => $setting->id,
+            'provider' => $setting->provider,
+            'enabled' => $setting->enabled,
+            'client_id' => $setting->client_id,
+            'client_secret' => $setting->client_secret,
+            'redirect_uri' => $setting->redirect_uri,
+            'tenant' => $setting->tenant,
+            'base_url' => $setting->base_url,
+            'custom_label' => $setting->custom_label,
+            'scopes' => $setting->scopes ?: 'openid email profile',
+            'use_pkce' => $setting->use_pkce ?? true,
+            'clock_skew_seconds' => $setting->clock_skew_seconds ?? 60,
+        ];
     }
 
     public function instantSave(string $provider)
@@ -176,7 +191,7 @@ class SettingsOauth extends Component
             $rules["$prefix.tenant"] = 'required';
         }
 
-        if (in_array($provider, ['authentik', 'clerk'], true)) {
+        if (in_array($provider, ['authentik', 'clerk', 'oidc'], true)) {
             $rules["$prefix.base_url"] = 'required';
         }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,28 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'custom_label',
+        'scopes',
+        'use_pkce',
+        'clock_skew_seconds',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'use_pkce' => 'boolean',
+            'clock_skew_seconds' => 'integer',
+        ];
+    }
 
     protected $hidden = [
         'client_secret',
@@ -32,9 +53,46 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);
         }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function scopeList(): array
+    {
+        $scopes = str($this->scopes ?: 'openid email profile')
+            ->replace(',', ' ')
+            ->explode(' ')
+            ->map(fn (string $scope) => trim($scope))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        return $scopes === [] ? ['openid', 'email', 'profile'] : $scopes;
+    }
+
+    public function loginLabel(): string
+    {
+        if (filled($this->custom_label)) {
+            return $this->custom_label;
+        }
+
+        $envLabel = config("services.{$this->provider}.custom_label");
+        if (filled($envLabel)) {
+            return $envLabel;
+        }
+
+        return __("auth.login.{$this->provider}");
+    }
+
+    public function isOidc(): bool
+    {
+        return $this->provider === 'oidc';
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Auth\Oidc\OidcDiscoveryService;
+use App\Auth\Oidc\OidcTokenValidator;
+use App\Auth\Oidc\Socialite\OidcProvider;
 use App\Models\PersonalAccessToken;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
@@ -10,6 +13,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Sanctum\Sanctum;
+use Laravel\Socialite\Contracts\Factory as SocialiteFactory;
 use Stripe\StripeClient;
 
 class AppServiceProvider extends ServiceProvider
@@ -27,7 +31,7 @@ class AppServiceProvider extends ServiceProvider
         $this->configurePasswords();
         $this->configureSanctumModel();
         $this->configureGitHubHttp();
-
+        $this->configureOidcSocialite();
     }
 
     private function configureCommands(): void
@@ -60,6 +64,24 @@ class AppServiceProvider extends ServiceProvider
     private function configureSanctumModel(): void
     {
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
+    }
+
+    private function configureOidcSocialite(): void
+    {
+        if (! $this->app->bound(SocialiteFactory::class)) {
+            return;
+        }
+
+        $this->app->make(SocialiteFactory::class)->extend('oidc', function ($app) {
+            return new OidcProvider(
+                $app['request'],
+                $app->make(OidcDiscoveryService::class),
+                $app->make(OidcTokenValidator::class),
+                '',
+                '',
+                '',
+            );
+        });
     }
 
     private function configureGitHubHttp(): void

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Auth\Oidc\OidcConfig;
 use App\Models\OauthSetting;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\BitbucketProvider;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitlabProvider;
+use SocialiteProviders\Discord\Provider;
+use SocialiteProviders\Manager\Config;
 
 function get_socialite_provider(string $provider)
 {
@@ -12,7 +18,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider === 'azure') {
-        $azure_config = new \SocialiteProviders\Manager\Config(
+        $azure_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -22,30 +28,23 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('azure')->setConfig($azure_config);
     }
 
-    if ($provider == 'authentik' || $provider == 'clerk') {
-        $authentik_clerk_config = new \SocialiteProviders\Manager\Config(
+    if (in_array($provider, ['authentik', 'clerk', 'zitadel'], true)) {
+        $baseUrlConfig = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
             ['base_url' => $oauth_setting->base_url],
         );
 
-        return Socialite::driver($provider)->setConfig($authentik_clerk_config);
+        return Socialite::driver($provider)->setConfig($baseUrlConfig);
     }
 
-    if ($provider == 'zitadel') {
-        $zitadel_config = new \SocialiteProviders\Manager\Config(
-            $oauth_setting->client_id,
-            $oauth_setting->client_secret,
-            $oauth_setting->redirect_uri,
-            ['base_url' => $oauth_setting->base_url],
-        );
-
-        return Socialite::driver('zitadel')->setConfig($zitadel_config);
+    if ($provider === 'oidc') {
+        return Socialite::driver('oidc')->setConfig(OidcConfig::fromOauthSetting($oauth_setting));
     }
 
-    if ($provider == 'google') {
-        $google_config = new \SocialiteProviders\Manager\Config(
+    if ($provider === 'google') {
+        $google_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri
@@ -63,11 +62,11 @@ function get_socialite_provider(string $provider)
     ];
 
     $provider_class_map = [
-        'bitbucket' => \Laravel\Socialite\Two\BitbucketProvider::class,
-        'discord' => \SocialiteProviders\Discord\Provider::class,
-        'github' => \Laravel\Socialite\Two\GithubProvider::class,
-        'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
-        'infomaniak' => \SocialiteProviders\Infomaniak\Provider::class,
+        'bitbucket' => BitbucketProvider::class,
+        'discord' => Provider::class,
+        'github' => GithubProvider::class,
+        'gitlab' => GitlabProvider::class,
+        'infomaniak' => SocialiteProviders\Infomaniak\Provider::class,
     ];
 
     $socialite = Socialite::buildProvider(
@@ -75,7 +74,7 @@ function get_socialite_provider(string $provider)
         $config
     );
 
-    if ($provider == 'gitlab' && ! empty($oauth_setting->base_url)) {
+    if ($provider === 'gitlab' && ! empty($oauth_setting->base_url)) {
         $socialite->setHost($oauth_setting->base_url);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^8.4",
         "danharrin/livewire-rate-limiting": "^2.2.1",
         "doctrine/dbal": "^4.4.4",
+        "firebase/php-jwt": "^7.1.0",
         "guzzlehttp/guzzle": "^7.15.3",
         "laravel/fortify": "^1.37.3",
         "laravel/framework": "^12.65.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "971daeb1b3078a36428c0fb56bb895b7",
+    "content-hash": "13c7e15f402e892799a900f4504e06c6",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/config/services.php
+++ b/config/services.php
@@ -60,6 +60,14 @@ return [
         'tenant' => env('GOOGLE_TENANT'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+        'custom_label' => env('OIDC_LOGIN_LABEL'),
+    ],
+
     'zitadel' => [
         'client_id' => env('ZITADEL_CLIENT_ID'),
         'client_secret' => env('ZITADEL_CLIENT_SECRET'),

--- a/database/migrations/2026_09_07_000000_add_oidc_fields_to_oauth_settings_table.php
+++ b/database/migrations/2026_09_07_000000_add_oidc_fields_to_oauth_settings_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->string('custom_label')->nullable();
+            $table->string('scopes')->nullable();
+            $table->boolean('use_pkce')->default(true);
+            $table->unsignedSmallInteger('clock_skew_seconds')->default(60);
+        });
+
+        if (! DB::table('oauth_settings')->where('provider', 'oidc')->exists()) {
+            DB::table('oauth_settings')->insert([
+                'provider' => 'oidc',
+                'enabled' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'custom_label',
+                'scopes',
+                'use_pkce',
+                'clock_skew_seconds',
+            ]);
+        });
+    }
+};

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -23,6 +23,7 @@ class OauthSettingSeeder extends Seeder
                 'github',
                 'gitlab',
                 'google',
+                'oidc',
                 'authentik',
                 'infomaniak',
                 'zitadel',

--- a/docs/oauth-oidc.md
+++ b/docs/oauth-oidc.md
@@ -1,0 +1,27 @@
+# Generic OpenID Connect
+
+Coolify can sign users in through any OIDC-compliant identity provider (Keycloak, Authentik, Pocket ID, Okta, Auth0, Nextcloud, and others) without a hardcoded driver for that vendor.
+
+## Settings
+
+Instance admins configure the provider at **Settings → Authentication → OpenID Connect**:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| Redirect URI | No | Defaults to `/auth/oidc/callback`. Register this exact URL on the IdP. |
+| Issuer URL | Yes | The OIDC issuer, **without** `/.well-known/openid-configuration`. Coolify discovers authorization, token, userinfo, and JWKS endpoints from that document. Must be HTTPS. |
+| Client ID | Yes | Confidential client created on the IdP. |
+| Client secret | Yes | Stored encrypted. |
+| Scopes | No | Space-separated. Defaults to `openid email profile`. Must include `openid`. |
+| Clock skew | No | Seconds of leeway for `exp` / `nbf` / `iat` (default 60). |
+| Login button label | No | Defaults to the translated “Login with SSO” string. |
+| Use PKCE | No | Enabled by default. |
+
+Environment overrides: `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`, `OIDC_BASE_URL`, `OIDC_LOGIN_LABEL`.
+
+## IdP checklist
+
+1. Create a confidential OIDC client.
+2. Set the redirect URI to `https://<coolify-host>/auth/oidc/callback`.
+3. Request at least the `openid` and `email` scopes so Coolify can match or create the local user.
+4. Paste the issuer, client id, and client secret into Coolify and enable the provider.

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "تسجيل الدخول باستخدام Gitlab",
     "auth.login.google": "تسجيل الدخول باستخدام Google",
     "auth.login.infomaniak": "تسجيل الدخول باستخدام Infomaniak",
+    "auth.login.oidc": "تسجيل الدخول باستخدام SSO",
     "auth.already_registered": "هل سبق لك التسجيل؟",
     "auth.confirm_password": "تأكيد كلمة المرور",
     "auth.forgot_password_link": "هل نسيت كلمة المرور؟",

--- a/lang/az.json
+++ b/lang/az.json
@@ -9,6 +9,7 @@
   "auth.login.gitlab": "GitLab ilə daxil ol",
   "auth.login.google": "Google ilə daxil ol",
   "auth.login.infomaniak": "Infomaniak ilə daxil ol",
+  "auth.login.oidc": "SSO ilə daxil ol",
   "auth.already_registered": "Qeytiyatınız var?",
   "auth.confirm_password": "Şifrəni təsdiqləyin",
   "auth.forgot_password_link": "Şifrəmi unutdum?",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Přihlásit se pomocí Gitlabu",
     "auth.login.google": "Přihlásit se pomocí Google",
     "auth.login.infomaniak": "Přihlásit se pomocí Infomaniak",
+    "auth.login.oidc": "Přihlásit se pomocí SSO",
     "auth.already_registered": "Již jste registrováni?",
     "auth.confirm_password": "Potvrďte heslo",
     "auth.forgot_password_link": "Zapomněli jste heslo?",

--- a/lang/de.json
+++ b/lang/de.json
@@ -9,6 +9,7 @@
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
+    "auth.login.oidc": "Mit SSO anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",
     "auth.forgot_password_link": "Passwort vergessen?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -10,6 +10,7 @@
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
     "auth.login.zitadel": "Login with Zitadel",
+    "auth.login.oidc": "Login with SSO",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",
     "auth.forgot_password_link": "Forgot password?",

--- a/lang/es.json
+++ b/lang/es.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Acceder con Gitlab",
     "auth.login.google": "Acceder con Google",
     "auth.login.infomaniak": "Acceder con Infomaniak",
+    "auth.login.oidc": "Acceder con SSO",
     "auth.already_registered": "¿Ya estás registrado?",
     "auth.confirm_password": "Confirmar contraseña",
     "auth.forgot_password_link": "¿Olvidaste tu contraseña?",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "ورود با گیت لب",
     "auth.login.google": "ورود با گوگل",
     "auth.login.infomaniak": "ورود با Infomaniak",
+    "auth.login.oidc": "ورود با SSO",
     "auth.already_registered": "قبلاً ثبت نام کرده‌اید؟",
     "auth.confirm_password": "تایید رمز عبور",
     "auth.forgot_password_link": "رمز عبور را فراموش کرده‌اید؟",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Connexion avec Gitlab",
     "auth.login.google": "Connexion avec Google",
     "auth.login.infomaniak": "Connexion avec Infomaniak",
+    "auth.login.oidc": "Connexion avec SSO",
     "auth.already_registered": "Déjà enregistré ?",
     "auth.confirm_password": "Confirmer le mot de passe",
     "auth.forgot_password_link": "Mot de passe oublié ?",

--- a/lang/id.json
+++ b/lang/id.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Masuk dengan Gitlab",
     "auth.login.google": "Masuk dengan Google",
     "auth.login.infomaniak": "Masuk dengan Infomaniak",
+    "auth.login.oidc": "Masuk dengan SSO",
     "auth.already_registered": "Sudah terdaftar?",
     "auth.confirm_password": "Konfirmasi kata sandi",
     "auth.forgot_password_link": "Lupa kata sandi?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Accedi con Gitlab",
     "auth.login.google": "Accedi con Google",
     "auth.login.infomaniak": "Accedi con Infomaniak",
+    "auth.login.oidc": "Accedi con SSO",
     "auth.already_registered": "Già registrato?",
     "auth.confirm_password": "Conferma password",
     "auth.forgot_password_link": "Hai dimenticato la password?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Gitlabでログイン",
     "auth.login.google": "Googleでログイン",
     "auth.login.infomaniak": "Infomaniakでログイン",
+    "auth.login.oidc": "SSOでログイン",
     "auth.already_registered": "すでに登録済みですか？",
     "auth.confirm_password": "パスワードを確認",
     "auth.forgot_password_link": "パスワードをお忘れですか？",

--- a/lang/no.json
+++ b/lang/no.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Logg inn med Gitlab",
     "auth.login.google": "Logg inn med Google",
     "auth.login.infomaniak": "Logg inn med Infomaniak",
+    "auth.login.oidc": "Logg inn med SSO",
     "auth.already_registered": "Allerede registrert?",
     "auth.confirm_password": "Bekreft passord",
     "auth.forgot_password_link": "Glemt passord?",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -10,6 +10,7 @@
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
+    "auth.login.oidc": "Zaloguj się przez SSO",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",
     "auth.forgot_password_link": "Zapomniałeś hasło?",

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -10,6 +10,7 @@
     "auth.login.google": "Entrar com Google",
     "auth.login.infomaniak": "Entrar com Infomaniak",
     "auth.login.zitadel": "Entrar com Zitadel",
+    "auth.login.oidc": "Entrar com SSO",
     "auth.already_registered": "Já tem uma conta?",
     "auth.confirm_password": "Confirmar senha",
     "auth.forgot_password_link": "Esqueceu a senha?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -10,6 +10,7 @@
     "auth.login.google": "Entrar com Google",
     "auth.login.infomaniak": "Entrar com Infomaniak",
     "auth.login.zitadel": "Entrar com Zitadel",
+    "auth.login.oidc": "Entrar com SSO",
     "auth.already_registered": "Já tem uma conta?",
     "auth.confirm_password": "Confirmar senha",
     "auth.forgot_password_link": "Esqueceu a senha?",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Autentificare prin Gitlab",
     "auth.login.google": "Autentificare prin Google",
     "auth.login.infomaniak": "Autentificare prin Infomaniak",
+    "auth.login.oidc": "Autentificare prin SSO",
     "auth.already_registered": "Sunteți deja înregistrat?",
     "auth.confirm_password": "Confirmați parola",
     "auth.forgot_password_link": "Ați uitat parola?",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -10,6 +10,7 @@
     "auth.login.google": "Google ile Giriş Yap",
     "auth.login.infomaniak": "Infomaniak ile Giriş Yap",
     "auth.login.zitadel": "Zitadel ile Giriş Yap",
+    "auth.login.oidc": "SSO ile Giriş Yap",
     "auth.already_registered": "Zaten kayıtlı mısınız?",
     "auth.confirm_password": "Şifreyi Onayla",
     "auth.forgot_password_link": "Şifrenizi mi unuttunuz?",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Đăng Nhập Bằng Gitlab",
     "auth.login.google": "Đăng Nhập Bằng Google",
     "auth.login.infomaniak": "Đăng Nhập Bằng Infomaniak",
+    "auth.login.oidc": "Đăng Nhập Bằng SSO",
     "auth.already_registered": "Đã đăng ký?",
     "auth.confirm_password": "Nhập lại mật khẩu",
     "auth.forgot_password_link": "Quên mật khẩu?",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -10,6 +10,7 @@
     "auth.login.google": "使用 Google 登录",
     "auth.login.infomaniak": "使用 Infomaniak 登录",
     "auth.login.zitadel": "使用 Zitadel 登录",
+    "auth.login.oidc": "使用 SSO 登录",
     "auth.already_registered": "已经注册？",
     "auth.confirm_password": "确认密码",
     "auth.forgot_password_link": "忘记密码？",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "使用 Gitlab 登入",
     "auth.login.google": "使用 Google 登入",
     "auth.login.infomaniak": "使用 Infomaniak 登入",
+    "auth.login.oidc": "使用 SSO 登入",
     "auth.already_registered": "已經註冊？",
     "auth.confirm_password": "確認密碼",
     "auth.forgot_password_link": "忘記密碼？",

--- a/public/svgs/oidc.svg
+++ b/public/svgs/oidc.svg
@@ -1,0 +1,5 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <title>OpenID Connect</title>
+    <path fill-rule="evenodd" d="M10 5.5a7.5 7.5 0 1 0 7.5 7.5c0-.9-.16-1.77-.45-2.57l-2.78 1.04c.15.48.23.99.23 1.53a4.5 4.5 0 1 1-4.5-4.5c.54 0 1.05.09 1.53.26l1.05-2.8A7.48 7.48 0 0 0 10 5.5Z" clip-rule="evenodd"/>
+    <path d="M16.5 1 12 5.5h3V10h3V5.5h3L16.5 1Z"/>
+</svg>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -84,7 +84,7 @@
                     @foreach ($enabled_oauth_providers as $provider_setting)
                         <x-forms.button class="w-full justify-center" type="button"
                             onclick="document.location.href='/auth/{{ $provider_setting->provider }}/redirect'">
-                            {{ __("auth.login.$provider_setting->provider") }}
+                            {{ $provider_setting->loginLabel() }}
                         </x-forms.button>
                     @endforeach
                 </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -6,14 +6,14 @@
     <x-settings.layout>
         <x-slot:submenu>
         <div
-            x-data="{ activeProvider: location.hash.slice(1).replace('-oauth-section', '') || '{{ $oauth_settings_map[0]['provider'] ?? '' }}' }"
+            x-data="{ activeProvider: location.hash.slice(1).replace('-oauth-section', '') || @js(array_key_first($oauth_settings_map)) }"
             @hashchange.window="activeProvider = location.hash.slice(1).replace('-oauth-section', '')">
             <nav aria-label="OAuth providers"
                 class="grid gap-0.5 py-1">
                 @foreach ($oauth_settings_map as $oauth_setting)
                     @php
                         $provider = $oauth_setting['provider'];
-                        $providerLabel = str($provider)->headline();
+                        $providerLabel = $provider === 'oidc' ? 'OpenID Connect' : str($provider)->headline();
                     @endphp
                     <a href="#{{ $provider }}-oauth-section" class="menu-item min-h-8! py-1! text-[12px]!"
                         :class="{ 'menu-item-active': activeProvider === '{{ $provider }}' }"
@@ -31,7 +31,7 @@
             @foreach ($oauth_settings_map as $oauth_setting)
                 @php
                     $provider = $oauth_setting['provider'];
-                    $providerLabel = str($provider)->headline();
+                    $providerLabel = $provider === 'oidc' ? 'OpenID Connect' : str($provider)->headline();
                 @endphp
 
                 <x-application.settings-section id="{{ $provider }}-oauth-section" class="scroll-mt-28"
@@ -55,10 +55,29 @@
                         <x-forms.input id="oauth_settings_map.{{ $provider }}.redirect_uri"
                             placeholder="{{ route('auth.callback', $provider) }}" label="Redirect URI" />
 
+                        @if ($provider === 'oidc')
+                            <x-forms.input id="oauth_settings_map.{{ $provider }}.base_url"
+                                label="Issuer URL" required
+                                helper="OpenID Provider issuer URL, for example https://auth.example.com/realms/coolify. Coolify discovers authorization, token, userinfo, and JWKS endpoints from {issuer}/.well-known/openid-configuration." />
+                        @endif
+
                         <x-forms.input id="oauth_settings_map.{{ $provider }}.client_id"
                             label="Client ID" required />
                         <x-forms.input id="oauth_settings_map.{{ $provider }}.client_secret"
                             type="password" label="Client secret" autocomplete="new-password" required />
+
+                        @if ($provider === 'oidc')
+                            <x-forms.input id="oauth_settings_map.{{ $provider }}.scopes" label="Scopes"
+                                helper="Space-separated scopes. Must include openid. Common values are openid email profile." />
+                            <x-forms.input id="oauth_settings_map.{{ $provider }}.clock_skew_seconds" type="number"
+                                label="Clock skew (seconds)"
+                                helper="Allowed clock difference when validating the id_token exp/nbf/iat claims." />
+                            <x-forms.input id="oauth_settings_map.{{ $provider }}.custom_label"
+                                label="Login button label" placeholder="Login with SSO" />
+                            <x-forms.checkbox id="oauth_settings_map.{{ $provider }}.use_pkce"
+                                label="Use PKCE"
+                                helper="Recommended. Sends a code challenge on authorize and a code verifier on token exchange." />
+                        @endif
 
                         @if ($provider === 'azure')
                             <x-forms.input id="oauth_settings_map.{{ $provider }}.tenant"

--- a/tests/Feature/OidcOauthCallbackTest.php
+++ b/tests/Feature/OidcOauthCallbackTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Auth\Oidc\OidcUser;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Once;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    InstanceSettings::forceCreate([
+        'id' => 0,
+        'is_registration_enabled' => false,
+    ]);
+
+    OauthSetting::query()->updateOrCreate(
+        ['provider' => 'oidc'],
+        [
+            'enabled' => true,
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'base_url' => 'https://idp.example.com',
+            'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+            'scopes' => 'openid email profile',
+        ]
+    );
+
+    Once::flush();
+});
+
+function fakeOidcSocialiteUser(array $claims = []): void
+{
+    $user = (new OidcUser)->setRaw(array_merge([
+        'iss' => 'https://idp.example.com',
+        'sub' => 'oidc-user-1',
+        'email' => 'user@example.com',
+        'email_verified' => true,
+        'name' => 'OIDC User',
+    ], $claims))->map([
+        'id' => $claims['sub'] ?? 'oidc-user-1',
+        'name' => $claims['name'] ?? 'OIDC User',
+        'email' => $claims['email'] ?? 'user@example.com',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->andReturnSelf();
+    $provider->shouldReceive('user')->andReturn($user);
+
+    Socialite::shouldReceive('driver')->with('oidc')->andReturn($provider);
+}
+
+it('logs in an existing user through the generic oidc provider', function () {
+    $user = User::factory()->create([
+        'email' => 'username@example.edu',
+    ]);
+
+    fakeOidcSocialiteUser([
+        'email' => 'UserName@example.edu',
+        'name' => 'Example User',
+        'sub' => 'oidc-user-1',
+    ]);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+    expect(User::count())->toBe(1);
+});
+
+it('creates a user from oidc when registration is enabled', function () {
+    InstanceSettings::query()->where('id', 0)->update([
+        'is_registration_enabled' => true,
+    ]);
+    Once::flush();
+
+    fakeOidcSocialiteUser([
+        'email' => 'new-oidc@example.com',
+        'name' => 'New OIDC User',
+        'sub' => 'oidc-new',
+    ]);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('new-oidc@example.com')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('New OIDC User');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects oidc logins when the provider does not return an email address', function () {
+    InstanceSettings::query()->where('id', 0)->update([
+        'is_registration_enabled' => true,
+    ]);
+
+    fakeOidcSocialiteUser([
+        'email' => '   ',
+        'name' => 'No Email',
+        'sub' => 'oidc-no-email',
+    ]);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/login');
+    expect(User::count())->toBe(0);
+});

--- a/tests/Feature/OidcOauthMigrationTest.php
+++ b/tests/Feature/OidcOauthMigrationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\OauthSetting;
+use Database\Seeders\OauthSettingSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('inserts a disabled oidc provider row so existing instances see the settings form', function () {
+    $oidc = OauthSetting::query()->where('provider', 'oidc')->first();
+
+    expect($oidc)->not->toBeNull()
+        ->and($oidc->enabled)->toBeFalse()
+        ->and($oidc->couldBeEnabled())->toBeFalse();
+});
+
+it('seeds the oidc provider alongside the other oauth providers', function () {
+    $this->seed(OauthSettingSeeder::class);
+
+    expect(OauthSetting::query()->where('provider', 'oidc')->exists())->toBeTrue()
+        ->and(OauthSetting::query()->pluck('provider'))->toContain('github', 'oidc', 'authentik');
+});

--- a/tests/Feature/SettingsOauthProviderControlsTest.php
+++ b/tests/Feature/SettingsOauthProviderControlsTest.php
@@ -30,6 +30,10 @@ it('requires the provider-specific fields used by oauth enablement', function ()
         'oauth_settings_map.authentik.client_id',
         'oauth_settings_map.authentik.client_secret',
         'oauth_settings_map.authentik.base_url',
+    ])->and($method->invoke($component, 'oidc'))->toHaveKeys([
+        'oauth_settings_map.oidc.client_id',
+        'oauth_settings_map.oidc.client_secret',
+        'oauth_settings_map.oidc.base_url',
     ]);
 });
 
@@ -46,6 +50,7 @@ it('uses monochrome brand logos for each oauth provider in the sidebar', functio
         'gitlab',
         'google',
         'infomaniak',
+        'oidc',
         'zitadel',
     ];
 

--- a/tests/Unit/OauthSettingOidcTest.php
+++ b/tests/Unit/OauthSettingOidcTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\OauthSetting;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('requires issuer url client id and client secret for oidc settings', function () {
+    $setting = new OauthSetting(['provider' => 'oidc']);
+    expect($setting->couldBeEnabled())->toBeFalse();
+
+    $setting->fill([
+        'client_id' => 'client-id',
+        'client_secret' => 'secret',
+        'base_url' => 'https://idp.example.com',
+    ]);
+
+    expect($setting->couldBeEnabled())->toBeTrue()
+        ->and($setting->isOidc())->toBeTrue();
+});
+
+it('returns configured scopes and custom login label', function () {
+    $setting = new OauthSetting([
+        'provider' => 'oidc',
+        'scopes' => 'openid email profile groups',
+        'custom_label' => 'Login with Okta',
+    ]);
+
+    expect($setting->scopeList())->toBe(['openid', 'email', 'profile', 'groups'])
+        ->and($setting->loginLabel())->toBe('Login with Okta');
+});
+
+it('defaults oidc scopes to openid email profile', function () {
+    $setting = new OauthSetting(['provider' => 'oidc']);
+
+    expect($setting->scopeList())->toBe(['openid', 'email', 'profile']);
+});

--- a/tests/Unit/OidcDiscoveryServiceTest.php
+++ b/tests/Unit/OidcDiscoveryServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Auth\Oidc\Exceptions\OidcDiscoveryException;
+use App\Auth\Oidc\Exceptions\OidcJwksException;
+use App\Auth\Oidc\OidcDiscoveryService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('fetches and caches discovery documents and jwks', function () {
+    Cache::flush();
+    Http::fake([
+        'https://idp.example.com/.well-known/openid-configuration' => Http::response([
+            'issuer' => 'https://idp.example.com',
+            'authorization_endpoint' => 'https://idp.example.com/auth',
+            'token_endpoint' => 'https://idp.example.com/token',
+            'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+            'jwks_uri' => 'https://idp.example.com/jwks',
+        ]),
+        'https://idp.example.com/jwks' => Http::response(['keys' => [['kid' => 'one']]]),
+    ]);
+
+    $service = app(OidcDiscoveryService::class);
+
+    $discovery = $service->discover('https://idp.example.com');
+    $jwks = $service->jwks($discovery->jwksUri);
+
+    expect($discovery->issuer)->toBe('https://idp.example.com')
+        ->and($jwks['keys'][0]['kid'])->toBe('one');
+
+    Http::assertSentCount(2);
+
+    $service->discover('https://idp.example.com');
+    $service->jwks('https://idp.example.com/jwks');
+
+    Http::assertSentCount(2);
+});
+
+it('does not cache discovery documents with mismatched issuers', function () {
+    Cache::flush();
+    Http::fakeSequence('https://idp.example.com/.well-known/openid-configuration')
+        ->push([
+            'issuer' => 'https://evil.example.com',
+            'authorization_endpoint' => 'https://idp.example.com/auth',
+            'token_endpoint' => 'https://idp.example.com/token',
+            'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+            'jwks_uri' => 'https://idp.example.com/jwks',
+        ])
+        ->push([
+            'issuer' => 'https://idp.example.com',
+            'authorization_endpoint' => 'https://idp.example.com/auth',
+            'token_endpoint' => 'https://idp.example.com/token',
+            'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+            'jwks_uri' => 'https://idp.example.com/jwks',
+        ]);
+
+    $service = app(OidcDiscoveryService::class);
+    $cacheKey = 'oidc:discovery:'.hash('sha256', 'https://idp.example.com');
+
+    expect(fn () => $service->discover('https://idp.example.com'))
+        ->toThrow(OidcDiscoveryException::class, 'Discovery issuer does not match the configured issuer URL.')
+        ->and(Cache::has($cacheKey))->toBeFalse()
+        ->and($service->discover('https://idp.example.com')->issuer)->toBe('https://idp.example.com');
+
+    Http::assertSentCount(2);
+});
+
+it('refetches jwks once on forced refresh to pick up rotated keys', function () {
+    Cache::flush();
+    Http::fakeSequence('https://idp.example.com/jwks')
+        ->push(['keys' => [['kid' => 'old']]])
+        ->push(['keys' => [['kid' => 'new']]]);
+
+    $service = app(OidcDiscoveryService::class);
+
+    expect($service->jwks('https://idp.example.com/jwks')['keys'][0]['kid'])->toBe('old');
+
+    // Forced refresh bypasses the cache and sees the rotated key.
+    expect($service->jwks('https://idp.example.com/jwks', true)['keys'][0]['kid'])->toBe('new');
+    Http::assertSentCount(2);
+
+    // Cooldown prevents a second immediate upstream fetch; cached value returned.
+    expect($service->jwks('https://idp.example.com/jwks', true)['keys'][0]['kid'])->toBe('new');
+    Http::assertSentCount(2);
+});
+
+it('rejects invalid discovery and jwks payloads', function () {
+    Cache::flush();
+    Http::fake([
+        'https://bad.example.com/.well-known/openid-configuration' => Http::response(['issuer' => 'https://bad.example.com']),
+    ]);
+
+    app(OidcDiscoveryService::class)->discover('https://bad.example.com');
+})->throws(OidcDiscoveryException::class);
+
+it('rejects jwks responses without keys', function () {
+    Cache::flush();
+    Http::fake([
+        'https://idp.example.com/jwks' => Http::response(['empty' => true]),
+    ]);
+
+    app(OidcDiscoveryService::class)->jwks('https://idp.example.com/jwks');
+})->throws(OidcJwksException::class);
+
+it('rejects non-https issuer urls', function () {
+    Cache::flush();
+    Http::fake();
+
+    app(OidcDiscoveryService::class)->discover('http://idp.example.com');
+})->throws(OidcDiscoveryException::class, 'Issuer URL must be an absolute HTTPS URL.');
+
+it('rejects non-https jwks uris', function () {
+    Cache::flush();
+    Http::fake();
+
+    app(OidcDiscoveryService::class)->jwks('http://idp.example.com/jwks');
+})->throws(OidcJwksException::class, 'JWKS URI must be an absolute HTTPS URL.');

--- a/tests/Unit/OidcProviderPkceTest.php
+++ b/tests/Unit/OidcProviderPkceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Auth\Oidc\Exceptions\OidcException;
+use App\Auth\Oidc\OidcConfig;
+use App\Auth\Oidc\OidcDiscoveryDocument;
+use App\Auth\Oidc\OidcDiscoveryService;
+use App\Auth\Oidc\OidcTokenValidator;
+use App\Auth\Oidc\Socialite\OidcProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Support\Carbon;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+class TestOidcProviderWithExposedAuthUrl extends OidcProvider
+{
+    public function authUrlForState(string $state): string
+    {
+        return $this->getAuthUrl($state);
+    }
+}
+
+function oidc_provider_discovery_document(): OidcDiscoveryDocument
+{
+    return new OidcDiscoveryDocument(
+        issuer: 'https://idp.example.com',
+        authorizationEndpoint: 'https://idp.example.com/oauth2/authorize',
+        tokenEndpoint: 'https://idp.example.com/oauth2/token',
+        userinfoEndpoint: 'https://idp.example.com/oauth2/userinfo',
+        jwksUri: 'https://idp.example.com/.well-known/jwks.json',
+    );
+}
+
+function oidc_provider_session(): Store
+{
+    $session = new Store('testing', new ArraySessionHandler(1200));
+    $session->start();
+
+    return $session;
+}
+
+function oidc_provider_request(Store $session, string $state = 'state-value'): Request
+{
+    $request = Request::create('/auth/oidc/callback', 'GET', ['state' => $state]);
+    $request->setLaravelSession($session);
+
+    return $request;
+}
+
+function oidc_provider(Request $request): TestOidcProviderWithExposedAuthUrl
+{
+    /** @var OidcDiscoveryService&MockInterface $discoveryService */
+    $discoveryService = Mockery::mock(OidcDiscoveryService::class);
+    $discoveryService->shouldReceive('discover')
+        ->byDefault()
+        ->with('https://idp.example.com')
+        ->andReturn(oidc_provider_discovery_document());
+
+    /** @var OidcTokenValidator&MockInterface $tokenValidator */
+    $tokenValidator = Mockery::mock(OidcTokenValidator::class);
+
+    return (new TestOidcProviderWithExposedAuthUrl(
+        $request,
+        $discoveryService,
+        $tokenValidator,
+        'client-id',
+        'client-secret',
+        'https://coolify.example.com/auth/oidc/callback',
+    ))->setConfig(new OidcConfig(
+        issuerUrl: 'https://idp.example.com',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        redirectUri: 'https://coolify.example.com/auth/oidc/callback',
+        usePkce: true,
+    ));
+}
+
+it('stores oidc nonce and pkce verifier with a ten minute expiry', function () {
+    Carbon::setTestNow('2026-06-15 12:00:00');
+
+    try {
+        $session = oidc_provider_session();
+        $provider = oidc_provider(oidc_provider_request($session));
+
+        $provider->authUrlForState('state-value');
+
+        $nonceEntry = $session->get('oidc.nonce.state-value');
+        $verifierEntry = $session->get('oidc.code_verifier.state-value');
+
+        expect($nonceEntry)->toBeArray()
+            ->and($nonceEntry['value'])->toBeString()->not->toBeEmpty()
+            ->and($nonceEntry['expires_at'])->toBe(now()->addMinutes(10)->timestamp)
+            ->and($verifierEntry)->toBeArray()
+            ->and($verifierEntry['value'])->toBeString()->not->toBeEmpty()
+            ->and($verifierEntry['expires_at'])->toBe(now()->addMinutes(10)->timestamp);
+    } finally {
+        Carbon::setTestNow();
+    }
+});
+
+it('sends a fresh oidc pkce verifier during token exchange', function () {
+    $session = oidc_provider_session();
+    $session->put('oidc.code_verifier.state-value', [
+        'value' => 'fresh-verifier',
+        'expires_at' => now()->addMinute()->timestamp,
+    ]);
+
+    $provider = oidc_provider(oidc_provider_request($session));
+    $history = [];
+    $handler = HandlerStack::create(new MockHandler([
+        new Response(200, [], json_encode(['access_token' => 'access-token', 'id_token' => 'id-token'], JSON_THROW_ON_ERROR)),
+    ]));
+    $handler->push(Middleware::history($history));
+    $provider->setHttpClient(new Client(['handler' => $handler]));
+
+    $provider->getAccessTokenResponse('authorization-code');
+
+    parse_str((string) $history[0]['request']->getBody(), $tokenRequestFields);
+
+    expect($tokenRequestFields['code_verifier'] ?? null)->toBe('fresh-verifier')
+        ->and($session->has('oidc.code_verifier.state-value'))->toBeFalse();
+});
+
+it('throws a session expired error for an expired oidc pkce verifier during token exchange', function () {
+    $session = oidc_provider_session();
+    $session->put('oidc.code_verifier.state-value', [
+        'value' => 'expired-verifier',
+        'expires_at' => now()->subSecond()->timestamp,
+    ]);
+
+    $provider = oidc_provider(oidc_provider_request($session));
+    $history = [];
+    $handler = HandlerStack::create(new MockHandler([
+        new Response(200, [], json_encode(['access_token' => 'access-token', 'id_token' => 'id-token'], JSON_THROW_ON_ERROR)),
+    ]));
+    $handler->push(Middleware::history($history));
+    $provider->setHttpClient(new Client(['handler' => $handler]));
+
+    $provider->getAccessTokenResponse('authorization-code');
+})->throws(OidcException::class, 'OIDC login session expired. Please try again.');

--- a/tests/Unit/OidcTokenValidatorTest.php
+++ b/tests/Unit/OidcTokenValidatorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use App\Auth\Oidc\Exceptions\OidcSigningKeyNotFoundException;
+use App\Auth\Oidc\Exceptions\OidcTokenException;
+use App\Auth\Oidc\OidcDiscoveryDocument;
+use App\Auth\Oidc\OidcTokenValidator;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+function oidc_base64url(string $value): string
+{
+    return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+}
+
+function oidc_keyset(string $kid = 'test-key'): array
+{
+    $privateKey = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+
+    openssl_pkey_export($privateKey, $privatePem);
+    $details = openssl_pkey_get_details($privateKey);
+
+    return [
+        'private_pem' => $privatePem,
+        'jwks' => [
+            'keys' => [[
+                'kty' => 'RSA',
+                'kid' => $kid,
+                'alg' => 'RS256',
+                'use' => 'sig',
+                'n' => oidc_base64url($details['rsa']['n']),
+                'e' => oidc_base64url($details['rsa']['e']),
+            ]],
+        ],
+    ];
+}
+
+function oidc_token(array $claims, string $privatePem, string $kid = 'test-key', string $algorithm = 'RS256'): string
+{
+    $header = oidc_base64url(json_encode(['alg' => $algorithm, 'typ' => 'JWT', 'kid' => $kid], JSON_THROW_ON_ERROR));
+    $payload = oidc_base64url(json_encode($claims, JSON_THROW_ON_ERROR));
+    $signatureInput = $header.'.'.$payload;
+    openssl_sign($signatureInput, $signature, $privatePem, OPENSSL_ALGO_SHA256);
+
+    return $signatureInput.'.'.oidc_base64url($signature);
+}
+
+function oidc_discovery(): OidcDiscoveryDocument
+{
+    return new OidcDiscoveryDocument(
+        issuer: 'https://idp.example.com',
+        authorizationEndpoint: 'https://idp.example.com/oauth2/authorize',
+        tokenEndpoint: 'https://idp.example.com/oauth2/token',
+        userinfoEndpoint: 'https://idp.example.com/oauth2/userinfo',
+        jwksUri: 'https://idp.example.com/.well-known/jwks.json',
+    );
+}
+
+it('validates a well formed RS256 id token', function () {
+    $keyset = oidc_keyset();
+    $now = time();
+    $token = oidc_token([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => $now,
+        'exp' => $now + 600,
+        'nonce' => 'expected-nonce',
+        'email' => 'User@Example.com',
+    ], $keyset['private_pem']);
+
+    $claims = app(OidcTokenValidator::class)->validate(
+        idToken: $token,
+        discovery: oidc_discovery(),
+        jwks: $keyset['jwks'],
+        clientId: 'client-id',
+        expectedNonce: 'expected-nonce',
+    );
+
+    expect($claims['sub'])->toBe('okta-user-1')
+        ->and($claims['email'])->toBe('User@Example.com');
+});
+
+it('rejects invalid token claims', function (array $claimOverrides, string $message) {
+    $keyset = oidc_keyset();
+    $now = time();
+    $claims = array_merge([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => $now,
+        'exp' => $now + 600,
+        'nonce' => 'expected-nonce',
+    ], $claimOverrides);
+
+    $token = oidc_token($claims, $keyset['private_pem']);
+
+    app(OidcTokenValidator::class)->validate(
+        idToken: $token,
+        discovery: oidc_discovery(),
+        jwks: $keyset['jwks'],
+        clientId: 'client-id',
+        expectedNonce: 'expected-nonce',
+    );
+})->throws(OidcTokenException::class)->with([
+    'issuer mismatch' => [['iss' => 'https://evil.example.com'], 'issuer'],
+    'audience mismatch' => [['aud' => 'other-client'], 'audience'],
+    'azp missing for multi audience' => [['aud' => ['client-id', 'other-client']], 'azp'],
+    'azp mismatch' => [['aud' => ['client-id', 'other-client'], 'azp' => 'other-client'], 'azp'],
+    'expired token' => [['exp' => time() - 3600], 'expired'],
+    'future issued at' => [['iat' => time() + 3600], 'issued'],
+    'nonce mismatch' => [['nonce' => 'wrong-nonce'], 'nonce'],
+    'missing subject' => [['sub' => null], 'subject'],
+    'empty subject' => [['sub' => ''], 'subject'],
+    'non-string subject' => [['sub' => 123], 'subject'],
+]);
+
+it('rejects a bad signature and unknown key id', function (string $kid) {
+    $keyset = oidc_keyset('test-key');
+    $otherKeyset = oidc_keyset($kid);
+    $now = time();
+    $token = oidc_token([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => $now,
+        'exp' => $now + 600,
+        'nonce' => 'expected-nonce',
+    ], $otherKeyset['private_pem'], $kid);
+
+    app(OidcTokenValidator::class)->validate(
+        idToken: $token,
+        discovery: oidc_discovery(),
+        jwks: $keyset['jwks'],
+        clientId: 'client-id',
+        expectedNonce: 'expected-nonce',
+    );
+})->throws(OidcTokenException::class)->with([
+    'same kid with bad signature' => ['test-key'],
+    'unknown kid' => ['other-key'],
+]);
+
+it('rejects disallowed algorithms', function () {
+    $keyset = oidc_keyset();
+    $now = time();
+    $token = oidc_token([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => $now,
+        'exp' => $now + 600,
+    ], $keyset['private_pem'], algorithm: 'HS256');
+
+    app(OidcTokenValidator::class)->validate($token, oidc_discovery(), $keyset['jwks'], 'client-id');
+})->throws(OidcTokenException::class);
+
+it('throws a dedicated exception when the signing key is unknown', function () {
+    $keyset = oidc_keyset('current-key');
+    $token = oidc_token([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => time(),
+        'exp' => time() + 600,
+    ], $keyset['private_pem'], 'rotated-key');
+
+    app(OidcTokenValidator::class)->validate($token, oidc_discovery(), $keyset['jwks'], 'client-id');
+})->throws(OidcSigningKeyNotFoundException::class);
+
+it('rejects a jwks key not designated for signing', function () {
+    $keyset = oidc_keyset();
+    $keyset['jwks']['keys'][0]['use'] = 'enc';
+    $now = time();
+    $token = oidc_token([
+        'iss' => 'https://idp.example.com',
+        'aud' => 'client-id',
+        'sub' => 'okta-user-1',
+        'iat' => $now,
+        'exp' => $now + 600,
+    ], $keyset['private_pem']);
+
+    // An encryption-only key is dropped from the keyset, so the kid no longer resolves.
+    app(OidcTokenValidator::class)->validate($token, oidc_discovery(), $keyset['jwks'], 'client-id');
+})->throws(OidcTokenException::class);


### PR DESCRIPTION
## Changes

Production Coolify still only has a fixed list of OAuth vendors. This adds a first-party generic OpenID Connect provider (discovery + JWKS + RS256 `id_token` + PKCE) so an instance can sign users in with Keycloak, Authentik, Pocket ID, Okta, Auth0, Nextcloud, or any other OIDC-compliant IdP.

This is a **production backport** of the first-party approach from #10543 on `next` (4.4), not another `kovah/laravel-socialite-oidc` stub. Scoped to auth only.

## Issues

- Relates to #6696 (generic OIDC). That issue was closed after #10543 landed on `next`. This targets `main` so production can use any IdP before 4.4 ships.
- Relates to https://github.com/coollabsio/coolify/discussions/2040

## Testing

40 tests / 190 assertions passing (OIDC discovery, token validation, PKCE, login/create, migration).

## AI Assistance

- [x] AI was used (Cursor) for implementation assistance and tests; reviewed against #10543 and existing OAuth settings flow.

## Contributor Agreement

- [x] Read CONTRIBUTING.md
- [x] Searched existing issues/PRs
- [x] Tests run locally