### PR TITLE
feat(deployments): add team-wide deployments page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -24,7 +24,7 @@ class Index extends Component
 
     public string $status = 'all';
 
-    public int $perPage = 25;
+    public int $perPage = 10;
 
     public function updated(string $property): void
     {

--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public string $project = 'all';
+
+    public string $server = 'all';
+
+    public string $source = 'all';
+
+    public string $status = 'all';
+
+    public int $perPage = 25;
+
+    public function updated(string $property): void
+    {
+        if (in_array($property, ['project', 'server', 'source', 'status', 'perPage'], true)) {
+            $this->perPage = max(10, min(100, $this->perPage));
+            $this->resetPage();
+        }
+    }
+
+    public function render(): View
+    {
+        $serverIds = Server::ownedByCurrentTeamCached()->pluck('id');
+        $base = ApplicationDeploymentQueue::query()->whereIn('server_id', $serverIds);
+
+        $projects = Project::ownedByCurrentTeam()->orderBy('name')->get(['id', 'name']);
+        $servers = Server::ownedByCurrentTeamCached()->sortBy('name')->values();
+        $sources = (clone $base)->whereNotNull('git_type')->distinct()->orderBy('git_type')->pluck('git_type');
+        $statuses = collect(ApplicationDeploymentStatus::cases())->pluck('value');
+
+        $deployments = (clone $base)
+            ->with(['application.environment.project'])
+            ->when($this->project !== 'all', fn (Builder $q) => $q->whereHas('application.environment', fn (Builder $e) => $e->where('project_id', $this->project)))
+            ->when($this->server !== 'all', fn (Builder $q) => $q->where('server_id', $this->server))
+            ->when($this->source !== 'all', fn (Builder $q) => $q->where('git_type', $this->source))
+            ->when($this->status !== 'all', fn (Builder $q) => $q->where('status', $this->status))
+            ->orderByDesc('id')
+            ->paginate($this->perPage);
+
+        $options = fn ($items, string $all) => [
+            ['value' => 'all', 'label' => $all],
+            ...$items->all(),
+        ];
+
+        return view('livewire.deployments.index', [
+            'deployments' => $deployments,
+            'projectOptions' => $projects->count() > 1 ? $options($projects->map(fn ($p) => ['value' => (string) $p->id, 'label' => $p->name]), 'All projects') : null,
+            'serverOptions' => $servers->count() > 1 ? $options($servers->map(fn ($s) => ['value' => (string) $s->id, 'label' => $s->name]), 'All servers') : null,
+            'sourceOptions' => $sources->count() > 1 ? $options($sources->map(fn ($s) => ['value' => $s, 'label' => Str::headline($s)]), 'All sources') : null,
+            'statusOptions' => $options($statuses->map(fn ($s) => ['value' => $s, 'label' => Str::headline($s)]), 'All statuses'),
+        ]);
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -95,6 +95,14 @@
                     <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Analytics</span>
                 </a>
             </li>
+            <li>
+                <a title="Deployments" {{ wireNavigate() }}
+                    class="{{ request()->is('deployments*') ? 'menu-item-active menu-item' : 'menu-item' }}"
+                    :class="collapsed && 'lg:justify-center lg:px-0'" href="{{ route('deployments.index') }}">
+                    <x-reicon name="upload" class="menu-item-icon" />
+                    <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                </a>
+            </li>
             @can('canAccessTerminal')
                 <li>
                     <a title="Terminal"

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,132 @@
+@php
+    $deploymentStatusMeta = function (string $status): array {
+        $label = match ($status) {
+            'finished' => 'Success',
+            'in_progress' => 'In progress',
+            'cancelled-by-user' => 'Cancelled',
+            'queued' => 'Queued',
+            'failed' => 'Failed',
+            default => str($status)->headline()->toString(),
+        };
+
+        $type = match ($status) {
+            'finished' => 'success',
+            'in_progress', 'queued' => 'warning',
+            'failed' => 'error',
+            default => 'neutral',
+        };
+
+        return [$label, $type];
+    };
+@endphp
+
+<div class="application-settings-form w-full" wire:poll.5000ms>
+    <x-slot:title>
+        Deployments | Coolify
+    </x-slot>
+
+    <header class="mb-5">
+        <h1 class="truncate text-[24px]! leading-7! font-semibold! tracking-tight!">Deployments</h1>
+        <p class="mt-1 text-[13px] text-neutral-500 dark:text-fg-dim">
+            Every deployment across the current team, newest first.
+        </p>
+    </header>
+
+    <div
+        class="overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.025]">
+        <div
+            class="grid grid-cols-2 gap-2 border-b border-neutral-200 p-3 sm:flex sm:items-center dark:border-white/[0.08]">
+            @if ($projectOptions)
+                <div class="sm:w-44">
+                    <x-forms.listbox id="project" live :options="$projectOptions" />
+                </div>
+            @endif
+            @if ($serverOptions)
+                <div class="sm:w-44">
+                    <x-forms.listbox id="server" live :options="$serverOptions" />
+                </div>
+            @endif
+            @if ($sourceOptions)
+                <div class="sm:w-40">
+                    <x-forms.listbox id="source" live :options="$sourceOptions" />
+                </div>
+            @endif
+            <div class="sm:w-40">
+                <x-forms.listbox id="status" live :options="$statusOptions" />
+            </div>
+        </div>
+
+        @if ($deployments->isNotEmpty())
+            <div class="transition-opacity" wire:loading.class="opacity-50 pointer-events-none"
+                wire:target="project,server,source,status,setPage,previousPage,nextPage">
+                <div
+                    class="dashboard-deployment-table-grid hidden items-center gap-4 border-b border-neutral-200 bg-neutral-50 px-4 py-2.5 text-[11px] font-medium text-neutral-500 md:grid dark:border-white/[0.08] dark:bg-white/[0.025] dark:text-fg-faint">
+                    <span>Application</span>
+                    <span>Environment</span>
+                    <span>Server</span>
+                    <span>Status</span>
+                    <span>Started</span>
+                </div>
+
+                @foreach ($deployments as $deployment)
+                    @php
+                        [$deploymentStatus, $deploymentStatusType] = $deploymentStatusMeta($deployment->status);
+                        $projectName = $deployment->application?->environment?->project?->name;
+                        $environmentName = $deployment->application?->environment?->name;
+                        $environmentPath = collect([$projectName, $environmentName])->filter()->join(' / ');
+                    @endphp
+
+                    <a wire:key="deployment-{{ $deployment->deployment_uuid }}" href="{{ $deployment->deployment_url }}"
+                        {{ wireNavigate() }}
+                        class="dashboard-deployment-table-grid group block border-b border-neutral-200 px-4 py-3 transition-colors last:border-b-0 hover:bg-neutral-50 focus-visible:z-10 focus-visible:bg-warning/10 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-warning focus-visible:ring-offset-0 md:grid md:items-center md:gap-4 dark:border-white/[0.08] dark:hover:bg-white/[0.025] dark:focus-visible:bg-warning/10">
+                        <div class="min-w-0">
+                            <p class="truncate text-[13px] font-semibold text-black dark:text-fg">
+                                {{ $deployment->application_name }}
+                            </p>
+                            @if ($deployment->pull_request_id)
+                                <p class="mt-0.5 text-[11px] text-neutral-500 dark:text-fg-faint">
+                                    Pull request #{{ $deployment->pull_request_id }}
+                                </p>
+                            @endif
+                        </div>
+
+                        <p class="hidden truncate text-[12px] text-neutral-500 md:block dark:text-fg-dim">
+                            {{ $environmentPath ?: '-' }}
+                        </p>
+                        <p class="hidden truncate text-[12px] text-neutral-500 md:block dark:text-fg-dim">
+                            {{ $deployment->server_name ?: '-' }}
+                        </p>
+                        <span class="hidden md:block">
+                            <x-status-badge :status="$deploymentStatus" :type="$deploymentStatusType" />
+                        </span>
+                        <p class="hidden truncate text-[12px] text-neutral-500 md:block dark:text-fg-dim"
+                            title="{{ $deployment->created_at?->toDayDateTimeString() }}">
+                            {{ $deployment->created_at?->diffForHumans() ?? '-' }}
+                        </p>
+
+                        <div class="mt-3 flex min-w-0 items-center gap-3 md:hidden">
+                            <x-status-badge :status="$deploymentStatus" :type="$deploymentStatusType" />
+                            <p class="min-w-0 truncate text-[11px] text-neutral-500 dark:text-fg-faint">
+                                {{ $environmentPath ?: '-' }}
+                                <span class="px-1 text-neutral-300 dark:text-white/15">·</span>
+                                {{ $deployment->server_name ?: '-' }}
+                            </p>
+                        </div>
+                    </a>
+                @endforeach
+            </div>
+
+            <x-table-pagination :from="$deployments->firstItem() ?? 0" :to="$deployments->lastItem() ?? 0"
+                :total="$deployments->total()" :current-page="$deployments->currentPage()"
+                :last-page="$deployments->lastPage()" wire-target="setPage,previousPage,nextPage"
+                previous-action="previousPage" next-action="nextPage">
+                <x-slot:pageSize>
+                    <x-page-size-select model="perPage" livewire storage-key="coolify.page-size.deployments" />
+                </x-slot:pageSize>
+            </x-table-pagination>
+        @else
+            <x-empty title="No deployments found"
+                description="Deployments of this team's applications will appear here." icon-name="time-back" size="sm" />
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Analytics;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Resources as DestinationResources;
 use App\Livewire\Destination\Show as DestinationShow;
@@ -161,6 +162,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/', Dashboard::class)->name('dashboard');
     Route::get('/analytics', Analytics::class)->name('analytics');
     Route::get('/admin', AdminIndex::class)->name('admin.index');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 
     Route::get('/subscription', SubscriptionShow::class)->name('subscription.show');

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -15,9 +15,8 @@ use Visus\Cuid2\Cuid2;
 
 uses(RefreshDatabase::class);
 
-function makeDeploymentForTeam(Team $team, string $applicationName): ApplicationDeploymentQueue
+function makeDeploymentForTeam(Team $team, string $applicationName, PrivateKey $privateKey): ApplicationDeploymentQueue
 {
-    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
     $server = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
     $destination = StandaloneDocker::where('server_id', $server->id)->first()
         ?? StandaloneDocker::factory()->create(['server_id' => $server->id, 'network' => 'net-'.$server->id]);
@@ -46,6 +45,9 @@ beforeEach(function () {
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
     $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    // One key for every server: PrivateKey rejects a second row with the same fingerprint.
+    $this->privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    $this->withoutVite();
     $this->actingAs($this->user);
     session(['currentTeam' => $this->team]);
     InstanceSettings::unguarded(function () {
@@ -54,8 +56,8 @@ beforeEach(function () {
 });
 
 it('lists only the current team deployments', function () {
-    makeDeploymentForTeam($this->team, 'mine-app');
-    makeDeploymentForTeam(Team::factory()->create(), 'theirs-app');
+    makeDeploymentForTeam($this->team, 'mine-app', $this->privateKey);
+    makeDeploymentForTeam(Team::factory()->create(), 'theirs-app', $this->privateKey);
 
     $this->get('/deployments')
         ->assertOk()

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Visus\Cuid2\Cuid2;
+
+uses(RefreshDatabase::class);
+
+function makeDeploymentForTeam(Team $team, string $applicationName): ApplicationDeploymentQueue
+{
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $server = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->first()
+        ?? StandaloneDocker::factory()->create(['server_id' => $server->id, 'network' => 'net-'.$server->id]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create([
+        'name' => $applicationName,
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+    ]);
+
+    return ApplicationDeploymentQueue::create([
+        'application_id' => $application->id,
+        'application_name' => $applicationName,
+        'deployment_uuid' => (string) new Cuid2,
+        'deployment_url' => '/deployments',
+        'server_id' => $server->id,
+        'server_name' => $server->name,
+        'status' => 'finished',
+        'git_type' => 'github',
+    ]);
+}
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::updateOrCreate(['id' => 0], []);
+    });
+});
+
+it('lists only the current team deployments', function () {
+    makeDeploymentForTeam($this->team, 'mine-app');
+    makeDeploymentForTeam(Team::factory()->create(), 'theirs-app');
+
+    $this->get('/deployments')
+        ->assertOk()
+        ->assertSee('mine-app')
+        ->assertDontSee('theirs-app');
+});


### PR DESCRIPTION
## Changes

- New `/deployments` page that lists every deployment queue entry for the current team, newest first, with pagination.
- Filters on top for project, server, source (git provider) and status. A filter is hidden when it has only one option, as requested in the issue.
- The list refreshes every 5 seconds via `wire:poll`, so running and queued deployments update in place.
- "Deployments" entry in the sidebar (Main section, next to Terminal).
- Row markup reuses the dashboard deployment table.
- One feature test: the page renders and only shows deployments of the current team's servers.

No new dependencies.

## Issues

- Fixes #7596

/claim  #7596 

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Sidebar entry, then the status, project and source filters narrowing the list. The server filter is hidden (single server).

![Deployments demo](https://raw.githubusercontent.com/badnikhil/coolify/pr-assets/demo-deployments.gif)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: first draft of the component, view and test; I reviewed and adjusted it by hand against the existing dashboard and audit-log pages.

## Testing

- `tests/Feature/DeploymentsPageTest.php` and Pint pass locally.
- Dev instance on this branch with a few queue rows of mixed status/source: `/deployments` renders, source/status filters narrow the list, the server filter is hidden with a single server (see Preview).
Outside this setup: watching a real build move through the statuses needs a build server. The refresh path itself is exercised, the page repolls every 5s against the seeded rows.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.



