### PR TITLE
feat(ui): add Container Info page with network connect/disconnect

### DIFF
--- a/app/Livewire/Project/Shared/ContainerInfo.php
+++ b/app/Livewire/Project/Shared/ContainerInfo.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Service;
+use Carbon\Carbon;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ContainerInfo extends Component
+{
+    use AuthorizesRequests;
+
+    public $resource;
+
+    public array $containers = [];
+
+    public array $availableNetworks = [];
+
+    public array $selectedNetwork = [];
+
+    public bool $loaded = false;
+
+    public function mount()
+    {
+        $this->authorize('view', $this->resource);
+    }
+
+    private function server()
+    {
+        return $this->resource instanceof Service
+            ? $this->resource->server
+            : $this->resource->destination->server;
+    }
+
+    public function load(): void
+    {
+        try {
+            $server = $this->server();
+            if (! $server->isFunctional() || $server->isSwarm()) {
+                return;
+            }
+
+            $names = match (true) {
+                $this->resource instanceof Application => getCurrentApplicationContainerStatus($server, $this->resource->id, includePullrequests: true),
+                $this->resource instanceof Service => getCurrentServiceContainerStatus($server, $this->resource->id),
+                default => getCurrentDatabaseContainerStatus($server, $this->resource->id),
+            };
+            $names = $names->pluck('Names')->filter()->sort()->values();
+
+            $this->containers = [];
+            if ($names->isNotEmpty()) {
+                $inspect = instant_remote_process(
+                    ["docker container inspect --format '{{json .}}' ".$names->map(fn ($name) => escapeshellarg($name))->implode(' ')],
+                    $server,
+                    false
+                );
+                $this->containers = format_docker_command_output_to_json($inspect)
+                    ->map(fn ($container) => $this->summarize($container))
+                    ->values()
+                    ->all();
+            }
+
+            $networks = instant_remote_process(["docker network ls --format '{{.Name}}'"], $server, false);
+            $this->availableNetworks = str($networks ?? '')->explode("\n")
+                ->map(fn ($name) => trim($name))
+                ->filter()
+                ->reject(fn ($name) => in_array($name, ['bridge', 'host', 'none']))
+                ->sort()
+                ->values()
+                ->all();
+            foreach ($this->containers as $container) {
+                $others = array_values(array_diff($this->availableNetworks, $container['network_names']));
+                $this->selectedNetwork[$container['name']] = $others[0] ?? '';
+            }
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        } finally {
+            $this->loaded = true;
+        }
+    }
+
+    private function summarize(array $container): array
+    {
+        $networks = collect(data_get($container, 'NetworkSettings.Networks', []))
+            ->map(fn ($network, $name) => [
+                'name' => $name,
+                'ipv4' => data_get($network, 'IPAddress') ?: null,
+                'ipv6' => data_get($network, 'GlobalIPv6Address') ?: null,
+                'gateway' => data_get($network, 'Gateway') ?: null,
+                'mac' => data_get($network, 'MacAddress') ?: null,
+                'aliases' => collect(data_get($network, 'Aliases', []))->implode(', '),
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'id' => data_get($container, 'Id'),
+            'short_id' => substr((string) data_get($container, 'Id'), 0, 12),
+            'name' => ltrim((string) data_get($container, 'Name'), '/'),
+            'image' => data_get($container, 'Config.Image'),
+            'image_id' => data_get($container, 'Image'),
+            'status' => data_get($container, 'State.Status'),
+            'restart_count' => data_get($container, 'RestartCount', 0),
+            'created' => $this->formatTime(data_get($container, 'Created')),
+            'started' => $this->formatTime(data_get($container, 'State.StartedAt')),
+            'networks' => $networks,
+            'network_names' => array_column($networks, 'name'),
+        ];
+    }
+
+    private function formatTime(?string $time): ?string
+    {
+        if (blank($time) || str_starts_with($time, '0001-')) {
+            return null;
+        }
+
+        return Carbon::parse($time)->toDateTimeString().' UTC';
+    }
+
+    public function connect(string $container): void
+    {
+        $this->changeNetwork('connect', $container, (string) ($this->selectedNetwork[$container] ?? ''));
+    }
+
+    public function disconnect(string $container, string $network): void
+    {
+        $this->changeNetwork('disconnect', $container, $network);
+    }
+
+    private function changeNetwork(string $action, string $container, string $network): void
+    {
+        try {
+            $this->authorize('update', $this->resource);
+            $known = collect($this->containers)->firstWhere('name', $container);
+            if (! $known || $network === '') {
+                throw new \RuntimeException('Unknown container or network.');
+            }
+            if ($action === 'disconnect' && count($known['network_names']) <= 1) {
+                throw new \RuntimeException('A container must stay connected to at least one network.');
+            }
+            instant_remote_process(
+                ["docker network {$action} ".escapeshellarg($network).' '.escapeshellarg($container)],
+                $this->server()
+            );
+            $this->dispatch('success', ucfirst($action).'ed '.$container.($action === 'connect' ? ' to ' : ' from ')."{$network}.", 'This is a runtime change: a redeploy recreates the container with its configured networks.');
+            $this->load();
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.container-info');
+    }
+}

--- a/resources/views/components/application/configuration-sidebar.blade.php
+++ b/resources/views/components/application/configuration-sidebar.blade.php
@@ -116,6 +116,11 @@
                 'active' => $currentRoute === 'project.application.metrics',
             ],
             [
+                'label' => 'Container Info',
+                'route' => 'project.application.container-info',
+                'active' => $currentRoute === 'project.application.container-info',
+            ],
+            [
                 'label' => 'Tags',
                 'route' => 'project.application.tags',
                 'active' => $currentRoute === 'project.application.tags',
@@ -154,6 +159,7 @@
             'Resource Limits' => 'cpu',
             'Resource Operations' => 'server-update',
             'Metrics' => 'graph',
+            'Container Info' => 'info-circle',
             'Tags' => 'tags',
             'Danger Zone' => 'shield-alert',
         ];
@@ -161,7 +167,7 @@
         // Discord-style groups for the settings sidebar
         $menuGroups = [
             'Settings' => ['General', 'Domains', 'Environment Variables', 'Persistent Storage', 'Advanced', 'Swarm', 'Healthcheck'],
-            'Observe & troubleshoot' => ['Runtime Logs', 'Deployment Logs', 'Terminal', 'Metrics'],
+            'Observe & troubleshoot' => ['Runtime Logs', 'Deployment Logs', 'Terminal', 'Metrics', 'Container Info'],
             'Deploy' => ['Git Source', 'Servers', 'Preview Deployments'],
             'Automation' => ['Scheduled Tasks', 'Webhooks', 'Backups'],
             'Operations' => ['Resource Operations', 'Resource Limits', 'Rollback', 'Tags', 'Danger Zone'],

--- a/resources/views/components/database/configuration-sidebar.blade.php
+++ b/resources/views/components/database/configuration-sidebar.blade.php
@@ -21,6 +21,7 @@
         ['label' => 'Resource Limits', 'route' => 'project.database.resource-limits', 'icon' => 'cpu'],
         ['label' => 'Resource Operations', 'route' => 'project.database.resource-operations', 'icon' => 'server-update'],
         ['label' => 'Metrics', 'route' => 'project.database.metrics', 'icon' => 'graph'],
+        ['label' => 'Container Info', 'route' => 'project.database.container-info', 'icon' => 'info-circle'],
         ['label' => 'Tags', 'route' => 'project.database.tags', 'icon' => 'tags'],
         ['label' => 'Danger Zone', 'route' => 'project.database.danger', 'icon' => 'shield-alert'],
     ])->filter(fn (array $item): bool => $item['visible'] ?? true)
@@ -33,7 +34,7 @@
 
     $menuGroups = [
         'Settings' => ['General', 'Environment Variables', 'Persistent Storage', 'Healthcheck'],
-        'Observe & troubleshoot' => ['Runtime Logs', 'Terminal', 'Metrics'],
+        'Observe & troubleshoot' => ['Runtime Logs', 'Terminal', 'Metrics', 'Container Info'],
         'Deploy' => ['Servers'],
         'Automation' => ['Webhooks', 'Backups', 'Import Backup'],
         'Operations' => ['Resource Operations', 'Resource Limits', 'Tags', 'Danger Zone'],

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -45,6 +45,8 @@
                 <livewire:project.shared.resource-operations :resource="$application" />
             @elseif ($currentRoute === 'project.application.metrics')
                 <livewire:project.shared.metrics :resource="$application" />
+            @elseif ($currentRoute === 'project.application.container-info')
+                <livewire:project.shared.container-info :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
             @elseif ($currentRoute === 'project.application.danger')

--- a/resources/views/livewire/project/database/configuration.blade.php
+++ b/resources/views/livewire/project/database/configuration.blade.php
@@ -48,6 +48,8 @@
                     <livewire:project.shared.resource-operations :resource="$database" />
                 @elseif ($currentRoute === 'project.database.metrics')
                     <livewire:project.shared.metrics :resource="$database" />
+                @elseif ($currentRoute === 'project.database.container-info')
+                    <livewire:project.shared.container-info :resource="$database" />
                 @elseif ($currentRoute === 'project.database.tags')
                     <livewire:project.shared.tags :resource="$database" />
                 @elseif ($currentRoute === 'project.database.danger')

--- a/resources/views/livewire/project/service/configuration.blade.php
+++ b/resources/views/livewire/project/service/configuration.blade.php
@@ -21,6 +21,7 @@
             ['label' => 'Import Backup', 'route' => 'project.service.import-backup', 'icon' => 'upload', 'navigate' => false],
             ['label' => 'Runtime Logs', 'route' => 'project.service.logs', 'icon' => 'unordered-list', 'navigate' => false],
             ['label' => 'Terminal', 'route' => 'project.service.command', 'icon' => 'browser-terminal', 'navigate' => false, 'visible' => auth()->user()?->can('canAccessTerminal')],
+            ['label' => 'Container Info', 'route' => 'project.service.container-info', 'icon' => 'info-circle'],
             ['label' => 'Scheduled Tasks', 'route' => 'project.service.scheduled-tasks.show', 'icon' => 'calendar'],
             ['label' => 'Webhooks', 'route' => 'project.service.webhooks', 'icon' => 'notifications'],
             ['label' => 'Resource Operations', 'route' => 'project.service.resource-operations', 'icon' => 'server-update'],
@@ -35,7 +36,7 @@
 
         $menuGroups = [
             'Settings' => ['General', 'Domains', 'Environment Variables', 'Persistent Storage'],
-            'Observe & troubleshoot' => ['Runtime Logs', 'Terminal'],
+            'Observe & troubleshoot' => ['Runtime Logs', 'Terminal', 'Container Info'],
             'Automation' => ['Scheduled Tasks', 'Webhooks', 'Backups', 'Import Backup'],
             'Operations' => ['Resource Operations', 'Tags', 'Danger Zone'],
         ];
@@ -204,6 +205,8 @@
                     <livewire:project.shared.webhooks :resource="$service" />
                 @elseif ($currentRoute === 'project.service.resource-operations')
                     <livewire:project.shared.resource-operations :resource="$service" />
+                @elseif ($currentRoute === 'project.service.container-info')
+                    <livewire:project.shared.container-info :resource="$service" />
                 @elseif ($currentRoute === 'project.service.tags')
                     <livewire:project.shared.tags :resource="$service" />
                 @elseif ($currentRoute === 'project.service.danger')

--- a/resources/views/livewire/project/shared/container-info.blade.php
+++ b/resources/views/livewire/project/shared/container-info.blade.php
@@ -1,0 +1,108 @@
+<div wire:init="load">
+    <div class="flex flex-col gap-6">
+        <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+                <h2>Container Info</h2>
+                <p class="text-sm text-neutral-500 dark:text-fg-dim">
+                    Live details read from the Docker daemon for every container of this resource.
+                </p>
+            </div>
+            <x-forms.button wire:click="load">Refresh</x-forms.button>
+        </div>
+
+        @if (! $loaded)
+            <x-loading text="Reading container details" />
+        @elseif (empty($containers))
+            <x-callout type="info" title="No containers found">
+                Either the resource is not deployed, the server is unreachable, or it runs in Swarm mode
+                (not supported here yet).
+            </x-callout>
+        @endif
+
+        @foreach ($containers as $container)
+            <x-application.settings-section wire:key="container-info-{{ $container['name'] }}"
+                :title="$container['name']">
+                <x-slot:actions>
+                    <x-status-badge :status="str($container['status'] ?? 'unknown')->headline()->value()"
+                        :type="$container['status'] === 'running' ? 'success' : ($container['status'] === 'exited' ? 'error' : 'warning')" />
+                </x-slot:actions>
+
+                <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    <x-forms.copy-input label="Container name" :text="$container['name']" />
+                    <x-forms.copy-input label="Container ID" :text="$container['id'] ?? ''" />
+                    <x-forms.copy-input label="Image" :text="$container['image'] ?? ''" />
+                    <x-forms.copy-input label="Image ID" :text="$container['image_id'] ?? ''" />
+                    <x-forms.copy-input label="Created" :text="$container['created'] ?? 'Unknown'" />
+                    <x-forms.copy-input label="Started" :text="$container['started'] ?? 'Not started'" />
+                    <x-forms.copy-input label="Restart count" :text="(string) $container['restart_count']" />
+                </div>
+
+                <h4 class="mt-6 mb-2 text-sm font-semibold text-black dark:text-fg">Networks</h4>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-left text-sm">
+                        <thead class="text-xs uppercase text-neutral-500 dark:text-fg-dim">
+                            <tr>
+                                <th class="py-2 pr-4 font-medium">Network</th>
+                                <th class="py-2 pr-4 font-medium">IPv4</th>
+                                <th class="py-2 pr-4 font-medium">IPv6</th>
+                                <th class="py-2 pr-4 font-medium">Gateway</th>
+                                <th class="py-2 pr-4 font-medium">MAC</th>
+                                <th class="py-2 pr-4 font-medium">Aliases</th>
+                                <th class="py-2 font-medium"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-neutral-200 dark:divide-white/[0.07]">
+                            @forelse ($container['networks'] as $network)
+                                <tr wire:key="container-info-{{ $container['name'] }}-{{ $network['name'] }}">
+                                    <td class="py-2 pr-4 font-mono text-xs">{{ $network['name'] }}</td>
+                                    @foreach (['ipv4', 'ipv6', 'gateway', 'mac'] as $field)
+                                        <td class="py-2 pr-4 font-mono text-xs">
+                                            @if ($network[$field])
+                                                <span class="inline-flex items-center gap-1">{{ $network[$field] }}
+                                                    <x-copy-button :value="$network[$field]" /></span>
+                                            @else
+                                                <span class="text-neutral-400">-</span>
+                                            @endif
+                                        </td>
+                                    @endforeach
+                                    <td class="py-2 pr-4 text-xs">{{ $network['aliases'] ?: '-' }}</td>
+                                    <td class="py-2 text-right">
+                                        <x-forms.button isError canGate="update" :canResource="$resource"
+                                            :disabled="count($container['networks']) <= 1"
+                                            wire:click="disconnect('{{ $container['name'] }}', '{{ $network['name'] }}')">
+                                            Disconnect
+                                        </x-forms.button>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="py-2 text-neutral-500 dark:text-fg-dim">Not connected to any network.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                @php $others = array_values(array_diff($availableNetworks, $container['network_names'])); @endphp
+                @if (! empty($others))
+                    <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-end">
+                        <x-forms.select label="Connect to network" canGate="update" :canResource="$resource"
+                            wire:model="selectedNetwork.{{ $container['name'] }}">
+                            @foreach ($others as $name)
+                                <option value="{{ $name }}">{{ $name }}</option>
+                            @endforeach
+                        </x-forms.select>
+                        <x-forms.button canGate="update" :canResource="$resource"
+                            wire:click="connect('{{ $container['name'] }}')">
+                            Connect
+                        </x-forms.button>
+                    </div>
+                @endif
+                <p class="mt-3 text-xs text-neutral-500 dark:text-fg-dim">
+                    Connecting or disconnecting here changes the running container only; a redeploy recreates it
+                    with the networks configured in its settings.
+                </p>
+            </x-application.settings-section>
+        @endforeach
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -291,6 +291,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/resource-limits', ApplicationConfiguration::class)->name('project.application.resource-limits');
         Route::get('/resource-operations', ApplicationConfiguration::class)->name('project.application.resource-operations');
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
+        Route::get('/container-info', ApplicationConfiguration::class)->name('project.application.container-info');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
 
@@ -311,6 +312,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/resource-limits', DatabaseConfiguration::class)->name('project.database.resource-limits');
         Route::get('/resource-operations', DatabaseConfiguration::class)->name('project.database.resource-operations');
         Route::get('/metrics', DatabaseConfiguration::class)->name('project.database.metrics');
+        Route::get('/container-info', DatabaseConfiguration::class)->name('project.database.container-info');
         Route::get('/tags', DatabaseConfiguration::class)->name('project.database.tags');
         Route::get('/danger', DatabaseConfiguration::class)->name('project.database.danger');
 
@@ -340,6 +342,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/scheduled-tasks', ServiceConfiguration::class)->name('project.service.scheduled-tasks.show');
         Route::get('/webhooks', ServiceConfiguration::class)->name('project.service.webhooks');
         Route::get('/resource-operations', ServiceConfiguration::class)->name('project.service.resource-operations');
+        Route::get('/container-info', ServiceConfiguration::class)->name('project.service.container-info');
         Route::get('/tags', ServiceConfiguration::class)->name('project.service.tags');
         Route::get('/danger', ServiceConfiguration::class)->name('project.service.danger');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.service.command')->middleware('can.access.terminal');

--- a/tests/Feature/ContainerInfoPageTest.php
+++ b/tests/Feature/ContainerInfoPageTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Livewire\Project\Shared\ContainerInfo;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    $privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    $this->server = Server::factory()->create(['team_id' => $this->team->id, 'private_key_id' => $privateKey->id]);
+    $this->server->settings->update(['is_reachable' => true, 'is_usable' => true]);
+    $destination = StandaloneDocker::where('server_id', $this->server->id)->first()
+        ?? StandaloneDocker::factory()->create(['server_id' => $this->server->id, 'network' => 'coolify']);
+    $project = Project::factory()->create(['team_id' => $this->team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+    ]);
+    $this->withoutVite();
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::updateOrCreate(['id' => 0], []));
+});
+
+it('renders the container info page for an application', function () {
+    $this->get(route('project.application.container-info', [
+        'project_uuid' => $this->application->environment->project->uuid,
+        'environment_uuid' => $this->application->environment->uuid,
+        'application_uuid' => $this->application->uuid,
+    ]))->assertOk()->assertSee('Container Info');
+});
+
+it('shows docker inspect details and networks for each container', function () {
+    $name = $this->application->uuid;
+    $inspect = json_encode([
+        'Id' => str_repeat('a', 64),
+        'Name' => "/{$name}",
+        'Image' => 'sha256:'.str_repeat('b', 64),
+        'Created' => '2026-09-01T10:00:00.000000000Z',
+        'RestartCount' => 2,
+        'Config' => ['Image' => 'nginx:1.27'],
+        'State' => ['Status' => 'running', 'StartedAt' => '2026-09-02T11:30:00.000000000Z'],
+        'NetworkSettings' => ['Networks' => [
+            'coolify' => ['IPAddress' => '172.18.0.5', 'GlobalIPv6Address' => 'fd00::5', 'Gateway' => '172.18.0.1', 'MacAddress' => '02:42:ac:12:00:05', 'Aliases' => ['web']],
+        ]],
+    ]);
+    Process::fake([
+        '*docker ps*' => Process::result(output: json_encode(['ID' => 'aaaaaaaaaaaa', 'Names' => $name, 'State' => 'running', 'Labels' => 'coolify.pullRequestId=0'])),
+        '*docker container inspect*' => Process::result(output: $inspect),
+        '*docker network ls*' => Process::result(output: "bridge\ncoolify\nhost\nnone\nother-net\n"),
+    ]);
+
+    Livewire::test(ContainerInfo::class, ['resource' => $this->application])
+        ->call('load')
+        ->assertSet('loaded', true)
+        ->assertSet('containers.0.name', $name)
+        ->assertSet('containers.0.short_id', 'aaaaaaaaaaaa')
+        ->assertSet('containers.0.image', 'nginx:1.27')
+        ->assertSet('containers.0.restart_count', 2)
+        ->assertSet('containers.0.created', '2026-09-01 10:00:00 UTC')
+        ->assertSet('containers.0.networks.0.ipv4', '172.18.0.5')
+        ->assertSet('containers.0.networks.0.ipv6', 'fd00::5')
+        ->assertSet('containers.0.networks.0.mac', '02:42:ac:12:00:05')
+        ->assertSet('availableNetworks', ['coolify', 'other-net'])
+        ->assertSet("selectedNetwork.{$name}", 'other-net')
+        ->assertSee('172.18.0.5')
+        ->assertSee('other-net');
+});
+
+it('refuses to disconnect the only network of a container', function () {
+    $name = $this->application->uuid;
+    Process::fake(['*' => Process::result(output: '')]);
+
+    Livewire::test(ContainerInfo::class, ['resource' => $this->application])
+        ->set('containers', [[
+            'id' => str_repeat('a', 64), 'short_id' => 'aaaaaaaaaaaa', 'name' => $name, 'image' => 'nginx', 'image_id' => 'sha256:b',
+            'status' => 'running', 'restart_count' => 0, 'created' => null, 'started' => null,
+            'networks' => [['name' => 'coolify', 'ipv4' => null, 'ipv6' => null, 'gateway' => null, 'mac' => null, 'aliases' => '']],
+            'network_names' => ['coolify'],
+        ]])
+        ->call('disconnect', $name, 'coolify')
+        ->assertDispatched('error');
+
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'docker network disconnect'));
+});


### PR DESCRIPTION
## Changes

- New **Container Info** page (*Observe & troubleshoot*) for applications, standalone databases and services, from one shared Livewire component.
- For each container of the resource (one docker container inspect per resource): name, container ID, image, image ID, created/started, restart count, status badge, copy buttons everywhere.
- Per-container **Networks** table: name, IPv4, IPv6, gateway, MAC, aliases.
- **Connect / Disconnect** to other networks on the server (needs update permission; the last network cannot be removed). The page says this is a runtime change that a redeploy undoes.
- Lazy loaded, Refresh button, callout when not deployed / server unreachable / Swarm.

Follow-ups: manual container names for databases, image last pulled.

## Issues

- Fixes #2495

/claim #2495

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

The new page on an application, then Connect attaching the container to a second network and Disconnect removing it.

![Container Info demo](https://raw.githubusercontent.com/badnikhil/coolify/pr-assets/demo-container-info.gif)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: first draft of the component, view and test; reviewed by hand against the existing Servers and Logs pages.

## Testing

- `tests/Feature/ContainerInfoPageTest.php` (page renders; faked inspect output parsed into fields and networks; disconnecting the only network is refused) and Pint pass.
- Dev instance with the testing host: page for a container on two networks matches `docker inspect`; Connect and Disconnect change its networks (see Preview).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.




