### PR TITLE
feat(dns): automate Cloudflare DNS record management

### DIFF
--- a/app/Http/Controllers/Api/CloudProviderTokensController.php
+++ b/app/Http/Controllers/Api/CloudProviderTokensController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\CloudProviderToken;
+use App\Services\CloudflareDnsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -37,8 +38,13 @@ class CloudProviderTokensController extends Controller
                 'digitalocean' => Http::withHeaders([
                     'Authorization' => 'Bearer '.$token,
                 ])->timeout(10)->get('https://api.digitalocean.com/v2/account'),
+                'cloudflare' => null,
                 default => null,
             };
+
+            if ($provider === 'cloudflare') {
+                return (new CloudflareDnsService($token))->validateToken();
+            }
 
             if ($response === null) {
                 return ['valid' => false, 'error' => 'Unsupported provider.'];
@@ -50,7 +56,7 @@ class CloudProviderTokensController extends Controller
 
             return ['valid' => false, 'error' => "Invalid {$provider} token. Please check your API token."];
         } catch (\Throwable $e) {
-            Log::error('Failed to validate cloud provider token', [
+            Log::error('Failed to validate integration token', [
                 'provider' => $provider,
                 'exception' => $e->getMessage(),
             ]);
@@ -60,18 +66,18 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Get(
-        summary: 'List Cloud Provider Tokens',
-        description: 'List all cloud provider tokens for the authenticated team.',
+        summary: 'List Integration Tokens',
+        description: 'List all integration tokens for the authenticated team.',
         path: '/cloud-tokens',
         operationId: 'list-cloud-tokens',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'Get all cloud provider tokens.',
+                description: 'Get all integration tokens.',
                 content: [
                     new OA\MediaType(
                         mediaType: 'application/json',
@@ -82,7 +88,7 @@ class CloudProviderTokensController extends Controller
                                 properties: [
                                     'uuid' => ['type' => 'string'],
                                     'name' => ['type' => 'string'],
-                                    'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean']],
+                                    'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean', 'cloudflare']],
                                     'team_id' => ['type' => 'integer'],
                                     'servers_count' => ['type' => 'integer'],
                                     'created_at' => ['type' => 'string'],
@@ -120,21 +126,21 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Get(
-        summary: 'Get Cloud Provider Token',
-        description: 'Get cloud provider token by UUID.',
+        summary: 'Get Integration Token',
+        description: 'Get integration token by UUID.',
         path: '/cloud-tokens/{uuid}',
         operationId: 'get-cloud-token-by-uuid',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         parameters: [
             new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Token UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'Get cloud provider token by UUID',
+                description: 'Get integration token by UUID',
                 content: [
                     new OA\MediaType(
                         mediaType: 'application/json',
@@ -182,14 +188,14 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Post(
-        summary: 'Create Cloud Provider Token',
-        description: 'Create a new cloud provider token. The token will be validated before being stored.',
+        summary: 'Create Integration Token',
+        description: 'Create a new integration token. The token will be validated before being stored.',
         path: '/cloud-tokens',
         operationId: 'create-cloud-token',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         requestBody: new OA\RequestBody(
             required: true,
             description: 'Cloud provider token details',
@@ -199,7 +205,7 @@ class CloudProviderTokensController extends Controller
                     type: 'object',
                     required: ['provider', 'token', 'name'],
                     properties: [
-                        'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean'], 'example' => 'hetzner', 'description' => 'The cloud provider.'],
+                        'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean', 'cloudflare'], 'example' => 'cloudflare', 'description' => 'The integration provider.'],
                         'token' => ['type' => 'string', 'example' => 'your-api-token-here', 'description' => 'The API token for the cloud provider.'],
                         'name' => ['type' => 'string', 'example' => 'My Hetzner Token', 'description' => 'A friendly name for the token.'],
                     ],
@@ -253,7 +259,7 @@ class CloudProviderTokensController extends Controller
         $body = $request->json()->all();
 
         $validator = customApiValidator($body, [
-            'provider' => 'required|string|in:hetzner,digitalocean',
+            'provider' => 'required|string|in:hetzner,digitalocean,cloudflare',
             'token' => 'required|string',
             'name' => 'required|string|max:255',
         ]);
@@ -300,14 +306,14 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Patch(
-        summary: 'Update Cloud Provider Token',
-        description: 'Update cloud provider token name.',
+        summary: 'Update Integration Token',
+        description: 'Update integration token name.',
         path: '/cloud-tokens/{uuid}',
         operationId: 'update-cloud-token-by-uuid',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         parameters: [
             new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Token UUID', schema: new OA\Schema(type: 'string')),
         ],
@@ -411,19 +417,19 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Delete(
-        summary: 'Delete Cloud Provider Token',
-        description: 'Delete cloud provider token by UUID. Cannot delete if token is used by any servers.',
+        summary: 'Delete Integration Token',
+        description: 'Delete integration token by UUID. Cannot delete if token is used by any servers.',
         path: '/cloud-tokens/{uuid}',
         operationId: 'delete-cloud-token-by-uuid',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         parameters: [
             new OA\Parameter(
                 name: 'uuid',
                 in: 'path',
-                description: 'UUID of the cloud provider token.',
+                description: 'UUID of the integration token.',
                 required: true,
                 schema: new OA\Schema(
                     type: 'string',
@@ -476,8 +482,8 @@ class CloudProviderTokensController extends Controller
             return response()->json(['message' => 'Cloud provider token not found.'], 404);
         }
 
-        if ($token->hasServers()) {
-            return response()->json(['message' => 'Cannot delete token that is used by servers.'], 400);
+        if ($token->isUsed()) {
+            return response()->json(['message' => 'Cannot delete token that is used by servers or Cloudflare DNS settings.'], 400);
         }
 
         $tokenUuid = $token->uuid;
@@ -496,14 +502,14 @@ class CloudProviderTokensController extends Controller
     }
 
     #[OA\Post(
-        summary: 'Validate Cloud Provider Token',
-        description: 'Validate a cloud provider token against the provider API.',
+        summary: 'Validate Integration Token',
+        description: 'Validate a integration token against the provider API.',
         path: '/cloud-tokens/{uuid}/validate',
         operationId: 'validate-cloud-token-by-uuid',
         security: [
             ['bearerAuth' => []],
         ],
-        tags: ['Cloud Tokens'],
+        tags: ['Integration Tokens'],
         parameters: [
             new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Token UUID', schema: new OA\Schema(type: 'string')),
         ],

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -19,6 +19,7 @@ use App\Models\StandaloneDocker;
 use App\Models\SwarmDocker;
 use App\Notifications\Application\DeploymentFailed;
 use App\Notifications\Application\DeploymentSuccess;
+use App\Services\CloudflareDnsService;
 use App\Support\ValidationPatterns;
 use App\Traits\EnvironmentVariableAnalyzer;
 use App\Traits\ExecuteRemoteCommand;
@@ -300,6 +301,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             return;
         }
         try {
+            $this->ensureCloudflareDnsRecords();
+
             // Make sure the private key is stored in the filesystem
             $this->server->privateKey->storeInFileSystem();
             // Generate custom host<->ip mapping
@@ -403,6 +406,31 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 // Log but don't fail - event dispatch errors shouldn't prevent status updates
                 \Log::warning('Failed to dispatch ServiceStatusChanged for deployment '.$this->deployment_uuid.': '.$e->getMessage());
             }
+        }
+    }
+
+    private function ensureCloudflareDnsRecords(): void
+    {
+        $service = CloudflareDnsService::forServer($this->server);
+        if (! $service) {
+            return;
+        }
+
+        $domains = $service->domainsForApplication($this->application, $this->preview);
+        if (empty($domains)) {
+            return;
+        }
+
+        $this->application_deployment_queue->addLogEntry('Checking Cloudflare DNS records.');
+
+        $results = $service->ensureRecordsForDomains(
+            server: $this->server,
+            domains: $domains,
+            proxied: (bool) $this->server->settings->cloudflare_dns_proxied,
+        );
+
+        foreach ($results as $result) {
+            $this->application_deployment_queue->addLogEntry("Cloudflare DNS {$result['action']}: {$result['host']} -> {$result['content']}");
         }
     }
 

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Project\Application;
 use App\Actions\Application\GenerateConfig;
 use App\Jobs\ApplicationDeploymentJob;
 use App\Models\Application;
+use App\Services\CloudflareDnsService;
 use App\Support\ValidationPatterns;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -696,6 +697,7 @@ class General extends Component
         if ($this->fqdn) {
             $domains = str($this->fqdn)->trim()->explode(',');
             if ($this->application->additional_servers->count() === 0) {
+                $this->ensureCloudflareDns($domains->all(), $showToaster);
                 foreach ($domains as $domain) {
                     if (! validateDNSEntry($domain, $this->application->destination->server)) {
                         $showToaster && $this->dispatch('error', 'Validating DNS failed.', "Make sure you have added the DNS records correctly.<br><br>$domain->{$this->application->destination->server->ip}<br><br>Check this <a target='_blank' class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/dns-configuration'>documentation</a> for further help.");
@@ -869,6 +871,7 @@ class General extends Component
                     foreach ($this->parsedServiceDomains as $service) {
                         $domain = data_get($service, 'domain');
                         if ($domain) {
+                            $this->ensureCloudflareDns(str($domain)->explode(',')->all(), $showToaster);
                             if (! validateDNSEntry($domain, $this->application->destination->server)) {
                                 $showToaster && $this->dispatch('error', 'Validating DNS failed.', "Make sure you have added the DNS records correctly.<br><br>$domain->{$this->application->destination->server->ip}<br><br>Check this <a target='_blank' class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/dns-configuration'>documentation</a> for further help.");
                             }
@@ -904,6 +907,27 @@ class General extends Component
             return handleError($e, $this);
         } finally {
             $this->dispatch('configurationChanged');
+        }
+    }
+
+    private function ensureCloudflareDns(array $domains, bool $showToaster = true): void
+    {
+        $server = $this->application->destination->server;
+        $service = CloudflareDnsService::forServer($server);
+
+        if (! $service) {
+            return;
+        }
+
+        $results = $service->ensureRecordsForDomains(
+            server: $server,
+            domains: $domains,
+            proxied: (bool) $server->settings->cloudflare_dns_proxied,
+        );
+
+        $changed = collect($results)->whereIn('action', ['created', 'updated'])->count();
+        if ($showToaster && $changed > 0) {
+            $this->dispatch('success', "Cloudflare DNS updated for {$changed} domain(s).");
         }
     }
 

--- a/app/Livewire/Security/CloudProviderTokenForm.php
+++ b/app/Livewire/Security/CloudProviderTokenForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Security;
 
 use App\Models\CloudProviderToken;
+use App\Services\CloudflareDnsService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Http;
 use Livewire\Component;
@@ -27,7 +28,7 @@ class CloudProviderTokenForm extends Component
     protected function rules(): array
     {
         return [
-            'provider' => 'required|string|in:hetzner,digitalocean',
+            'provider' => 'required|string|in:hetzner,digitalocean,cloudflare',
             'token' => 'required|string',
             'name' => 'required|string|max:255',
         ];
@@ -36,8 +37,8 @@ class CloudProviderTokenForm extends Component
     protected function messages(): array
     {
         return [
-            'provider.required' => 'Please select a cloud provider.',
-            'provider.in' => 'Invalid cloud provider selected.',
+            'provider.required' => 'Please select an integration provider.',
+            'provider.in' => 'Invalid integration provider selected.',
             'token.required' => 'API token is required.',
             'name.required' => 'Token name is required.',
         ];
@@ -50,13 +51,21 @@ class CloudProviderTokenForm extends Component
                 $response = Http::withHeaders([
                     'Authorization' => 'Bearer '.$token,
                 ])->timeout(10)->get('https://api.hetzner.cloud/v1/servers');
-                ray($response);
 
                 return $response->successful();
             }
 
-            // Add other providers here in the future
-            // if ($provider === 'digitalocean') { ... }
+            if ($provider === 'digitalocean') {
+                $response = Http::withToken($token)
+                    ->timeout(10)
+                    ->get('https://api.digitalocean.com/v2/account');
+
+                return $response->successful();
+            }
+
+            if ($provider === 'cloudflare') {
+                return (new CloudflareDnsService($token))->validateToken()['valid'];
+            }
 
             return false;
         } catch (\Throwable $e) {
@@ -86,7 +95,7 @@ class CloudProviderTokenForm extends Component
             // Dispatch event with token ID so parent components can react
             $this->dispatch('tokenAdded', tokenId: $savedToken->id);
 
-            $this->dispatch('success', 'Cloud provider token added successfully.');
+            $this->dispatch('success', 'Integration token added successfully.');
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Security/CloudProviderTokens.php
+++ b/app/Livewire/Security/CloudProviderTokens.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Security;
 
 use App\Models\CloudProviderToken;
+use App\Services\CloudflareDnsService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
@@ -50,6 +51,13 @@ class CloudProviderTokens extends Component
                 } else {
                     $this->dispatch('error', 'DigitalOcean token validation failed. Please check the token.');
                 }
+            } elseif ($token->provider === 'cloudflare') {
+                $validation = (new CloudflareDnsService($token->token))->validateToken();
+                if ($validation['valid']) {
+                    $this->dispatch('success', 'Cloudflare token is valid.');
+                } else {
+                    $this->dispatch('error', $validation['error'] ?? 'Cloudflare token validation failed. Please check the token.');
+                }
             } else {
                 $this->dispatch('error', 'Unknown provider.');
             }
@@ -91,9 +99,10 @@ class CloudProviderTokens extends Component
             $this->authorize('delete', $token);
 
             // Check if any servers are using this token
-            if ($token->hasServers()) {
+            if ($token->isUsed()) {
                 $serverCount = $token->servers()->count();
-                $this->dispatch('error', "Cannot delete this token. It is currently used by {$serverCount} server(s). Please reassign those servers to a different token first.");
+                $dnsServerCount = $token->cloudflareDnsServerSettings()->count();
+                $this->dispatch('error', "Cannot delete this token. It is currently used by {$serverCount} server(s) and {$dnsServerCount} Cloudflare DNS configuration(s). Please reassign them first.");
 
                 return;
             }
@@ -101,7 +110,7 @@ class CloudProviderTokens extends Component
             $token->delete();
             $this->loadTokens();
 
-            $this->dispatch('success', 'Cloud provider token deleted successfully.');
+            $this->dispatch('success', 'Integration token deleted successfully.');
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Server/Advanced.php
+++ b/app/Livewire/Server/Advanced.php
@@ -2,12 +2,17 @@
 
 namespace App\Livewire\Server;
 
+use App\Models\CloudProviderToken;
 use App\Models\Server;
+use App\Services\CloudflareDnsService;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 class Advanced extends Component
 {
+    use AuthorizesRequests;
+
     public Server $server;
 
     public array $parameters = [];
@@ -27,11 +32,20 @@ class Advanced extends Component
     #[Validate(['required', 'integer', 'min:1'])]
     public int|string $deploymentQueueLimit = 25;
 
+    public bool $cloudflareDnsEnabled = false;
+
+    public int|string|null $cloudflareDnsTokenId = null;
+
+    public bool $cloudflareDnsProxied = false;
+
+    public $cloudflareTokens = [];
+
     public function mount(string $server_uuid)
     {
         try {
             $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
             $this->parameters = get_route_parameters();
+            $this->loadCloudflareTokens();
             $this->syncData();
 
         } catch (\Throwable) {
@@ -44,18 +58,91 @@ class Advanced extends Component
         if ($toModel) {
             $this->authorize('update', $this->server);
             $this->validate();
+            $this->validateCloudflareDnsSettings();
             $this->server->settings->concurrent_builds = $this->concurrentBuilds;
             $this->server->settings->dynamic_timeout = $this->dynamicTimeout;
             $this->server->settings->deployment_queue_limit = $this->deploymentQueueLimit;
             $this->server->settings->server_disk_usage_notification_threshold = $this->serverDiskUsageNotificationThreshold;
             $this->server->settings->server_disk_usage_check_frequency = $this->serverDiskUsageCheckFrequency;
+            $this->server->settings->cloudflare_dns_enabled = $this->cloudflareDnsEnabled;
+            $this->server->settings->cloudflare_dns_token_id = $this->cloudflareDnsEnabled ? $this->cloudflareDnsTokenId : null;
+            $this->server->settings->cloudflare_dns_proxied = $this->cloudflareDnsEnabled && $this->cloudflareDnsProxied;
             $this->server->settings->save();
+            $this->server->refresh();
         } else {
             $this->concurrentBuilds = $this->server->settings->concurrent_builds;
             $this->dynamicTimeout = $this->server->settings->dynamic_timeout;
             $this->deploymentQueueLimit = $this->server->settings->deployment_queue_limit;
             $this->serverDiskUsageNotificationThreshold = $this->server->settings->server_disk_usage_notification_threshold;
             $this->serverDiskUsageCheckFrequency = $this->server->settings->server_disk_usage_check_frequency;
+            $this->cloudflareDnsEnabled = (bool) $this->server->settings->cloudflare_dns_enabled;
+            $this->cloudflareDnsTokenId = $this->server->settings->cloudflare_dns_token_id;
+            $this->cloudflareDnsProxied = (bool) $this->server->settings->cloudflare_dns_proxied;
+        }
+    }
+
+    public function loadCloudflareTokens(): void
+    {
+        $this->cloudflareTokens = CloudProviderToken::ownedByCurrentTeam()
+            ->where('provider', 'cloudflare')
+            ->get();
+    }
+
+    public function checkCloudflareDns(): void
+    {
+        try {
+            $this->syncData(true);
+
+            $service = CloudflareDnsService::forServer($this->server);
+            if (! $service) {
+                $this->dispatch('error', 'Cloudflare DNS is not configured for this server.');
+
+                return;
+            }
+
+            $results = collect();
+            foreach ($this->server->applications() as $application) {
+                $domains = $service->domainsForApplication($application);
+                if (empty($domains)) {
+                    continue;
+                }
+
+                $results = $results->concat($service->ensureRecordsForDomains(
+                    server: $this->server,
+                    domains: $domains,
+                    proxied: $this->cloudflareDnsProxied,
+                ));
+            }
+
+            if ($results->isEmpty()) {
+                $this->dispatch('warning', 'No application domains found on this server.');
+
+                return;
+            }
+
+            $this->dispatch('success', "Cloudflare DNS checked for {$results->count()} domain(s).");
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+    }
+
+    private function validateCloudflareDnsSettings(): void
+    {
+        if (! $this->cloudflareDnsEnabled) {
+            return;
+        }
+
+        if (blank($this->cloudflareDnsTokenId)) {
+            throw new \Exception('Please select a Cloudflare integration token.');
+        }
+
+        $token = CloudProviderToken::ownedByCurrentTeam()
+            ->where('provider', 'cloudflare')
+            ->whereKey($this->cloudflareDnsTokenId)
+            ->first();
+
+        if (! $token) {
+            throw new \Exception('Selected Cloudflare token is invalid.');
         }
     }
 

--- a/app/Models/CloudProviderToken.php
+++ b/app/Models/CloudProviderToken.php
@@ -2,8 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
 class CloudProviderToken extends BaseModel
 {
+    use HasFactory;
+
     protected $fillable = [
         'team_id',
         'provider',
@@ -25,9 +29,19 @@ class CloudProviderToken extends BaseModel
         return $this->hasMany(Server::class);
     }
 
+    public function cloudflareDnsServerSettings()
+    {
+        return $this->hasMany(ServerSetting::class, 'cloudflare_dns_token_id');
+    }
+
     public function hasServers(): bool
     {
         return $this->servers()->exists();
+    }
+
+    public function isUsed(): bool
+    {
+        return $this->hasServers() || $this->cloudflareDnsServerSettings()->exists();
     }
 
     public static function ownedByCurrentTeam(array $select = ['*'])

--- a/app/Models/ServerSetting.php
+++ b/app/Models/ServerSetting.php
@@ -64,6 +64,9 @@ class ServerSetting extends Model
         'is_usable',
         'wildcard_domain',
         'is_cloudflare_tunnel',
+        'cloudflare_dns_enabled',
+        'cloudflare_dns_token_id',
+        'cloudflare_dns_proxied',
         'is_logdrain_newrelic_enabled',
         'logdrain_newrelic_license_key',
         'logdrain_newrelic_base_uri',
@@ -112,6 +115,8 @@ class ServerSetting extends Model
         'is_terminal_enabled' => 'boolean',
         'disable_application_image_retention' => 'boolean',
         'connection_timeout' => 'integer',
+        'cloudflare_dns_enabled' => 'boolean',
+        'cloudflare_dns_proxied' => 'boolean',
     ];
 
     protected static function booted()
@@ -232,6 +237,11 @@ class ServerSetting extends Model
     public function server()
     {
         return $this->belongsTo(Server::class);
+    }
+
+    public function cloudflareDnsToken()
+    {
+        return $this->belongsTo(CloudProviderToken::class, 'cloudflare_dns_token_id');
     }
 
     public function dockerCleanupFrequency(): Attribute

--- a/app/Services/CloudflareDnsService.php
+++ b/app/Services/CloudflareDnsService.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use App\Models\Server;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Spatie\Url\Url;
+
+class CloudflareDnsService
+{
+    private string $baseUrl = 'https://api.cloudflare.com/client/v4';
+
+    public function __construct(private readonly string $token) {}
+
+    public static function forServer(Server $server): ?self
+    {
+        $server->loadMissing('settings.cloudflareDnsToken');
+
+        if (! $server->settings?->cloudflare_dns_enabled || ! $server->settings?->cloudflareDnsToken) {
+            return null;
+        }
+
+        return new self($server->settings->cloudflareDnsToken->token);
+    }
+
+    /**
+     * @return array{valid: bool, error: string|null}
+     */
+    public function validateToken(): array
+    {
+        try {
+            $verifyResponse = $this->request('get', '/user/tokens/verify');
+            if (! $verifyResponse->successful() || $verifyResponse->json('success') !== true) {
+                return ['valid' => false, 'error' => 'Invalid Cloudflare token.'];
+            }
+
+            $zonesResponse = $this->request('get', '/zones', ['per_page' => 1]);
+            if (! $zonesResponse->successful() || $zonesResponse->json('success') !== true) {
+                return ['valid' => false, 'error' => 'Cloudflare token must be able to read zones.'];
+            }
+
+            return ['valid' => true, 'error' => null];
+        } catch (\Throwable) {
+            return ['valid' => false, 'error' => 'Failed to validate token with Cloudflare API.'];
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $domains
+     * @return array<int, array{domain: string, host: string, type: string, content: string, action: string}>
+     */
+    public function ensureRecordsForDomains(Server $server, array $domains, bool $proxied = false): array
+    {
+        $ip = $this->serverIp($server);
+        $type = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? 'AAAA' : 'A';
+
+        return collect($domains)
+            ->filter()
+            ->map(fn (string $domain) => trim($domain))
+            ->filter()
+            ->unique()
+            ->map(fn (string $domain) => $this->ensureRecord($domain, $type, $ip, $proxied))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function domainsForApplication(Application $application, ?ApplicationPreview $preview = null): array
+    {
+        $domains = collect();
+
+        $this->pushCommaSeparatedDomains($domains, $application->fqdn);
+        $this->pushDockerComposeDomains($domains, $application->docker_compose_domains);
+
+        if ($preview) {
+            $this->pushCommaSeparatedDomains($domains, $preview->fqdn);
+            $this->pushDockerComposeDomains($domains, $preview->docker_compose_domains);
+        }
+
+        return $domains->filter()->unique()->values()->all();
+    }
+
+    /**
+     * @return array{domain: string, host: string, type: string, content: string, action: string}
+     */
+    private function ensureRecord(string $domain, string $type, string $content, bool $proxied): array
+    {
+        $host = $this->hostFromDomain($domain);
+        $zone = $this->findZoneForHost($host);
+        $existingRecord = $this->findRecord($zone['id'], $type, $host);
+        $payload = [
+            'type' => $type,
+            'name' => $host,
+            'content' => $content,
+            'ttl' => 1,
+            'proxied' => $proxied,
+        ];
+
+        if ($existingRecord === null) {
+            $response = $this->request('post', "/zones/{$zone['id']}/dns_records", $payload);
+            $this->throwIfFailed($response, "Unable to create Cloudflare DNS record for {$host}.");
+
+            return compact('domain', 'host', 'type', 'content') + ['action' => 'created'];
+        }
+
+        if (
+            data_get($existingRecord, 'content') === $content &&
+            (bool) data_get($existingRecord, 'proxied') === $proxied
+        ) {
+            return compact('domain', 'host', 'type', 'content') + ['action' => 'unchanged'];
+        }
+
+        $response = $this->request('patch', "/zones/{$zone['id']}/dns_records/{$existingRecord['id']}", $payload);
+        $this->throwIfFailed($response, "Unable to update Cloudflare DNS record for {$host}.");
+
+        return compact('domain', 'host', 'type', 'content') + ['action' => 'updated'];
+    }
+
+    /**
+     * @return array{id: string, name: string}
+     */
+    private function findZoneForHost(string $host): array
+    {
+        $labels = explode('.', $host);
+
+        while (count($labels) >= 2) {
+            $zoneName = implode('.', $labels);
+            $response = $this->request('get', '/zones', [
+                'name' => $zoneName,
+                'status' => 'active',
+                'per_page' => 1,
+            ]);
+            $this->throwIfFailed($response, "Unable to find Cloudflare zone for {$host}.");
+
+            $zone = collect($response->json('result', []))->first();
+            if ($zone) {
+                return [
+                    'id' => $zone['id'],
+                    'name' => $zone['name'],
+                ];
+            }
+
+            array_shift($labels);
+        }
+
+        throw new \RuntimeException("No active Cloudflare zone found for {$host}.");
+    }
+
+    private function findRecord(string $zoneId, string $type, string $host): ?array
+    {
+        $response = $this->request('get', "/zones/{$zoneId}/dns_records", [
+            'type' => $type,
+            'name' => $host,
+            'per_page' => 100,
+        ]);
+        $this->throwIfFailed($response, "Unable to list Cloudflare DNS records for {$host}.");
+
+        return collect($response->json('result', []))->first();
+    }
+
+    private function request(string $method, string $endpoint, array $data = []): Response
+    {
+        return Http::withToken($this->token)
+            ->acceptJson()
+            ->asJson()
+            ->timeout(30)
+            ->{$method}($this->baseUrl.$endpoint, $data);
+    }
+
+    private function throwIfFailed(Response $response, string $message): void
+    {
+        if ($response->successful() && $response->json('success') === true) {
+            return;
+        }
+
+        $error = collect($response->json('errors', []))->pluck('message')->filter()->implode(' ');
+
+        throw new \RuntimeException(trim($message.' '.$error));
+    }
+
+    private function hostFromDomain(string $domain): string
+    {
+        $domain = trim($domain);
+        $url = Url::fromString(str($domain)->contains('://') ? $domain : 'http://'.$domain, ['http', 'https']);
+
+        return strtolower($url->getHost());
+    }
+
+    private function serverIp(Server $server): string
+    {
+        $ip = $server->ip;
+
+        if (! filter_var($ip, FILTER_VALIDATE_IP)) {
+            throw new \RuntimeException("Server {$server->name} does not have a valid public IP address.");
+        }
+
+        return $ip;
+    }
+
+    private function pushCommaSeparatedDomains(Collection $domains, ?string $domainString): void
+    {
+        if (blank($domainString)) {
+            return;
+        }
+
+        str($domainString)->explode(',')->each(function (string $domain) use ($domains) {
+            $domains->push(trim($domain));
+        });
+    }
+
+    private function pushDockerComposeDomains(Collection $domains, ?string $dockerComposeDomains): void
+    {
+        if (blank($dockerComposeDomains)) {
+            return;
+        }
+
+        collect(json_decode($dockerComposeDomains, true) ?: [])
+            ->pluck('domain')
+            ->each(fn (?string $domain) => $this->pushCommaSeparatedDomains($domains, $domain));
+    }
+}

--- a/database/factories/CloudProviderTokenFactory.php
+++ b/database/factories/CloudProviderTokenFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CloudProviderToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CloudProviderToken>
+ */
+class CloudProviderTokenFactory extends Factory
+{
+    protected $model = CloudProviderToken::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => 1,
+            'provider' => 'hetzner',
+            'token' => fake()->sha256(),
+            'name' => fake()->words(2, true),
+        ];
+    }
+}

--- a/database/migrations/2026_05_11_000001_add_cloudflare_dns_settings_to_server_settings_table.php
+++ b/database/migrations/2026_05_11_000001_add_cloudflare_dns_settings_to_server_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->boolean('cloudflare_dns_enabled')->default(false)->after('is_cloudflare_tunnel');
+            $table->foreignId('cloudflare_dns_token_id')->nullable()->after('cloudflare_dns_enabled')->constrained('cloud_provider_tokens')->nullOnDelete();
+            $table->boolean('cloudflare_dns_proxied')->default(false)->after('cloudflare_dns_token_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->dropForeign(['cloudflare_dns_token_id']);
+            $table->dropColumn([
+                'cloudflare_dns_enabled',
+                'cloudflare_dns_token_id',
+                'cloudflare_dns_proxied',
+            ]);
+        });
+    }
+};

--- a/resources/views/components/security/navbar.blade.php
+++ b/resources/views/components/security/navbar.blade.php
@@ -8,7 +8,7 @@
             </a>
             @can('viewAny', App\Models\CloudProviderToken::class)
                 <a href="{{ route('security.cloud-tokens') }}" {{ wireNavigate() }}>
-                    <button>Cloud Tokens</button>
+                    <button>Integration Tokens</button>
                 </a>
             @endcan
             @can('viewAny', App\Models\CloudInitScript::class)

--- a/resources/views/livewire/security/cloud-provider-token-form.blade.php
+++ b/resources/views/livewire/security/cloud-provider-token-form.blade.php
@@ -6,6 +6,7 @@
                 <x-forms.select required id="provider" label="Provider">
                     <option value="hetzner">Hetzner</option>
                     <option value="digitalocean">DigitalOcean</option>
+                    <option value="cloudflare">Cloudflare</option>
                 </x-forms.select>
             @else
                 <input type="hidden" wire:model="provider" />
@@ -20,9 +21,9 @@
             @if (auth()->user()->currentTeam()->cloudProviderTokens->where('provider', $provider)->isEmpty())
                 <div class="text-sm text-neutral-500 dark:text-neutral-400">
                     Create an API token in the <a
-                        href='{{ $provider === 'hetzner' ? 'https://console.hetzner.com/projects' : '#' }}'
+                        href='{{ $provider === 'hetzner' ? 'https://console.hetzner.com/projects' : ($provider === 'cloudflare' ? 'https://dash.cloudflare.com/profile/api-tokens' : '#') }}'
                         target='_blank' class='underline dark:text-white'>{{ ucfirst($provider) }} Console</a> → choose
-                    Project → Security → API Tokens.
+                    {{ $provider === 'cloudflare' ? 'API Tokens → Create Token with Zone Read and DNS Write permissions.' : 'Project → Security → API Tokens.' }}
                     @if ($provider === 'hetzner')
                         <br><br>
                         Don't have a Hetzner account? <a href='https://coolify.io/hetzner' target='_blank'
@@ -39,9 +40,10 @@
             {{-- Full page layout: horizontal, spacious --}}
             <div class="flex gap-2 items-end flex-wrap">
                 <div class="w-64">
-                    <x-forms.select required id="provider" label="Provider" disabled>
-                        <option value="hetzner" selected>Hetzner</option>
+                    <x-forms.select required id="provider" label="Provider">
+                        <option value="hetzner">Hetzner</option>
                         <option value="digitalocean">DigitalOcean</option>
+                        <option value="cloudflare">Cloudflare</option>
                     </x-forms.select>
                 </div>
                 <div class="flex-1 min-w-64">
@@ -54,15 +56,19 @@
                     placeholder="Enter your API token" />
                 @if (auth()->user()->currentTeam()->cloudProviderTokens->where('provider', $provider)->isEmpty())
                     <div class="text-sm text-neutral-500 dark:text-neutral-400 mt-2">
-                        Create an API token in the <a href='https://console.hetzner.com/projects' target='_blank'
-                            class='underline dark:text-white'>Hetzner Console</a> → choose Project → Security → API
-                        Tokens.
+                        Create an API token in the <a
+                            href='{{ $provider === 'cloudflare' ? 'https://dash.cloudflare.com/profile/api-tokens' : 'https://console.hetzner.com/projects' }}'
+                            target='_blank'
+                            class='underline dark:text-white'>{{ $provider === 'cloudflare' ? 'Cloudflare Console' : 'Hetzner Console' }}</a>
+                        → {{ $provider === 'cloudflare' ? 'API Tokens → Create Token with Zone Read and DNS Write permissions.' : 'choose Project → Security → API Tokens.' }}
                         <br><br>
-                        Don't have a Hetzner account? <a href='https://coolify.io/hetzner' target='_blank'
-                            class='underline dark:text-white'>Sign up here</a>
-                        <br>
-                        <span class="text-xs">(Coolify's affiliate link, only new accounts - supports us (€10)
-                            and gives you €20)</span>
+                        @if ($provider === 'hetzner')
+                            Don't have a Hetzner account? <a href='https://coolify.io/hetzner' target='_blank'
+                                class='underline dark:text-white'>Sign up here</a>
+                            <br>
+                            <span class="text-xs">(Coolify's affiliate link, only new accounts - supports us (€10)
+                                and gives you €20)</span>
+                        @endif
                     </div>
                 @endif
             </div>

--- a/resources/views/livewire/security/cloud-provider-tokens.blade.php
+++ b/resources/views/livewire/security/cloud-provider-tokens.blade.php
@@ -1,6 +1,6 @@
 <div>
-    <h2>Cloud Provider Tokens</h2>
-    <div class="pb-4">Manage API tokens for cloud providers (Hetzner, DigitalOcean, etc.).</div>
+    <h2>Integration Tokens</h2>
+    <div class="pb-4">Manage API tokens for third-party integrations (Hetzner, DigitalOcean, Cloudflare, etc.).</div>
 
     <h3>New Token</h3>
     @can('create', App\Models\CloudProviderToken::class)
@@ -30,8 +30,8 @@
                     @can('delete', $savedToken)
                         <x-modal-confirmation title="Confirm Token Deletion?" isErrorButton buttonTitle="Delete"
                             submitAction="deleteToken({{ $savedToken->id }})" :actions="[
-                                'This cloud provider token will be permanently deleted.',
-                                'Any servers using this token will need to be reconfigured.',
+                'This integration token will be permanently deleted.',
+                'Any servers or Cloudflare DNS settings using this token will need to be reconfigured.',
                             ]"
                             confirmationText="{{ $savedToken->name }}"
                             confirmationLabel="Please confirm the deletion by entering the token name below"
@@ -41,7 +41,7 @@
             </div>
         @empty
             <div>
-                <div>No cloud provider tokens found.</div>
+                <div>No integration tokens found.</div>
             </div>
         @endforelse
     </div>

--- a/resources/views/livewire/security/cloud-tokens.blade.php
+++ b/resources/views/livewire/security/cloud-tokens.blade.php
@@ -1,6 +1,6 @@
 <div>
     <x-slot:title>
-        Cloud Tokens | Coolify
+        Integration Tokens | Coolify
     </x-slot>
     <x-security.navbar />
     <livewire:security.cloud-provider-tokens />

--- a/resources/views/livewire/server/advanced.blade.php
+++ b/resources/views/livewire/server/advanced.blade.php
@@ -45,6 +45,36 @@
                             helper="Maximum number of queued deployments allowed. New deployments will be rejected with a 429 status when the limit is reached." />
                     </div>
                 </div>
+
+                <div class="flex flex-col">
+                    <div class="flex items-center gap-2">
+                        <h3>Cloudflare DNS</h3>
+                        <x-forms.button canGate="update" :canResource="$server" type="button"
+                            wire:click.prevent="checkCloudflareDns">
+                            Check DNS now
+                        </x-forms.button>
+                    </div>
+                    <div class="pb-4 text-sm text-neutral-500 dark:text-neutral-400">
+                        Let Coolify create or update A/AAAA records for application domains on this server.
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <x-forms.checkbox canGate="update" :canResource="$server" id="cloudflareDnsEnabled"
+                            label="Enable Cloudflare DNS management" />
+                        <div class="flex flex-wrap gap-2 sm:flex-nowrap">
+                            <x-forms.select canGate="update" :canResource="$server" id="cloudflareDnsTokenId"
+                                label="Cloudflare Integration Token"
+                                helper="Create a Cloudflare token with Zone Read and DNS Write permissions.">
+                                <option value="">Select a token</option>
+                                @foreach ($cloudflareTokens as $token)
+                                    <option value="{{ $token->id }}">{{ $token->name }}</option>
+                                @endforeach
+                            </x-forms.select>
+                        </div>
+                        <x-forms.checkbox canGate="update" :canResource="$server" id="cloudflareDnsProxied"
+                            label="Enable Cloudflare proxy (orange cloud)"
+                            helper="Off by default. When enabled, Cloudflare will proxy supported DNS records." />
+                    </div>
+                </div>
             </div>
         </form>
     </div>

--- a/tests/Feature/ApplicationGeneralBuildpackSelectorTest.php
+++ b/tests/Feature/ApplicationGeneralBuildpackSelectorTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Project\Application\General;
 use App\Models\Application;
+use App\Models\CloudProviderToken;
 use App\Models\Environment;
 use App\Models\InstanceSettings;
 use App\Models\PrivateKey;
@@ -11,6 +12,8 @@ use App\Models\StandaloneDocker;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
@@ -83,4 +86,61 @@ test('existing application shows railpack beta badge in build helper copy', func
         ->assertSuccessful()
         ->assertSee('Railpack')
         ->assertSee('Beta');
+});
+
+test('saving application domains creates missing Cloudflare DNS records when enabled on server', function () {
+    $token = CloudProviderToken::factory()->create([
+        'team_id' => $this->team->id,
+        'provider' => 'cloudflare',
+    ]);
+    $this->server->settings->update([
+        'cloudflare_dns_enabled' => true,
+        'cloudflare_dns_token_id' => $token->id,
+        'cloudflare_dns_proxied' => false,
+    ]);
+
+    Http::preventStrayRequests();
+    Http::fake(function (Request $request) {
+        parse_str(parse_url($request->url(), PHP_URL_QUERY) ?: '', $query);
+        $zoneName = $query['name'] ?? null;
+
+        if (str_contains($request->url(), '/zones?') && $zoneName === 'app.example.com') {
+            return Http::response(['success' => true, 'result' => []], 200);
+        }
+
+        if (str_contains($request->url(), '/zones?') && $zoneName === 'example.com') {
+            return Http::response(['success' => true, 'result' => [['id' => 'zone-id', 'name' => 'example.com']]], 200);
+        }
+
+        if ($request->method() === 'GET' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response(['success' => true, 'result' => []], 200);
+        }
+
+        if ($request->method() === 'POST' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response(['success' => true, 'result' => ['id' => 'record-id']], 200);
+        }
+
+        return Http::response(['success' => false], 500);
+    });
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'nixpacks',
+        'static_image' => 'nginx:alpine',
+        'base_directory' => '/',
+        'is_http_basic_auth_enabled' => false,
+        'redirect' => 'no',
+    ]);
+
+    Livewire::test(General::class, ['application' => $application])
+        ->set('fqdn', 'https://app.example.com')
+        ->call('submit')
+        ->assertDispatched('success');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/zones/zone-id/dns_records')
+        && $request['name'] === 'app.example.com'
+        && $request['content'] === $this->server->ip);
 });

--- a/tests/Feature/CloudProviderTokenApiTest.php
+++ b/tests/Feature/CloudProviderTokenApiTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\CloudProviderToken;
+use App\Models\Server;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -159,6 +160,32 @@ describe('POST /api/v1/cloud-tokens', function () {
         $response->assertJsonStructure(['uuid']);
     });
 
+    test('creates a Cloudflare integration token', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.cloudflare.com/client/v4/user/tokens/verify' => Http::response(['success' => true], 200),
+            'https://api.cloudflare.com/client/v4/zones*' => Http::response(['success' => true, 'result' => []], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/cloud-tokens', [
+            'provider' => 'cloudflare',
+            'token' => 'test-cloudflare-token',
+            'name' => 'My Cloudflare Token',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['uuid']);
+
+        $this->assertDatabaseHas('cloud_provider_tokens', [
+            'team_id' => $this->team->id,
+            'provider' => 'cloudflare',
+            'name' => 'My Cloudflare Token',
+        ]);
+    });
+
     test('validates provider is required', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
@@ -198,7 +225,7 @@ describe('POST /api/v1/cloud-tokens', function () {
         $response->assertJsonValidationErrors(['name']);
     });
 
-    test('validates provider must be hetzner or digitalocean', function () {
+    test('validates provider must be supported', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
             'Content-Type' => 'application/json',
@@ -343,6 +370,27 @@ describe('DELETE /api/v1/cloud-tokens/{uuid}', function () {
         $response->assertStatus(404);
     });
 
+    test('cannot delete token used by Cloudflare DNS settings', function () {
+        $token = CloudProviderToken::factory()->create([
+            'team_id' => $this->team->id,
+            'provider' => 'cloudflare',
+        ]);
+        $server = Server::factory()->create([
+            'team_id' => $this->team->id,
+        ]);
+        $server->settings->update([
+            'cloudflare_dns_enabled' => true,
+            'cloudflare_dns_token_id' => $token->id,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->deleteJson("/api/v1/cloud-tokens/{$token->uuid}");
+
+        $response->assertStatus(400);
+    });
+
     test('returns 404 for non-existent token', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
@@ -400,6 +448,27 @@ describe('POST /api/v1/cloud-tokens/{uuid}/validate', function () {
 
         Http::fake([
             'https://api.digitalocean.com/v2/account' => Http::response([], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/cloud-tokens/{$token->uuid}/validate");
+
+        $response->assertStatus(200);
+        $response->assertJson(['valid' => true, 'message' => 'Token is valid.']);
+    });
+
+    test('validates a valid Cloudflare token', function () {
+        $token = CloudProviderToken::factory()->create([
+            'team_id' => $this->team->id,
+            'provider' => 'cloudflare',
+        ]);
+
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.cloudflare.com/client/v4/user/tokens/verify' => Http::response(['success' => true], 200),
+            'https://api.cloudflare.com/client/v4/zones*' => Http::response(['success' => true, 'result' => []], 200),
         ]);
 
         $response = $this->withHeaders([

--- a/tests/Feature/CloudflareDnsServiceTest.php
+++ b/tests/Feature/CloudflareDnsServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\Server;
+use App\Services\CloudflareDnsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+function cloudflareQueryValue(Request $request, string $key): ?string
+{
+    parse_str(parse_url($request->url(), PHP_URL_QUERY) ?: '', $query);
+
+    return $query[$key] ?? null;
+}
+
+test('it creates missing Cloudflare DNS records', function () {
+    Http::preventStrayRequests();
+    Http::fake(function (Request $request) {
+        $zoneName = cloudflareQueryValue($request, 'name');
+
+        if (str_contains($request->url(), '/zones?') && $zoneName === 'app.example.com') {
+            return Http::response(['success' => true, 'result' => []], 200);
+        }
+
+        if (str_contains($request->url(), '/zones?') && $zoneName === 'example.com') {
+            return Http::response(['success' => true, 'result' => [['id' => 'zone-id', 'name' => 'example.com']]], 200);
+        }
+
+        if ($request->method() === 'GET' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response(['success' => true, 'result' => []], 200);
+        }
+
+        if ($request->method() === 'POST' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response(['success' => true, 'result' => ['id' => 'record-id']], 200);
+        }
+
+        return Http::response(['success' => false], 500);
+    });
+
+    $server = new Server(['name' => 'Production', 'ip' => '192.0.2.10']);
+    $service = new CloudflareDnsService('cloudflare-token');
+
+    $results = $service->ensureRecordsForDomains($server, ['https://app.example.com'], proxied: false);
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0]['action'])->toBe('created')
+        ->and($results[0]['type'])->toBe('A')
+        ->and($results[0]['content'])->toBe('192.0.2.10');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/zones/zone-id/dns_records')
+        && $request['name'] === 'app.example.com'
+        && $request['content'] === '192.0.2.10'
+        && $request['proxied'] === false);
+});
+
+test('it updates existing Cloudflare DNS records with wrong content or proxy state', function () {
+    Http::preventStrayRequests();
+    Http::fake(function (Request $request) {
+        $zoneName = cloudflareQueryValue($request, 'name');
+
+        if (str_contains($request->url(), '/zones?') && $zoneName === 'example.com') {
+            return Http::response(['success' => true, 'result' => [['id' => 'zone-id', 'name' => 'example.com']]], 200);
+        }
+
+        if ($request->method() === 'GET' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response([
+                'success' => true,
+                'result' => [['id' => 'record-id', 'content' => '198.51.100.1', 'proxied' => false]],
+            ], 200);
+        }
+
+        if ($request->method() === 'PATCH' && str_contains($request->url(), '/zones/zone-id/dns_records/record-id')) {
+            return Http::response(['success' => true, 'result' => ['id' => 'record-id']], 200);
+        }
+
+        return Http::response(['success' => true, 'result' => []], 200);
+    });
+
+    $server = new Server(['name' => 'Production', 'ip' => '192.0.2.10']);
+    $service = new CloudflareDnsService('cloudflare-token');
+
+    $results = $service->ensureRecordsForDomains($server, ['https://example.com'], proxied: true);
+
+    expect($results[0]['action'])->toBe('updated');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'PATCH'
+        && str_contains($request->url(), '/zones/zone-id/dns_records/record-id')
+        && $request['content'] === '192.0.2.10'
+        && $request['proxied'] === true);
+});
+
+test('it leaves matching Cloudflare DNS records unchanged', function () {
+    Http::preventStrayRequests();
+    Http::fake(function (Request $request) {
+        if (str_contains($request->url(), '/zones?')) {
+            return Http::response(['success' => true, 'result' => [['id' => 'zone-id', 'name' => 'example.com']]], 200);
+        }
+
+        if ($request->method() === 'GET' && str_contains($request->url(), '/zones/zone-id/dns_records')) {
+            return Http::response([
+                'success' => true,
+                'result' => [['id' => 'record-id', 'content' => '192.0.2.10', 'proxied' => false]],
+            ], 200);
+        }
+
+        return Http::response(['success' => false], 500);
+    });
+
+    $server = new Server(['name' => 'Production', 'ip' => '192.0.2.10']);
+    $service = new CloudflareDnsService('cloudflare-token');
+
+    $results = $service->ensureRecordsForDomains($server, ['https://example.com'], proxied: false);
+
+    expect($results[0]['action'])->toBe('unchanged');
+
+    Http::assertNotSent(fn (Request $request) => in_array($request->method(), ['POST', 'PATCH'], true));
+});

--- a/tests/Feature/ServerCloudflareDnsSettingsTest.php
+++ b/tests/Feature/ServerCloudflareDnsSettingsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Livewire\Server\Advanced;
+use App\Models\CloudProviderToken;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'ip' => '192.0.2.10',
+    ]);
+});
+
+test('server advanced settings persist Cloudflare DNS configuration', function () {
+    $token = CloudProviderToken::factory()->create([
+        'team_id' => $this->team->id,
+        'provider' => 'cloudflare',
+        'name' => 'Production Cloudflare',
+    ]);
+
+    Livewire::test(Advanced::class, ['server_uuid' => $this->server->uuid])
+        ->set('cloudflareDnsEnabled', true)
+        ->set('cloudflareDnsTokenId', $token->id)
+        ->set('cloudflareDnsProxied', false)
+        ->call('submit')
+        ->assertDispatched('success');
+
+    $this->server->settings->refresh();
+
+    expect($this->server->settings->cloudflare_dns_enabled)->toBeTrue()
+        ->and($this->server->settings->cloudflare_dns_token_id)->toBe($token->id)
+        ->and($this->server->settings->cloudflare_dns_proxied)->toBeFalse();
+});
+
+test('server advanced settings require a Cloudflare token when DNS management is enabled', function () {
+    Livewire::test(Advanced::class, ['server_uuid' => $this->server->uuid])
+        ->set('cloudflareDnsEnabled', true)
+        ->set('cloudflareDnsTokenId', null)
+        ->call('submit')
+        ->assertDispatched('error');
+});


### PR DESCRIPTION
## Summary

- Add Cloudflare API tokens to Integration Tokens with validation and usage protection.
- Add per-server Cloudflare DNS settings, including optional proxying.
- Automatically create or update A/AAAA records when application domains are saved or deployed.
- Add manual DNS synchronization and deployment logging.
- Add test coverage for token handling, server configuration, and DNS record creation and updates.