### PR TITLE
fix(previews): preserve HTTPS domains and redirects on redeploy

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -279,7 +279,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->application->build_pack === 'dockerimage' && str($this->dockerImagePreviewTag)->isEmpty()) {
                 $this->dockerImagePreviewTag = $this->preview?->docker_registry_image_tag;
             }
-            if ($this->preview) {
+            if ($this->preview && blank($this->preview->fqdn)) {
                 if ($this->application->build_pack === 'dockercompose') {
                     $this->preview->generate_preview_fqdn_compose();
                 } else {

--- a/app/Livewire/Project/Application/PreviewDomains.php
+++ b/app/Livewire/Project/Application/PreviewDomains.php
@@ -108,7 +108,7 @@ class PreviewDomains extends Component
                 $checkId,
                 $this->preview->application->additional_servers->count() > 0,
             );
-            $this->dispatch('success', 'Domain added. DNS check started.');
+            $this->dispatch('success', 'Domain added. DNS check started. Redeploy the preview to apply the changes.');
         } catch (\Throwable) {
             $this->domainRows[$index]['dns_status'] = 'skipped';
             $this->domainRows[$index]['dns_message'] = 'DNS check could not be started.';
@@ -145,7 +145,7 @@ class PreviewDomains extends Component
             $this->preview->generate_preview_fqdn(generateWithoutApplicationDomain: true);
         }
         $this->refreshDomains();
-        $this->dispatch('success', 'Domain generated.');
+        $this->dispatch('success', 'Domain generated. Redeploy the preview to apply the changes.');
     }
 
     public function startEdit(int $index): void
@@ -197,7 +197,7 @@ class PreviewDomains extends Component
         }
         $this->forceUseUnknownPort = false;
         $this->dispatch('close-preview-domain-edit', previewId: $this->preview->id);
-        $this->dispatch('success', 'Domain updated.');
+        $this->dispatch('success', 'Domain updated. Redeploy the preview to apply the changes.');
         $this->checkDomainDns($index);
     }
 
@@ -243,7 +243,7 @@ class PreviewDomains extends Component
         if (! $this->persistDomains()) {
             return;
         }
-        $this->dispatch('success', 'Domain removed.');
+        $this->dispatch('success', 'Domain removed. Redeploy the preview to apply the changes.');
     }
 
     public function removeDomainByKey(string $domainKey): void

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -138,7 +138,9 @@ class Previews extends Component
                         'docker_compose_domains' => $this->application->docker_compose_domains,
                     ]);
                 }
-                $found->generate_preview_fqdn_compose();
+                if (blank($found->fqdn)) {
+                    $found->generate_preview_fqdn_compose();
+                }
                 $this->application->refresh();
                 $this->syncDockerTags();
             } else {
@@ -156,7 +158,9 @@ class Previews extends Component
                     $found->docker_registry_image_tag = $docker_registry_image_tag;
                     $found->save();
                 }
-                $found->generate_preview_fqdn(generateWithoutApplicationDomain: true);
+                if (blank($found->fqdn)) {
+                    $found->generate_preview_fqdn(generateWithoutApplicationDomain: true);
+                }
                 $this->application->refresh();
                 $this->syncDockerTags();
                 $this->dispatch('update_links');

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -530,8 +530,25 @@ function isNoindexDomain(string $domain, ?Collection $noindex_domains): bool
         ->contains(ValidationPatterns::normalizeApplicationDomainUrl($domain));
 }
 
+function filterHttpDomainsWithHttpsCounterpart(Collection $domains): Collection
+{
+    $httpsRoutes = $domains->map(fn (string $domain) => parseDomainUrlParts($domain))
+        ->filter(fn (?array $parts) => ($parts['scheme'] ?? null) === 'https')
+        ->mapWithKeys(fn (array $parts) => [strtolower($parts['host']).'|'.$parts['path'] => true]);
+
+    return $domains->reject(function (string $domain) use ($httpsRoutes): bool {
+        $parts = parseDomainUrlParts($domain);
+
+        return ($parts['scheme'] ?? null) === 'http'
+            && $httpsRoutes->has(strtolower($parts['host']).'|'.$parts['path']);
+    });
+}
+
 function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, ?string $image = null, string $redirect_direction = 'both', ?string $predefinedPort = null, bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null, ?Collection $noindex_domains = null, array $domainPortOverrides = [])
 {
+    if ($is_force_https_enabled) {
+        $domains = filterHttpDomainsWithHttpsCounterpart($domains);
+    }
     $labels = collect([]);
     if ($serviceLabels) {
         $labels->push("caddy_ingress_network={$uuid}");
@@ -654,6 +671,9 @@ function dockerComposeServicePorts(?string $compose, ?string $serviceName): arra
 
 function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null, ?Collection $noindex_domains = null, bool $escape_redirect_replacement_for_compose = true, array $domainPortOverrides = [])
 {
+    if ($is_force_https_enabled) {
+        $domains = filterHttpDomainsWithHttpsCounterpart($domains);
+    }
     $labels = collect([]);
     $labels->push('traefik.enable=true');
     if ($is_gzip_enabled) {

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1257,7 +1257,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                 if ($docker_compose_domains->count() > 0) {
                     $found_fqdn = getComposeServiceDomainString($docker_compose_domains, (string) $serviceName);
                     if ($found_fqdn) {
-                        $fqdns = collect($found_fqdn);
+                        $fqdns = str($found_fqdn)->explode(',')->map(fn ($domain) => trim($domain))->filter();
                     } else {
                         $fqdns = collect([]);
                     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3867,7 +3867,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             if (count($docker_compose_domains) > 0) {
                                 $found_fqdn = getComposeServiceDomainString($docker_compose_domains, (string) $serviceName);
                                 if ($found_fqdn) {
-                                    $fqdns = collect($found_fqdn);
+                                    $fqdns = str($found_fqdn)->explode(',')->map(fn ($domain) => trim($domain))->filter();
                                 } else {
                                     $fqdns = collect([]);
                                 }

--- a/resources/views/livewire/project/application/preview-domains.blade.php
+++ b/resources/views/livewire/project/application/preview-domains.blade.php
@@ -21,6 +21,11 @@
     @if (collect($domainRows)->contains(fn ($row) => $row['dns_status'] === 'checking'))
         <div class="hidden" wire:poll.2000ms="pollDnsChecks" aria-hidden="true"></div>
     @endif
+    <x-callout type="info" title="Apply preview domains">
+        Redeploy the preview to apply domain changes and request HTTPS certificates.
+        HTTP to HTTPS redirects inherit the application setting.
+        Enable HTTP to HTTPS redirect in the application's Domains settings to redirect HTTP visitors.
+    </x-callout>
     <div class="flex flex-wrap items-center gap-2">
         <p class="min-w-0 flex-1 truncate text-[13px] text-neutral-500 dark:text-fg-dim">
             {{ count($domainRows) }} domain{{ count($domainRows) === 1 ? '' : 's' }}

--- a/tests/Feature/PreviewDomainPortOverridesTest.php
+++ b/tests/Feature/PreviewDomainPortOverridesTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Jobs\ApplicationDeploymentJob;
 use App\Livewire\Project\Application\PreviewDomains;
+use App\Livewire\Project\Application\Previews;
 use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
 use App\Models\ApplicationPreview;
 use App\Models\Environment;
 use App\Models\InstanceSettings;
@@ -12,6 +15,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
@@ -975,3 +979,108 @@ it('preserves readonly compose preview redirects when saving an address', functi
         'api' => ['domain' => '', 'redirect' => 'www'],
     ]);
 });
+
+it('keeps saved HTTPS preview routing when a deployment starts', function (int $parsingVersion, bool $forceHttps, bool $keepHttpDomain) {
+    $compose = $parsingVersion > 0;
+    $this->application->update([
+        'fqdn' => 'http://app.example.com',
+        'build_pack' => $compose ? 'dockercompose' : 'nixpacks',
+        'compose_parsing_version' => (string) $parsingVersion,
+        'docker_compose_raw' => "services:\n  web:\n    image: nginx:alpine\n    expose: [3000]\n",
+        'docker_compose_domains' => json_encode(['web' => ['domain' => 'http://app.example.com']]),
+    ]);
+    $this->application->settings()->update(['is_force_https_enabled' => $forceHttps]);
+    $domain = 'https://17.app.example.com';
+    $domains = $keepHttpDomain ? 'http://17.app.example.com,'.$domain : $domain;
+    $preview = createPreviewForPortTests($this->application, 17, [
+        'fqdn' => $domains,
+        'domain_port_overrides' => [$domain => 8080],
+        'docker_compose_domains' => $compose ? json_encode(['web' => ['domain' => $domains]]) : null,
+    ]);
+    $deployment = ApplicationDeploymentQueue::create([
+        'application_id' => $this->application->id,
+        'deployment_uuid' => (string) Str::uuid(),
+        'server_id' => $this->server->id,
+        'destination_id' => $this->destination->id,
+        'pull_request_id' => 17,
+        'commit' => 'HEAD',
+    ]);
+
+    new ApplicationDeploymentJob($deployment->id);
+
+    $preview->refresh();
+    expect($preview->fqdn)->toBe($domains)
+        ->and($preview->domain_port_overrides)->toBe([$domain => 8080]);
+
+    $labels = $compose
+        ? collect(data_get($this->application->fresh()->parse(17, $preview->id), 'services.web-pr-17.labels'))->implode("\n")
+        : implode("\n", generateLabelsApplication($this->application->fresh(), $preview));
+
+    expect($labels)->toContain('tls.certresolver=letsencrypt')
+        ->toContain('loadbalancer.server.port=8080')
+        ->toContain('Host(`17.app.example.com`)')
+        ->and((bool) preg_match('/\.middlewares=[^\n]*redirect-to-https/', $labels))->toBe($forceHttps);
+
+    if ($forceHttps) {
+        preg_match_all('/traefik\.http\.routers\.([^=\n]+)\.entryPoints=http$/m', $labels, $httpRouters);
+        foreach ($httpRouters[1] as $router) {
+            expect($labels)->toMatch('/traefik\.http\.routers\.'.preg_quote($router, '/').'\.middlewares=[^\n]*redirect-to-https/');
+        }
+    }
+})->with([0, 2, 3])->with([false, true])->with([false, true]);
+
+it('explains preview domain activation and the inherited redirect policy', function () {
+    $preview = createPreviewForPortTests($this->application, 150, ['fqdn' => 'https://preview.example.com']);
+
+    Livewire::test(PreviewDomains::class, ['preview' => $preview])
+        ->assertSee('Redeploy the preview to apply domain changes and request HTTPS certificates.')
+        ->assertSee('HTTP to HTTPS redirects inherit the application setting.');
+});
+
+it('keeps saved preview domains when configuring an existing pull request', function (bool $compose) {
+    $domain = 'https://custom-preview.example.com';
+    $this->application->update([
+        'fqdn' => 'http://app.example.com',
+        'build_pack' => $compose ? 'dockercompose' : 'nixpacks',
+        'docker_compose_domains' => json_encode(['web' => ['domain' => 'http://app.example.com']]),
+    ]);
+    $preview = createPreviewForPortTests($this->application, 151, [
+        'fqdn' => $domain,
+        'domain_port_overrides' => [$domain => 8080],
+        'docker_compose_domains' => $compose ? json_encode(['web' => ['domain' => $domain]]) : null,
+    ]);
+
+    URL::defaults([
+        'project_uuid' => $this->project->uuid,
+        'environment_uuid' => $this->environment->uuid,
+        'application_uuid' => $this->application->uuid,
+    ]);
+
+    Livewire::test(Previews::class, ['application' => $this->application])
+        ->call('add', 151)
+        ->assertHasNoErrors();
+
+    expect($preview->fresh()->fqdn)->toBe($domain)
+        ->and($preview->fresh()->domain_port_overrides)->toBe([$domain => 8080]);
+})->with([false, true]);
+
+it('still generates domains when a preview deployment has none', function (bool $compose) {
+    $this->application->update([
+        'fqdn' => 'https://app.example.com',
+        'build_pack' => $compose ? 'dockercompose' : 'nixpacks',
+        'docker_compose_domains' => json_encode(['web' => ['domain' => 'https://app.example.com']]),
+    ]);
+    $preview = createPreviewForPortTests($this->application, 152);
+    $deployment = ApplicationDeploymentQueue::create([
+        'application_id' => $this->application->id,
+        'deployment_uuid' => (string) Str::uuid(),
+        'server_id' => $this->server->id,
+        'destination_id' => $this->destination->id,
+        'pull_request_id' => 152,
+        'commit' => 'HEAD',
+    ]);
+
+    new ApplicationDeploymentJob($deployment->id);
+
+    expect($preview->fresh()->fqdn)->toBe('https://152.app.example.com');
+})->with([false, true]);

--- a/tests/Unit/FqdnLabelsNoindexTest.php
+++ b/tests/Unit/FqdnLabelsNoindexTest.php
@@ -284,3 +284,27 @@ test('fqdnLabelsForCaddy keeps routing a legacy port-bearing FQDN without an ove
         ->toContain('caddy_0=https://legacy.example.com')
         ->toContain('caddy_0.handle_path.0_reverse_proxy={{upstreams 9090}}');
 });
+
+test('forced HTTPS does not leave a competing explicit HTTP route', function (bool $forceHttps) {
+    $domains = ['http://example.com:3000/api', 'https://example.com:8080/api', 'http://example.com/other', 'http://other.example.com/api'];
+    $traefik = traefikLabels($domains, forceHttps: $forceHttps);
+    $caddy = caddyLabels($domains, forceHttps: $forceHttps);
+
+    expect($traefik)->toContain('traefik.http.routers.https-1-testuuid.tls.certresolver=letsencrypt')
+        ->toContain('traefik.http.services.https-1-testuuid.loadbalancer.server.port=8080')
+        ->toContain('traefik.http.routers.http-2-testuuid.rule=Host(`example.com`) && PathPrefix(`/other`)')
+        ->toContain('traefik.http.routers.http-3-testuuid.rule=Host(`other.example.com`) && PathPrefix(`/api`)')
+        ->and($caddy)->toContain('caddy_2=http://example.com')
+        ->toContain('caddy_3=http://other.example.com');
+
+    if ($forceHttps) {
+        expect($traefik)->not->toContain('traefik.http.routers.http-0-testuuid.entryPoints=http')
+            ->toContain('traefik.http.routers.http-1-testuuid.middlewares=redirect-to-https')
+            ->and($caddy)->not->toContain('caddy_0=http://example.com')
+            ->toContain('caddy_1=https://example.com');
+    } else {
+        expect($traefik)->toContain('traefik.http.routers.http-0-testuuid.entryPoints=http')
+            ->and($caddy)->toContain('caddy_0=http://example.com')
+            ->toContain('caddy_1=http://example.com, https://example.com');
+    }
+})->with([false, true]);


### PR DESCRIPTION
## Changes

I found a few issues that are closely related.
- Redeploying a `Preview Deployment` resets all custom domains, leaving only the default http `{pr-id}.subdomain...`
- Adding a `https` subdomain to a `Preview Deployment` doesn't generate a TLS certificate `net::ERR_CERT_AUTHORITY_INVALID`
- Visiting the https link, it gives `no available server`, implying a reverse-proxy/routing issue

I believe this PR a valid even though I used Codex `gpt-6-astra-medium` to investigate root cause and fix the issues.

## Issues

Fixes #6536. Related: #9399, #7915. Overlaps #11653 on non-Compose preservation; this patch also handles both Compose parsers and competing HTTP routes. Maintainer coordination is needed.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Manual deployment validation pending.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

Tools used: OpenAI Codex for investigation, implementation, tests and review.

New Compose services need explicit preview domains. Removing every domain can still regenerate defaults.

## Testing

124 targeted tests passed initially. Strengthened regression: 12 cases, 186 assertions passed for regular previews and both Compose parsers:

1. Domains and ports survive two deployment initializations.
2. The HTTPS router retains TLS and the Let’s Encrypt resolver.
3. That router matches the preview hostname and binds to its service on port 8080, addressing the missing-route fallback 503.

HTTP+HTTPS and redirect on/off are covered. Pint and Blade compilation passed. Live deployment/certificate issuance remains unverified. Backend health and ACME failures can independently cause these symptoms.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.


