### PR TITLE
feat(ui): instance themes and custom CSS

### DIFF
--- a/app/Livewire/Settings/Theme.php
+++ b/app/Livewire/Settings/Theme.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use App\Models\InstanceSettings;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Validation\ValidationException;
+use Livewire\Component;
+
+class Theme extends Component
+{
+    use AuthorizesRequests;
+
+    public InstanceSettings $settings;
+
+    public string $theme_preset = '';
+
+    public ?string $custom_css = null;
+
+    public function mount()
+    {
+        if (! isInstanceAdmin()) {
+            return redirect()->route('dashboard');
+        }
+        $this->settings = instanceSettings();
+        $this->theme_preset = $this->settings->theme_preset ?? '';
+        $this->custom_css = $this->settings->custom_css;
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->settings);
+            $this->validate([
+                'theme_preset' => ['nullable', 'string', 'in:custom,'.implode(',', array_keys(themePresets()))],
+                'custom_css' => ['nullable', 'string', 'max:200000'],
+            ]);
+            if ($this->theme_preset === 'custom' && ($converted = itermColorsToCss((string) $this->custom_css)) !== null) {
+                $this->custom_css = $converted;
+            }
+            $this->settings->theme_preset = $this->theme_preset ?: null;
+            $this->settings->custom_css = $this->custom_css;
+            $this->settings->save();
+            $this->dispatch('success', 'Theme saved. Reloading…');
+            $this->dispatch('reloadWindow', 800);
+        } catch (ValidationException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.settings.theme', [
+            'options' => collect([['value' => '', 'label' => 'Default (Coolify)']])
+                ->concat(collect(themePresets())->map(fn ($label, $slug) => ['value' => $slug, 'label' => $label])->values())
+                ->push(['value' => 'custom', 'label' => 'Custom CSS…'])
+                ->all(),
+        ]);
+    }
+}

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -58,6 +58,8 @@ class InstanceSettings extends Model
         'avatar_storage_type',
         'avatar_s3_storage_id',
         'is_dashboard_force_https_enabled',
+        'theme_preset',
+        'custom_css',
     ];
 
     protected $hidden = [

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -919,6 +919,147 @@ function isCloud(): bool
     return ! config('constants.coolify.self_hosted');
 }
 
+function customThemePath(): string
+{
+    return storage_path('app/themes/custom.css');
+}
+
+function themePresets(): array
+{
+    return collect(glob(resource_path('themes/*.css')))
+        ->mapWithKeys(fn ($f) => [basename($f, '.css') => str(basename($f, '.css'))->headline()->toString()])
+        ->all();
+}
+
+function instanceThemeCss(?InstanceSettings $settings): string
+{
+    $preset = $settings?->theme_preset;
+    if (blank($preset)) {
+        return '';
+    }
+    $css = $preset === 'custom'
+        ? (string) $settings->custom_css
+        : (string) @file_get_contents(resource_path("themes/{$preset}.css"));
+
+    return str_ireplace('</style', '<\/style', $css);
+}
+
+function itermColorsToCss(string $plist): ?string
+{
+    if (! str_contains($plist, '<plist')) {
+        return null;
+    }
+    $xml = @simplexml_load_string($plist, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+    if (! $xml || ! isset($xml->dict)) {
+        return null;
+    }
+
+    $colors = [];
+    $nodes = $xml->dict->children();
+    for ($i = 0; $i < count($nodes); $i += 2) {
+        if ($nodes[$i]->getName() !== 'key' || ! isset($nodes[$i + 1]) || $nodes[$i + 1]->getName() !== 'dict') {
+            continue;
+        }
+        $c = [];
+        $inner = $nodes[$i + 1]->children();
+        for ($j = 0; $j < count($inner); $j += 2) {
+            $c[(string) $inner[$j]] = (float) $inner[$j + 1];
+        }
+        if (isset($c['Red Component'], $c['Green Component'], $c['Blue Component'])) {
+            $colors[(string) $nodes[$i]] = sprintf('#%02x%02x%02x', ...array_map(fn ($v) => (int) round(max(0, min(1, $v)) * 255), [$c['Red Component'], $c['Green Component'], $c['Blue Component']]));
+        }
+    }
+    if (! isset($colors['Background Color'], $colors['Foreground Color'])) {
+        return null;
+    }
+
+    $mix = function (string $a, string $b, float $t): string {
+        [$ar, $ag, $ab] = sscanf($a, '#%02x%02x%02x');
+        [$br, $bg, $bb] = sscanf($b, '#%02x%02x%02x');
+
+        return sprintf('#%02x%02x%02x', (int) round($ar + ($br - $ar) * $t), (int) round($ag + ($bg - $ag) * $t), (int) round($ab + ($bb - $ab) * $t));
+    };
+    $luma = function (string $hex): float {
+        [$r, $g, $b] = sscanf($hex, '#%02x%02x%02x');
+
+        return (0.2126 * $r + 0.7152 * $g + 0.0722 * $b) / 255;
+    };
+
+    $bg = $colors['Background Color'];
+    $fg = $colors['Foreground Color'];
+    $accent = $colors['Ansi 4 Color'] ?? $colors['Ansi 12 Color'] ?? $fg;
+
+    return themeCssFromPalette([
+        'app' => $mix($bg, '#000000', 0.25),
+        'panel' => $bg,
+        'surface' => $mix($bg, $fg, 0.05),
+        'raised' => $mix($bg, $fg, 0.09),
+        'selected' => $colors['Selection Color'] ?? $mix($bg, $fg, 0.16),
+        'fg' => $colors['Bold Color'] ?? $fg,
+        'fg_dim' => $fg,
+        'fg_faint' => $colors['Ansi 8 Color'] ?? $mix($fg, $bg, 0.45),
+        'accent' => $accent,
+        'accent_fg' => $luma($accent) > 0.55 ? '#000000' : '#ffffff',
+        'success' => $colors['Ansi 2 Color'] ?? '#22c55e',
+        'error' => $colors['Ansi 1 Color'] ?? '#dc2626',
+    ]);
+}
+
+function themeCssFromPalette(array $p): string
+{
+    return <<<CSS
+html.dark {
+    --theme-base-color: {$p['accent']} !important;
+    --theme-bright-color: {$p['accent']};
+    --theme-accent-foreground: {$p['accent_fg']} !important;
+    --theme-scrollbar-thumb: {$p['selected']};
+    --theme-border-color: {$p['selected']};
+    --theme-placeholder-color: {$p['fg_faint']};
+
+    --color-accent: {$p['accent']};
+    --color-accent-foreground: {$p['accent_fg']};
+    --color-coollabs: {$p['accent']};
+    --color-coollabs-100: color-mix(in oklab, {$p['accent']} 85%, white);
+    --color-coollabs-200: color-mix(in oklab, {$p['accent']} 85%, black);
+    --color-coollabs-300: color-mix(in oklab, {$p['accent']} 70%, black);
+    --color-warning: {$p['accent']};
+
+    --color-app: {$p['app']};
+    --color-panel: {$p['panel']};
+    --color-surface: {$p['surface']};
+    --color-raised: {$p['raised']};
+    --color-selected: {$p['selected']};
+    --color-coolgray-100: {$p['surface']};
+    --color-coolgray-200: {$p['raised']};
+    --color-coolgray-300: {$p['selected']};
+    --color-coolgray-400: {$p['selected']};
+    --color-coolgray-500: color-mix(in oklab, {$p['selected']} 85%, white);
+    --coollabs-canvas: {$p['app']};
+    --coollabs-elevated: {$p['surface']};
+    --coollabs-recessed: {$p['raised']};
+    --coollabs-base: {$p['surface']};
+    --color-content-surface: {$p['surface']};
+    --coollabs-fill: {$p['selected']};
+    --coollabs-line: {$p['selected']};
+    --coollabs-hairline: color-mix(in srgb, {$p['selected']} 60%, {$p['panel']});
+    --color-hairline: color-mix(in srgb, {$p['fg']} 10%, transparent);
+    --color-log: {$p['app']};
+    --color-log-toolbar: {$p['panel']};
+
+    --color-fg: {$p['fg']};
+    --color-fg-dim: {$p['fg_dim']};
+    --color-fg-faint: {$p['fg_faint']};
+    --coollabs-subtle: {$p['fg_dim']};
+    --color-nav-text: {$p['fg_dim']};
+    --color-nav-muted: {$p['fg_faint']};
+    --color-nav-active: {$p['fg']};
+
+    --color-success: {$p['success']};
+    --color-error: {$p['error']};
+}
+CSS;
+}
+
 /**
  * Resolve the queue used for application deployments, database starts and service starts.
  *

--- a/database/migrations/2026_09_07_100000_add_theme_to_instance_settings_table.php
+++ b/database/migrations/2026_09_07_100000_add_theme_to_instance_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->string('theme_preset')->nullable();
+            $table->text('custom_css')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['theme_preset', 'custom_css']);
+        });
+    }
+};

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
       - /data/coolify/services:/var/www/html/storage/app/services
       - /data/coolify/backups:/var/www/html/storage/app/backups
       - /data/coolify/images:/var/www/html/storage/app/images
+      - /data/coolify/themes:/var/www/html/storage/app/themes:ro
     environment:
       - APP_ENV=${APP_ENV:-production}
       - PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT:-256M}

--- a/resources/themes/catppuccin-mocha.css
+++ b/resources/themes/catppuccin-mocha.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #cba6f7 !important;
+    --theme-bright-color: #cba6f7;
+    --theme-accent-foreground: #11111b !important;
+    --theme-scrollbar-thumb: #45475a;
+    --theme-border-color: #45475a;
+    --theme-placeholder-color: #7f849c;
+
+    --color-accent: #cba6f7;
+    --color-accent-foreground: #11111b;
+    --color-coollabs: #cba6f7;
+    --color-coollabs-100: color-mix(in oklab, #cba6f7 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #cba6f7 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #cba6f7 70%, black);
+    --color-warning: #cba6f7;
+
+    --color-app: #11111b;
+    --color-panel: #181825;
+    --color-surface: #1e1e2e;
+    --color-raised: #313244;
+    --color-selected: #45475a;
+    --color-coolgray-100: #1e1e2e;
+    --color-coolgray-200: #313244;
+    --color-coolgray-300: #45475a;
+    --color-coolgray-400: #45475a;
+    --color-coolgray-500: color-mix(in oklab, #45475a 85%, white);
+    --coollabs-canvas: #11111b;
+    --coollabs-elevated: #1e1e2e;
+    --coollabs-recessed: #313244;
+    --coollabs-base: #1e1e2e;
+    --color-content-surface: #1e1e2e;
+    --coollabs-fill: #45475a;
+    --coollabs-line: #45475a;
+    --coollabs-hairline: color-mix(in srgb, #45475a 60%, #181825);
+    --color-hairline: color-mix(in srgb, #cdd6f4 10%, transparent);
+    --color-log: #11111b;
+    --color-log-toolbar: #181825;
+
+    --color-fg: #cdd6f4;
+    --color-fg-dim: #bac2de;
+    --color-fg-faint: #7f849c;
+    --coollabs-subtle: #bac2de;
+    --color-nav-text: #bac2de;
+    --color-nav-muted: #7f849c;
+    --color-nav-active: #cdd6f4;
+
+    --color-success: #a6e3a1;
+    --color-error: #f38ba8;
+}

--- a/resources/themes/dracula.css
+++ b/resources/themes/dracula.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #bd93f9 !important;
+    --theme-bright-color: #bd93f9;
+    --theme-accent-foreground: #191a21 !important;
+    --theme-scrollbar-thumb: #44475a;
+    --theme-border-color: #44475a;
+    --theme-placeholder-color: #6272a4;
+
+    --color-accent: #bd93f9;
+    --color-accent-foreground: #191a21;
+    --color-coollabs: #bd93f9;
+    --color-coollabs-100: color-mix(in oklab, #bd93f9 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #bd93f9 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #bd93f9 70%, black);
+    --color-warning: #bd93f9;
+
+    --color-app: #191a21;
+    --color-panel: #21222c;
+    --color-surface: #282a36;
+    --color-raised: #343746;
+    --color-selected: #44475a;
+    --color-coolgray-100: #282a36;
+    --color-coolgray-200: #343746;
+    --color-coolgray-300: #44475a;
+    --color-coolgray-400: #44475a;
+    --color-coolgray-500: color-mix(in oklab, #44475a 85%, white);
+    --coollabs-canvas: #191a21;
+    --coollabs-elevated: #282a36;
+    --coollabs-recessed: #343746;
+    --coollabs-base: #282a36;
+    --color-content-surface: #282a36;
+    --coollabs-fill: #44475a;
+    --coollabs-line: #44475a;
+    --coollabs-hairline: color-mix(in srgb, #44475a 60%, #21222c);
+    --color-hairline: color-mix(in srgb, #f8f8f2 10%, transparent);
+    --color-log: #191a21;
+    --color-log-toolbar: #21222c;
+
+    --color-fg: #f8f8f2;
+    --color-fg-dim: #d6d6d0;
+    --color-fg-faint: #6272a4;
+    --coollabs-subtle: #d6d6d0;
+    --color-nav-text: #d6d6d0;
+    --color-nav-muted: #6272a4;
+    --color-nav-active: #f8f8f2;
+
+    --color-success: #50fa7b;
+    --color-error: #ff5555;
+}

--- a/resources/themes/gruvbox-dark.css
+++ b/resources/themes/gruvbox-dark.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #fe8019 !important;
+    --theme-bright-color: #fe8019;
+    --theme-accent-foreground: #1d2021 !important;
+    --theme-scrollbar-thumb: #504945;
+    --theme-border-color: #504945;
+    --theme-placeholder-color: #928374;
+
+    --color-accent: #fe8019;
+    --color-accent-foreground: #1d2021;
+    --color-coollabs: #fe8019;
+    --color-coollabs-100: color-mix(in oklab, #fe8019 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #fe8019 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #fe8019 70%, black);
+    --color-warning: #fe8019;
+
+    --color-app: #1d2021;
+    --color-panel: #282828;
+    --color-surface: #32302f;
+    --color-raised: #3c3836;
+    --color-selected: #504945;
+    --color-coolgray-100: #32302f;
+    --color-coolgray-200: #3c3836;
+    --color-coolgray-300: #504945;
+    --color-coolgray-400: #504945;
+    --color-coolgray-500: color-mix(in oklab, #504945 85%, white);
+    --coollabs-canvas: #1d2021;
+    --coollabs-elevated: #32302f;
+    --coollabs-recessed: #3c3836;
+    --coollabs-base: #32302f;
+    --color-content-surface: #32302f;
+    --coollabs-fill: #504945;
+    --coollabs-line: #504945;
+    --coollabs-hairline: color-mix(in srgb, #504945 60%, #282828);
+    --color-hairline: color-mix(in srgb, #ebdbb2 10%, transparent);
+    --color-log: #1d2021;
+    --color-log-toolbar: #282828;
+
+    --color-fg: #ebdbb2;
+    --color-fg-dim: #d5c4a1;
+    --color-fg-faint: #928374;
+    --coollabs-subtle: #d5c4a1;
+    --color-nav-text: #d5c4a1;
+    --color-nav-muted: #928374;
+    --color-nav-active: #ebdbb2;
+
+    --color-success: #b8bb26;
+    --color-error: #fb4934;
+}

--- a/resources/themes/nord.css
+++ b/resources/themes/nord.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #88c0d0 !important;
+    --theme-bright-color: #88c0d0;
+    --theme-accent-foreground: #2e3440 !important;
+    --theme-scrollbar-thumb: #4c566a;
+    --theme-border-color: #4c566a;
+    --theme-placeholder-color: #7b88a1;
+
+    --color-accent: #88c0d0;
+    --color-accent-foreground: #2e3440;
+    --color-coollabs: #88c0d0;
+    --color-coollabs-100: color-mix(in oklab, #88c0d0 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #88c0d0 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #88c0d0 70%, black);
+    --color-warning: #88c0d0;
+
+    --color-app: #242933;
+    --color-panel: #2e3440;
+    --color-surface: #3b4252;
+    --color-raised: #434c5e;
+    --color-selected: #4c566a;
+    --color-coolgray-100: #3b4252;
+    --color-coolgray-200: #434c5e;
+    --color-coolgray-300: #4c566a;
+    --color-coolgray-400: #4c566a;
+    --color-coolgray-500: color-mix(in oklab, #4c566a 85%, white);
+    --coollabs-canvas: #242933;
+    --coollabs-elevated: #3b4252;
+    --coollabs-recessed: #434c5e;
+    --coollabs-base: #3b4252;
+    --color-content-surface: #3b4252;
+    --coollabs-fill: #4c566a;
+    --coollabs-line: #4c566a;
+    --coollabs-hairline: color-mix(in srgb, #4c566a 60%, #2e3440);
+    --color-hairline: color-mix(in srgb, #eceff4 10%, transparent);
+    --color-log: #242933;
+    --color-log-toolbar: #2e3440;
+
+    --color-fg: #eceff4;
+    --color-fg-dim: #d8dee9;
+    --color-fg-faint: #7b88a1;
+    --coollabs-subtle: #d8dee9;
+    --color-nav-text: #d8dee9;
+    --color-nav-muted: #7b88a1;
+    --color-nav-active: #eceff4;
+
+    --color-success: #a3be8c;
+    --color-error: #bf616a;
+}

--- a/resources/themes/one-dark.css
+++ b/resources/themes/one-dark.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #61afef !important;
+    --theme-bright-color: #61afef;
+    --theme-accent-foreground: #1e2227 !important;
+    --theme-scrollbar-thumb: #3e4451;
+    --theme-border-color: #3e4451;
+    --theme-placeholder-color: #5c6370;
+
+    --color-accent: #61afef;
+    --color-accent-foreground: #1e2227;
+    --color-coollabs: #61afef;
+    --color-coollabs-100: color-mix(in oklab, #61afef 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #61afef 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #61afef 70%, black);
+    --color-warning: #61afef;
+
+    --color-app: #1e2227;
+    --color-panel: #21252b;
+    --color-surface: #282c34;
+    --color-raised: #2c313a;
+    --color-selected: #3e4451;
+    --color-coolgray-100: #282c34;
+    --color-coolgray-200: #2c313a;
+    --color-coolgray-300: #3e4451;
+    --color-coolgray-400: #3e4451;
+    --color-coolgray-500: color-mix(in oklab, #3e4451 85%, white);
+    --coollabs-canvas: #1e2227;
+    --coollabs-elevated: #282c34;
+    --coollabs-recessed: #2c313a;
+    --coollabs-base: #282c34;
+    --color-content-surface: #282c34;
+    --coollabs-fill: #3e4451;
+    --coollabs-line: #3e4451;
+    --coollabs-hairline: color-mix(in srgb, #3e4451 60%, #21252b);
+    --color-hairline: color-mix(in srgb, #dcdfe4 10%, transparent);
+    --color-log: #1e2227;
+    --color-log-toolbar: #21252b;
+
+    --color-fg: #dcdfe4;
+    --color-fg-dim: #abb2bf;
+    --color-fg-faint: #5c6370;
+    --coollabs-subtle: #abb2bf;
+    --color-nav-text: #abb2bf;
+    --color-nav-muted: #5c6370;
+    --color-nav-active: #dcdfe4;
+
+    --color-success: #98c379;
+    --color-error: #e06c75;
+}

--- a/resources/themes/rose-pine.css
+++ b/resources/themes/rose-pine.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #c4a7e7 !important;
+    --theme-bright-color: #c4a7e7;
+    --theme-accent-foreground: #191724 !important;
+    --theme-scrollbar-thumb: #403d52;
+    --theme-border-color: #403d52;
+    --theme-placeholder-color: #6e6a86;
+
+    --color-accent: #c4a7e7;
+    --color-accent-foreground: #191724;
+    --color-coollabs: #c4a7e7;
+    --color-coollabs-100: color-mix(in oklab, #c4a7e7 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #c4a7e7 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #c4a7e7 70%, black);
+    --color-warning: #c4a7e7;
+
+    --color-app: #191724;
+    --color-panel: #1f1d2e;
+    --color-surface: #26233a;
+    --color-raised: #2a273f;
+    --color-selected: #403d52;
+    --color-coolgray-100: #26233a;
+    --color-coolgray-200: #2a273f;
+    --color-coolgray-300: #403d52;
+    --color-coolgray-400: #403d52;
+    --color-coolgray-500: color-mix(in oklab, #403d52 85%, white);
+    --coollabs-canvas: #191724;
+    --coollabs-elevated: #26233a;
+    --coollabs-recessed: #2a273f;
+    --coollabs-base: #26233a;
+    --color-content-surface: #26233a;
+    --coollabs-fill: #403d52;
+    --coollabs-line: #403d52;
+    --coollabs-hairline: color-mix(in srgb, #403d52 60%, #1f1d2e);
+    --color-hairline: color-mix(in srgb, #e0def4 10%, transparent);
+    --color-log: #191724;
+    --color-log-toolbar: #1f1d2e;
+
+    --color-fg: #e0def4;
+    --color-fg-dim: #908caa;
+    --color-fg-faint: #6e6a86;
+    --coollabs-subtle: #908caa;
+    --color-nav-text: #908caa;
+    --color-nav-muted: #6e6a86;
+    --color-nav-active: #e0def4;
+
+    --color-success: #9ccfd8;
+    --color-error: #eb6f92;
+}

--- a/resources/themes/solarized-dark.css
+++ b/resources/themes/solarized-dark.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #268bd2 !important;
+    --theme-bright-color: #268bd2;
+    --theme-accent-foreground: #002b36 !important;
+    --theme-scrollbar-thumb: #144956;
+    --theme-border-color: #144956;
+    --theme-placeholder-color: #657b83;
+
+    --color-accent: #268bd2;
+    --color-accent-foreground: #002b36;
+    --color-coollabs: #268bd2;
+    --color-coollabs-100: color-mix(in oklab, #268bd2 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #268bd2 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #268bd2 70%, black);
+    --color-warning: #268bd2;
+
+    --color-app: #00212b;
+    --color-panel: #002b36;
+    --color-surface: #073642;
+    --color-raised: #0b3d4a;
+    --color-selected: #144956;
+    --color-coolgray-100: #073642;
+    --color-coolgray-200: #0b3d4a;
+    --color-coolgray-300: #144956;
+    --color-coolgray-400: #144956;
+    --color-coolgray-500: color-mix(in oklab, #144956 85%, white);
+    --coollabs-canvas: #00212b;
+    --coollabs-elevated: #073642;
+    --coollabs-recessed: #0b3d4a;
+    --coollabs-base: #073642;
+    --color-content-surface: #073642;
+    --coollabs-fill: #144956;
+    --coollabs-line: #144956;
+    --coollabs-hairline: color-mix(in srgb, #144956 60%, #002b36);
+    --color-hairline: color-mix(in srgb, #eee8d5 10%, transparent);
+    --color-log: #00212b;
+    --color-log-toolbar: #002b36;
+
+    --color-fg: #eee8d5;
+    --color-fg-dim: #93a1a1;
+    --color-fg-faint: #657b83;
+    --coollabs-subtle: #93a1a1;
+    --color-nav-text: #93a1a1;
+    --color-nav-muted: #657b83;
+    --color-nav-active: #eee8d5;
+
+    --color-success: #859900;
+    --color-error: #dc322f;
+}

--- a/resources/themes/tokyo-night.css
+++ b/resources/themes/tokyo-night.css
@@ -1,0 +1,49 @@
+html.dark {
+    --theme-base-color: #7aa2f7 !important;
+    --theme-bright-color: #7aa2f7;
+    --theme-accent-foreground: #16161e !important;
+    --theme-scrollbar-thumb: #414868;
+    --theme-border-color: #414868;
+    --theme-placeholder-color: #565f89;
+
+    --color-accent: #7aa2f7;
+    --color-accent-foreground: #16161e;
+    --color-coollabs: #7aa2f7;
+    --color-coollabs-100: color-mix(in oklab, #7aa2f7 85%, white);
+    --color-coollabs-200: color-mix(in oklab, #7aa2f7 85%, black);
+    --color-coollabs-300: color-mix(in oklab, #7aa2f7 70%, black);
+    --color-warning: #7aa2f7;
+
+    --color-app: #16161e;
+    --color-panel: #1a1b26;
+    --color-surface: #1f2335;
+    --color-raised: #292e42;
+    --color-selected: #414868;
+    --color-coolgray-100: #1f2335;
+    --color-coolgray-200: #292e42;
+    --color-coolgray-300: #414868;
+    --color-coolgray-400: #414868;
+    --color-coolgray-500: color-mix(in oklab, #414868 85%, white);
+    --coollabs-canvas: #16161e;
+    --coollabs-elevated: #1f2335;
+    --coollabs-recessed: #292e42;
+    --coollabs-base: #1f2335;
+    --color-content-surface: #1f2335;
+    --coollabs-fill: #414868;
+    --coollabs-line: #414868;
+    --coollabs-hairline: color-mix(in srgb, #414868 60%, #1a1b26);
+    --color-hairline: color-mix(in srgb, #c0caf5 10%, transparent);
+    --color-log: #16161e;
+    --color-log-toolbar: #1a1b26;
+
+    --color-fg: #c0caf5;
+    --color-fg-dim: #a9b1d6;
+    --color-fg-faint: #565f89;
+    --coollabs-subtle: #a9b1d6;
+    --color-nav-text: #a9b1d6;
+    --color-nav-muted: #565f89;
+    --color-nav-active: #c0caf5;
+
+    --color-success: #9ece6a;
+    --color-error: #f7768e;
+}

--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -10,6 +10,7 @@
             ['label' => 'Email', 'route' => 'settings.email', 'icon' => 'mail'],
             ['label' => 'Authentication', 'route' => 'settings.oauth', 'icon' => 'keys'],
             ['label' => 'Scheduled Jobs', 'route' => 'settings.scheduled-jobs', 'icon' => 'calendar'],
+            ['label' => 'Theme', 'route' => 'settings.theme', 'icon' => 'eye'],
         ],
     ];
 @endphp

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -71,6 +71,12 @@
     @endenv
     <meta name="csrf-token" content="{{ csrf_token() }}">
     @vite(['resources/js/app.js', 'resources/css/app.css'])
+    @if (!isCloud() && is_file(customThemePath()) && is_readable(customThemePath()))
+        <link rel="stylesheet" href="{{ route('custom-theme.css', ['v' => substr(hash_file('sha256', customThemePath()), 0, 12)]) }}">
+    @endif
+    @if (($instanceThemeCss = instanceThemeCss($instanceSettings)) !== '')
+        <style id="instance-theme">{!! $instanceThemeCss !!}</style>
+    @endif
     <script>
         // Update theme-color meta tag (non-critical, can run async)
         const t = localStorage.theme || 'dark';

--- a/resources/views/livewire/settings/theme.blade.php
+++ b/resources/views/livewire/settings/theme.blade.php
@@ -1,0 +1,39 @@
+<div>
+    <x-slot:title>
+        Theme Settings | Coolify
+    </x-slot>
+
+    <x-settings.layout>
+        <form wire:submit="submit" class="application-settings-form flex min-w-0 flex-col gap-6">
+            <x-unsaved-bar action="submit" targets="theme_preset,custom_css" />
+
+            <x-application.settings-section title="Theme"
+                helper="Applies to everyone on this instance in Dark, System (dark) and Custom appearance. Light appearance is not affected. Saving reloads the page.">
+                <div class="flex flex-col gap-4">
+                    <div class="max-w-md">
+                        <x-forms.listbox id="theme_preset" :live="true" :options="$options" />
+                    </div>
+
+                    @if ($theme_preset === 'custom')
+                        <div class="flex flex-col gap-2">
+                            <x-forms.textarea id="custom_css" rows="16" label="Custom CSS or iTerm2 colour scheme"
+                                helper="Override the semantic variables (--color-app, --color-panel, --color-surface, --color-fg, --color-accent, …) rather than component classes. Scope rules to html.dark to leave Light appearance alone."
+                                placeholder="html.dark { --color-accent: #7aa2f7; --color-app: #16161e; }" />
+                            <p class="text-xs text-neutral-500 dark:text-neutral-400">
+                                Paste plain CSS (served as-is, no Tailwind directives), <strong>or an iTerm2 <code>.itermcolors</code> file</strong> (XML plist).
+                                iTerm2 schemes are converted to CSS when you save, so you can tweak the result afterwards.
+                            </p>
+                        </div>
+                    @endif
+
+                    <div class="flex items-center gap-3">
+                        <x-forms.button type="submit">Save</x-forms.button>
+                        @if ($theme_preset !== '' && $theme_preset !== 'custom')
+                            <span class="text-xs text-neutral-500">Tip: pick “Custom CSS…” to start from this preset — the file is in <code>resources/themes/{{ $theme_preset }}.css</code>.</span>
+                        @endif
+                    </div>
+                </div>
+            </x-application.settings-section>
+        </form>
+    </x-settings.layout>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,6 +79,7 @@ use App\Livewire\Server\TransferImport as ServerTransferImport;
 use App\Livewire\Settings\Advanced as SettingsAdvanced;
 use App\Livewire\Settings\Index as SettingsIndex;
 use App\Livewire\Settings\ScheduledJobs as SettingsScheduledJobs;
+use App\Livewire\Settings\Theme as SettingsTheme;
 use App\Livewire\Settings\Updates as SettingsUpdates;
 use App\Livewire\SettingsBackup;
 use App\Livewire\SettingsEmail;
@@ -118,6 +119,17 @@ Route::get('/verify', [Controller::class, 'verify'])->middleware('auth')->name('
 Route::get('/email/verify/{id}/{hash}', [Controller::class, 'email_verify'])->middleware(['auth'])->name('verify.verify');
 Route::get('/auth/link', [Controller::class, 'link'])->name('auth.link');
 Route::post('/auth/link', [Controller::class, 'acceptLink'])->middleware('throttle:magic-link')->name('auth.link.accept');
+
+Route::get('/custom-theme.css', function () {
+    $path = customThemePath();
+    abort_if(isCloud() || ! is_file($path) || ! is_readable($path), 404);
+
+    return response(file_get_contents($path), 200, [
+        'Content-Type' => 'text/css; charset=UTF-8',
+        'Cache-Control' => 'public, max-age=0, must-revalidate',
+        'X-Content-Type-Options' => 'nosniff',
+    ]);
+})->name('custom-theme.css');
 
 Route::get('/auth/{provider}/redirect', [OauthController::class, 'redirect'])->name('auth.redirect');
 Route::get('/auth/{provider}/callback', [OauthController::class, 'callback'])->name('auth.callback');
@@ -166,6 +178,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/settings', SettingsIndex::class)->name('settings.index');
     Route::get('/settings/advanced', SettingsAdvanced::class)->name('settings.advanced');
     Route::get('/settings/updates', SettingsUpdates::class)->name('settings.updates');
+    Route::get('/settings/theme', SettingsTheme::class)->name('settings.theme');
 
     Route::get('/settings/backup', SettingsBackup::class)->name('settings.backup');
     Route::get('/settings/email', SettingsEmail::class)->name('settings.email');

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -228,7 +228,7 @@ if [ "$WARNING_SPACE" = true ]; then
     sleep 5
 fi
 
-mkdir -p /data/coolify/{source,ssh,applications,databases,backups,services,proxy,sentinel}
+mkdir -p /data/coolify/{source,ssh,applications,databases,backups,services,proxy,sentinel,themes}
 mkdir -p /data/coolify/images
 mkdir -p /data/coolify/ssh/{keys,mux}
 mkdir -p /data/coolify/proxy/dynamic

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -174,6 +174,8 @@ mkdir -p /data/coolify/images/{avatars,project-icons}
 chown -R 9999:root /data/coolify/images
 chmod -R 700 /data/coolify/images
 
+mkdir -p /data/coolify/themes
+
 # Fix SSH directory ownership if not owned by container user UID 9999 (fixes #6621)
 # Only changes owner — preserves existing group to respect custom setups
 SSH_OWNER=$(stat -c '%u' /data/coolify/ssh 2>/dev/null || echo "unknown")

--- a/tests/Feature/CustomThemeTest.php
+++ b/tests/Feature/CustomThemeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutVite();
+    InstanceSettings::forceCreate(['id' => 0]);
+    User::factory()->create();
+    config(['constants.coolify.self_hosted' => true]);
+    File::delete(customThemePath());
+});
+
+afterEach(fn () => File::delete(customThemePath()));
+
+function writeCustomTheme(string $css): void
+{
+    File::ensureDirectoryExists(dirname(customThemePath()));
+    File::put(customThemePath(), $css);
+}
+
+test('stylesheet route returns 404 when the theme file is missing', function () {
+    $this->get('/custom-theme.css')->assertNotFound();
+});
+
+test('stylesheet route serves the theme file as css', function () {
+    writeCustomTheme('html[data-theme="custom"] { --color-accent: #123456; }');
+
+    $this->get('/custom-theme.css')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'text/css; charset=UTF-8')
+        ->assertHeader('X-Content-Type-Options', 'nosniff')
+        ->assertSee('--color-accent: #123456', escape: false);
+});
+
+test('layout links the custom stylesheet after the application css', function () {
+    writeCustomTheme('html[data-theme="custom"] { --color-accent: #123456; }');
+
+    $this->get('/login')->assertOk()->assertSee('/custom-theme.css?v=');
+
+    $layout = file_get_contents(resource_path('views/layouts/base.blade.php'));
+    expect(strpos($layout, "route('custom-theme.css'"))->toBeGreaterThan(strpos($layout, "@vite(['resources/js/app.js', 'resources/css/app.css'])"));
+});
+
+test('layout omits the custom stylesheet when the theme file is missing', function () {
+    $this->get('/login')->assertOk()->assertDontSee('/custom-theme.css');
+});
+
+test('stylesheet version changes with the file content', function () {
+    $version = fn () => str($this->get('/login')->getContent())->after('/custom-theme.css?v=')->before('"')->value();
+
+    writeCustomTheme('html { --a: 1; }');
+    $first = $version();
+
+    writeCustomTheme('html { --a: 2; }');
+
+    expect($first)->not->toBe('')->and($version())->not->toBe($first);
+});
+
+test('cloud does not expose the custom stylesheet', function () {
+    writeCustomTheme('html { --a: 1; }');
+    config(['constants.coolify.self_hosted' => false]);
+
+    $this->get('/custom-theme.css')->assertNotFound();
+    $this->get('/login')->assertOk()->assertDontSee('/custom-theme.css');
+});

--- a/tests/Feature/InstanceThemeTest.php
+++ b/tests/Feature/InstanceThemeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Livewire\Settings\Theme;
+use App\Models\InstanceSettings;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Once;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function actingAsThemeAdmin(): User
+{
+    $team = Team::forceCreate(['id' => 0, 'name' => 'Root Team', 'personal_team' => true]);
+    $user = User::factory()->create(['id' => 0, 'email' => 'root@example.com', 'email_verified_at' => now()]);
+    if (! $user->teams()->whereKey($team->id)->exists()) {
+        $user->teams()->attach($team, ['role' => 'owner']);
+    }
+    session(['currentTeam' => $team]);
+    test()->actingAs($user);
+
+    return $user;
+}
+
+beforeEach(function () {
+    $this->withoutVite();
+    config()->set('app.maintenance.driver', 'file');
+    InstanceSettings::forceCreate(['id' => 0]);
+    Once::flush();
+});
+
+test('layout emits nothing when no theme is chosen', function () {
+    actingAsThemeAdmin();
+
+    $this->withoutMiddleware(DecideWhatToDoWithUser::class)->get('/settings/theme')
+        ->assertOk()->assertDontSee('id="instance-theme"', escape: false);
+});
+
+test('layout inlines the chosen preset', function () {
+    InstanceSettings::find(0)->update(['theme_preset' => 'nord']);
+    Once::flush();
+    actingAsThemeAdmin();
+
+    $this->withoutMiddleware(DecideWhatToDoWithUser::class)->get('/settings/theme')
+        ->assertOk()->assertSee('id="instance-theme"', escape: false)->assertSee('#88c0d0', escape: false);
+});
+
+test('layout inlines custom css and neutralises a closing style tag', function () {
+    InstanceSettings::find(0)->update(['theme_preset' => 'custom', 'custom_css' => 'html.dark { --color-accent: #123456; }</style><script>alert(1)</script>']);
+    Once::flush();
+    actingAsThemeAdmin();
+
+    $html = $this->withoutMiddleware(DecideWhatToDoWithUser::class)->get('/settings/theme')->assertOk()->getContent();
+
+    expect($html)->toContain('--color-accent: #123456')
+        ->not->toContain('</style><script>alert(1)</script>');
+});
+
+test('theme settings page saves preset and custom css', function () {
+    actingAsThemeAdmin();
+
+    Livewire::test(Theme::class)
+        ->set('theme_preset', 'custom')
+        ->set('custom_css', 'html.dark { --color-app: #000; }')
+        ->call('submit')
+        ->assertHasNoErrors()
+        ->assertDispatched('reloadWindow');
+
+    expect(InstanceSettings::find(0))->theme_preset->toBe('custom')->custom_css->toBe('html.dark { --color-app: #000; }');
+
+    Livewire::test(Theme::class)->set('theme_preset', 'not-a-theme')->call('submit')->assertHasErrors('theme_preset');
+    Livewire::test(Theme::class)->set('theme_preset', '')->call('submit')->assertHasNoErrors();
+    expect(InstanceSettings::find(0)->theme_preset)->toBeNull();
+});
+
+test('theme presets are listed from resources/themes', function () {
+    expect(themePresets())->toHaveKey('catppuccin-mocha')->and(themePresets()['catppuccin-mocha'])->toBe('Catppuccin Mocha');
+});
+
+test('pasting an iTerm2 colour scheme converts it to css on save', function () {
+    $plist = file_get_contents(base_path('tests/Fixtures/iterm-theme.itermcolors'));
+
+    $css = itermColorsToCss($plist);
+    expect($css)->toContain('html.dark {')
+        ->toContain('--color-panel: #2a1f1d;')
+        ->toContain('--color-fg-dim: #e0dbb7;')
+        ->toContain('--color-accent: #5a86ad;')
+        ->toContain('--color-selected: #563c27;')
+        ->toContain('--color-error: #be2d26;');
+
+    expect(itermColorsToCss('html.dark { --x: 1 }'))->toBeNull()
+        ->and(itermColorsToCss('<plist><dict><key>Nope</key><string>x</string></dict></plist>'))->toBeNull();
+
+    actingAsThemeAdmin();
+    Livewire::test(Theme::class)
+        ->set('theme_preset', 'custom')
+        ->set('custom_css', $plist)
+        ->call('submit')
+        ->assertHasNoErrors()
+        ->assertSet('custom_css', $css);
+
+    expect(InstanceSettings::find(0)->custom_css)->toBe($css);
+});

--- a/tests/Fixtures/iterm-theme.itermcolors
+++ b/tests/Fixtures/iterm-theme.itermcolors
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Ansi 0 Color</key>
+    <dict><key>Blue Component</key><real>0.14815604686737061</real><key>Green Component</key><real>0.23939560353755951</real><key>Red Component</key><real>0.34250012040138245</real></dict>
+    <key>Ansi 1 Color</key>
+    <dict><key>Blue Component</key><real>0.15002942085266113</real><key>Green Component</key><real>0.17691341042518616</real><key>Red Component</key><real>0.74596774578094482</real></dict>
+    <key>Ansi 2 Color</key>
+    <dict><key>Blue Component</key><real>0.54230403900146484</real><key>Green Component</key><real>0.63089627027511597</real><key>Red Component</key><real>0.42121317982673645</real></dict>
+    <key>Ansi 4 Color</key>
+    <dict><key>Blue Component</key><real>0.67741340398788452</real><key>Green Component</key><real>0.52710437774658203</real><key>Red Component</key><real>0.35345837473869324</real></dict>
+    <key>Ansi 8 Color</key>
+    <dict><key>Blue Component</key><real>0.28995892405509949</real><key>Green Component</key><real>0.42290288209915161</real><key>Red Component</key><real>0.60647803544998169</real></dict>
+    <key>Background Color</key>
+    <dict><key>Blue Component</key><real>0.11481549590826035</real><key>Green Component</key><real>0.11964945495128632</real><key>Red Component</key><real>0.1651807576417923</real></dict>
+    <key>Bold Color</key>
+    <dict><key>Blue Component</key><real>0.84511500597000122</real><key>Green Component</key><real>0.97382241487503052</real><key>Red Component</key><real>0.99951791763305664</real></dict>
+    <key>Foreground Color</key>
+    <dict><key>Blue Component</key><real>0.71936088800430298</real><key>Green Component</key><real>0.85797154903411865</real><key>Red Component</key><real>0.87773138284683228</real></dict>
+    <key>Selection Color</key>
+    <dict><key>Blue Component</key><real>0.15426947176456451</real><key>Green Component</key><real>0.23570387065410614</real><key>Red Component</key><real>0.33870631456375122</real></dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Changes

Settings → Theme page for self-hosted instances. Instance admins pick one of eight bundled dark palettes or paste their own CSS. Paste an iTerm2 `.itermcolors` file instead and it's converted into a theme on save, most of us already have a terminal palette we like.

The CSS is inlined after the app stylesheet for everyone on the instance, scoped to `html.dark` so Light appearance is untouched. Only the semantic colour variables the UI already reads are overridden.

Optionally, `/data/coolify/themes/custom.css` is served at `/custom-theme.css` when it exists.

Instance admins only, pasted CSS is inlined as-is. Not hidden on Cloud yet, happy to add a guard. Migration adds two nullable columns to instance settings.

## Issues

- Related: #10655
- Supersedes #11669, closed by the quality bot (long description, code comments, commit message). All fixed here.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
<img width="1440" height="900" alt="pr-1-theme-dropdown" src="https://github.com/user-attachments/assets/866ebb23-1535-4258-8310-0871b68bcaa1" />
<img width="1440" height="900" alt="pr-4-iterm-dashboard" src="https://github.com/user-attachments/assets/88c5a148-a8f7-45c5-87c7-1ea3418352c9" />


## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Implementation, tests and the iTerm2 parser. Reviewed and tested by hand on a local instance.

## Testing

14 Pest tests (presets, iTerm2 conversion, inlining, escaping, validation, file route). Pint clean, build passes. Manually: all eight palettes, Light untouched, custom CSS, iTerm2 file, theme file added and removed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.