### PR TITLE
fix(environment-variables): resolve server-scoped shared variables in compose environment

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -4817,7 +4817,7 @@ function convertContainerMemoryBytesToMegabytes(array $metrics): array
 }
 
 /**
- * Resolve shared environment variable patterns like {{environment.VAR}}, {{project.VAR}}, {{team.VAR}}.
+ * Resolve shared environment variable patterns like {{environment.VAR}}, {{project.VAR}}, {{team.VAR}}, {{server.VAR}}.
  *
  * This is the canonical implementation used by both EnvironmentVariable::realValue and the compose parsers
  * to ensure shared variable references are replaced with their actual values.
@@ -4845,6 +4845,12 @@ function resolveSharedEnvironmentVariables(?string $value, $resource): ?string
             $id = $resource->environment->project->id;
         } elseif ($type->value() === 'team') {
             $id = $resource->team()->id;
+        } elseif ($type->value() === 'server') {
+            if (isset($resource->server) && $resource->server) {
+                $id = $resource->server->id;
+            } elseif (isset($resource->destination) && $resource->destination && isset($resource->destination->server)) {
+                $id = $resource->destination->server->id;
+            }
         }
         if (is_null($id)) {
             continue;

--- a/tests/Feature/SharedVariableComposeResolutionTest.php
+++ b/tests/Feature/SharedVariableComposeResolutionTest.php
@@ -4,7 +4,9 @@ use App\Models\Application;
 use App\Models\Environment;
 use App\Models\EnvironmentVariable;
 use App\Models\Project;
+use App\Models\Server;
 use App\Models\SharedEnvironmentVariable;
+use App\Models\StandaloneDocker;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,8 +23,13 @@ beforeEach(function () {
         'project_id' => $this->project->id,
     ]);
 
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $destination = $this->server->standaloneDockers()->firstOrFail();
+
     $this->application = Application::factory()->create([
         'environment_id' => $this->environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
     ]);
 });
 
@@ -62,6 +69,19 @@ test('resolveSharedEnvironmentVariables resolves team-scoped variable', function
 
     $resolved = resolveSharedEnvironmentVariables('{{team.GLOBAL_API_KEY}}', $this->application);
     expect($resolved)->toBe('sk-123456');
+});
+
+test('resolveSharedEnvironmentVariables resolves server-scoped variable', function () {
+    SharedEnvironmentVariable::create([
+        'key' => 'COMMON_PG_HOST',
+        'value' => 'postgres.coolify',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    $resolved = resolveSharedEnvironmentVariables('{{server.COMMON_PG_HOST}}', $this->application);
+    expect($resolved)->toBe('postgres.coolify');
 });
 
 test('resolveSharedEnvironmentVariables returns original when no match found', function () {


### PR DESCRIPTION
## Changes

Server-scoped shared variables are not resolved in Docker Compose deployments. The reference reaches the container as the literal placeholder string instead of the value, even though the environment view shows it resolved correctly.

The shared-variable resolver was extracted into a single helper in #8930, but that refactor only carried over the environment, project, and team scopes. The server branch that already existed in the EnvironmentVariable model was left out, so the server scope silently fell through and was never substituted. This change adds the missing server branch to the helper, resolving the server through the resource or its deployment destination, and adds a matching test next to the existing scope tests.

## Issues

- Fixes #8918

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — backend fix, no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code.
- How extensively: used to locate the regression and draft the fix. All changes were manually reviewed and tested.

## Testing

Added a server-scoped test to the shared-variable suite (all green, no regression). Also deployed a Compose resource referencing `{{server.VAR}}` on a local dev instance and confirmed the container received the resolved value. Pint and lint clean.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.