### PR TITLE
fix(proxy): create proxy networks with IPv6 enabled

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify').' 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1726,7 +1726,7 @@ $siteAddress {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify').' 2>&1 || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -54,7 +54,7 @@ class StandaloneDocker extends BaseModel
     {
         $safeNetwork = escapeshellarg($this->network);
 
-        return "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --attachable {$safeNetwork} >/dev/null";
+        return "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($this->network);
     }
 
     public function setNetworkAttribute(string $value): void

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -191,6 +191,17 @@ function format_docker_envs_to_json($rawOutput)
         return collect([]);
     }
 }
+/**
+ * Create an attachable bridge network with IPv6 enabled, so the proxy receives real IPv6 client addresses
+ * instead of the docker-proxy gateway IP. Falls back to IPv4-only when the daemon cannot allocate an IPv6 subnet.
+ */
+function dockerNetworkCreateCommand(string $network): string
+{
+    $safe = escapeshellarg($network);
+
+    return "docker network create --attachable --ipv6 {$safe} >/dev/null 2>&1 || docker network create --attachable {$safe} >/dev/null";
+}
+
 function checkMinimumDockerEngineVersion($dockerVersion)
 {
     $majorDockerVersion = (int) str($dockerVersion)->before('.')->value();

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -160,7 +160,7 @@ function ensureProxyNetworksExist(Server $server)
 
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+it('creates proxy networks with IPv6 enabled and falls back to IPv4 only', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)
+        ->toBe("docker network create --attachable --ipv6 'coolify' >/dev/null 2>&1 || docker network create --attachable 'coolify' >/dev/null");
+});
+
+it('escapes the network name in both create attempts', function () {
+    $command = dockerNetworkCreateCommand('net;rm -rf /');
+
+    expect($command)
+        ->toContain("--ipv6 'net;rm -rf /'")
+        ->toContain("--attachable 'net;rm -rf /' >/dev/null")
+        ->not->toContain('--attachable net;');
+});


### PR DESCRIPTION
## Changes

The standalone proxy network is created IPv4-only, so Docker routes IPv6 clients through the userland docker-proxy and Traefik/Caddy see the docker gateway address in X-Forwarded-For instead of the real client IP. That is the "random" wrong IP in #3436: it is every IPv6 visitor.

New helper `dockerNetworkCreateCommand()` creates the network with `--ipv6`, falling back to the previous IPv4-only command when the daemon cannot allocate an IPv6 subnet. Used everywhere a standalone proxy or destination network is created. App and service compose networks and swarm overlays are left alone, per the maintainer note in the issue.

Existing installs are not migrated; recreating the network stays manual.

## Issues

- Fixes #3436

/claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

The helper command on Docker 29 (network created with an IPv6 subnet, container gets a global address), then the IPv4-only fallback on Docker 24.

![IPv6 proxy network demo](https://raw.githubusercontent.com/badnikhil/coolify/pr-assets/demo-ipv6.gif)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: helped trace the network creation code paths; the change and description were reviewed by hand.

## Testing

- Unit test + Pint pass locally.
- Docker 29.6.1: the helper command creates the network with EnableIPv6 true and an auto-allocated ULA /64; an attached container gets a global fd.. address.
- Docker 24.0.9: --ipv6 fails (no address pool), the fallback runs, network is IPv4-only as before.
Outside this setup: an end-to-end IPv6 request through Traefik needs a public dual-stack host. The change itself is the network creation command, verified on both daemon versions above.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.






