### PR TITLE
fix(upgrade): report container start failures

### DIFF
--- a/other/nightly/upgrade.sh
+++ b/other/nightly/upgrade.sh
@@ -279,8 +279,15 @@ nohup bash -c "
     fi
 
     log 'Running docker compose up...'
-    docker run -v /data/coolify/source:/data/coolify/source -v /var/run/docker.sock:/var/run/docker.sock \${DOCKER_CONFIG_MOUNT} --rm \${REGISTRY_URL:-docker.io}/coollabsio/coolify-helper:\${LATEST_HELPER_VERSION} bash -c \"LATEST_IMAGE=\${LATEST_IMAGE} docker compose --env-file /data/coolify/source/.env \${COMPOSE_FILES} up -d --remove-orphans --wait --wait-timeout 60\" >>\"\$LOGFILE\" 2>&1
-    log 'Docker compose up completed'
+    if docker run -v /data/coolify/source:/data/coolify/source -v /var/run/docker.sock:/var/run/docker.sock \${DOCKER_CONFIG_MOUNT} --rm \${REGISTRY_URL:-docker.io}/coollabsio/coolify-helper:\${LATEST_HELPER_VERSION} bash -c \"LATEST_IMAGE=\${LATEST_IMAGE} docker compose --env-file /data/coolify/source/.env \${COMPOSE_FILES} up -d --remove-orphans --wait --wait-timeout 60\" >>\"\$LOGFILE\" 2>&1; then
+        log 'Docker compose up completed'
+    else
+        exit_code=\$?
+        error_message=\"Failed to start Coolify containers (exit code \${exit_code})\"
+        log \"ERROR: \${error_message}\"
+        write_status 'error' \"\${error_message}\"
+        exit \"\${exit_code}\"
+    fi
 
     # Final log entry
     echo '' >>\"\$LOGFILE\"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -292,8 +292,15 @@ nohup bash -c "
     fi
 
     log 'Running docker compose up...'
-    docker run -v /data/coolify/source:/data/coolify/source -v /var/run/docker.sock:/var/run/docker.sock \${DOCKER_CONFIG_MOUNT} --rm \${REGISTRY_URL:-docker.io}/coollabsio/coolify-helper:\${LATEST_HELPER_VERSION} bash -c \"LATEST_IMAGE=\${LATEST_IMAGE} docker compose --env-file /data/coolify/source/.env \${COMPOSE_FILES} up -d --remove-orphans --wait --wait-timeout 60\" >>\"\$LOGFILE\" 2>&1
-    log 'Docker compose up completed'
+    if docker run -v /data/coolify/source:/data/coolify/source -v /var/run/docker.sock:/var/run/docker.sock \${DOCKER_CONFIG_MOUNT} --rm \${REGISTRY_URL:-docker.io}/coollabsio/coolify-helper:\${LATEST_HELPER_VERSION} bash -c \"LATEST_IMAGE=\${LATEST_IMAGE} docker compose --env-file /data/coolify/source/.env \${COMPOSE_FILES} up -d --remove-orphans --wait --wait-timeout 60\" >>\"\$LOGFILE\" 2>&1; then
+        log 'Docker compose up completed'
+    else
+        exit_code=\$?
+        error_message=\"Failed to start Coolify containers (exit code \${exit_code})\"
+        log \"ERROR: \${error_message}\"
+        write_status 'error' \"\${error_message}\"
+        exit \"\${exit_code}\"
+    fi
 
     # Final log entry
     echo '' >>\"\$LOGFILE\"

--- a/tests/Feature/UpgradeScriptTest.php
+++ b/tests/Feature/UpgradeScriptTest.php
@@ -1,0 +1,158 @@
+<?php
+
+use App\Services\CoolifyUpgradeStatus;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+function createUpgradeTestBinary(string $directory, string $name, string $contents): void
+{
+    file_put_contents("{$directory}/{$name}", $contents);
+    chmod("{$directory}/{$name}", 0755);
+}
+
+function runUpgradeWithComposeResult(string $scriptPath, int $composeExitCode): array
+{
+    $workingDirectory = sys_get_temp_dir().'/coolify-upgrade-test-'.Str::random(12);
+    $dataDirectory = $workingDirectory.'/data/coolify';
+    $sourceDirectory = $dataDirectory.'/source';
+    $binDirectory = $workingDirectory.'/bin';
+
+    File::makeDirectory($sourceDirectory, 0755, true);
+    File::makeDirectory($dataDirectory.'/ssh', 0755, true);
+    File::makeDirectory($binDirectory, 0755, true);
+
+    file_put_contents($sourceDirectory.'/.env', implode("\n", [
+        'PUSHER_APP_ID=test',
+        'PUSHER_APP_KEY=test',
+        'PUSHER_APP_SECRET=test',
+        '',
+    ]));
+
+    $script = file_get_contents(base_path($scriptPath));
+    if ($script === false) {
+        throw new RuntimeException("Unable to read {$scriptPath}");
+    }
+
+    $testScript = $workingDirectory.'/upgrade.sh';
+    file_put_contents($testScript, str_replace('/data/coolify', $dataDirectory, $script));
+    chmod($testScript, 0755);
+
+    createUpgradeTestBinary($binDirectory, 'curl', <<<'BASH'
+#!/bin/bash
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = '-o' ]; then
+        shift
+        mkdir -p "$(dirname "$1")"
+        : > "$1"
+        exit 0
+    fi
+    shift
+done
+exit 1
+BASH);
+
+    createUpgradeTestBinary($binDirectory, 'docker', <<<'BASH'
+#!/bin/bash
+case "$1" in
+    compose)
+        printf '%s\n' 'docker.io/coollabsio/coolify:test'
+        exit 0
+        ;;
+    network|pull|ps)
+        exit 0
+        ;;
+    run)
+        if [ "${MOCK_COMPOSE_EXIT_CODE}" -ne 0 ]; then
+            printf '%s\n' 'failed to bind host port 6001: address already in use' >&2
+        fi
+        exit "${MOCK_COMPOSE_EXIT_CODE}"
+        ;;
+esac
+exit 0
+BASH);
+
+    createUpgradeTestBinary($binDirectory, 'nohup', <<<'BASH'
+#!/bin/bash
+"$@"
+exit_code=$?
+printf '%s' "$exit_code" > "$MOCK_NOHUP_EXIT_FILE"
+exit "$exit_code"
+BASH);
+
+    createUpgradeTestBinary($binDirectory, 'sleep', <<<'BASH'
+#!/bin/bash
+if [ "$1" = '2' ]; then
+    for _ in $(seq 1 500); do
+        [ -f "$MOCK_NOHUP_EXIT_FILE" ] && exit 0
+        /bin/sleep 0.01
+    done
+    exit 1
+fi
+exit 0
+BASH);
+
+    createUpgradeTestBinary($binDirectory, 'chown', <<<'BASH'
+#!/bin/bash
+exit 0
+BASH);
+
+    $nohupExitFile = $workingDirectory.'/nohup-exit';
+    $process = new Process(
+        ['bash', $testScript, '4.3.15', '1.0.17', 'docker.io', 'true'],
+        env: [
+            'PATH' => $binDirectory.':'.getenv('PATH'),
+            'MOCK_COMPOSE_EXIT_CODE' => (string) $composeExitCode,
+            'MOCK_NOHUP_EXIT_FILE' => $nohupExitFile,
+        ],
+    );
+    $process->run();
+
+    $logs = glob($sourceDirectory.'/upgrade-*.log');
+    $result = [
+        'process_exit_code' => $process->getExitCode(),
+        'nohup_exit_code' => is_file($nohupExitFile) ? (int) file_get_contents($nohupExitFile) : null,
+        'status' => is_file($sourceDirectory.'/.upgrade-status') ? file_get_contents($sourceDirectory.'/.upgrade-status') : null,
+        'log' => $logs === false || $logs === [] ? '' : file_get_contents($logs[0]),
+    ];
+
+    File::deleteDirectory($workingDirectory);
+
+    return $result;
+}
+
+it('records a failed container start instead of reporting a successful upgrade', function (string $scriptPath) {
+    $result = runUpgradeWithComposeResult($scriptPath, 42);
+    $parsedStatus = CoolifyUpgradeStatus::fromFile(
+        content: $result['status'] ?? '',
+        runningVersion: '4.3.14',
+        targetVersion: '4.3.15',
+    );
+
+    expect($result['process_exit_code'])->toBe(0)
+        ->and($result['nohup_exit_code'])->toBe(42)
+        ->and($result['status'])->toStartWith('error|Failed to start Coolify containers (exit code 42)|')
+        ->and($result['log'])->toContain('address already in use')
+        ->and($result['log'])->not->toContain('Upgrade complete')
+        ->and($result['log'])->not->toContain('completed successfully')
+        ->and($parsedStatus)->toMatchArray([
+            'status' => 'error',
+            'message' => 'Failed to start Coolify containers (exit code 42)',
+        ]);
+})->with([
+    'stable upgrade' => 'scripts/upgrade.sh',
+    'nightly upgrade' => 'other/nightly/upgrade.sh',
+]);
+
+it('still records a successful upgrade when the containers start', function (string $scriptPath) {
+    $result = runUpgradeWithComposeResult($scriptPath, 0);
+
+    expect($result['process_exit_code'])->toBe(0)
+        ->and($result['nohup_exit_code'])->toBe(0)
+        ->and($result['status'])->toBeNull()
+        ->and($result['log'])->toContain('Step 6/6: Upgrade complete')
+        ->and($result['log'])->toContain('Coolify upgrade completed successfully');
+})->with([
+    'stable upgrade' => 'scripts/upgrade.sh',
+    'nightly upgrade' => 'other/nightly/upgrade.sh',
+]);


### PR DESCRIPTION
## Changes

- Stop the detached upgrade restart flow when the helper/Compose command exits non-zero.
- Preserve the command's exit code in the upgrade status and log, and skip the successful completion block.
- Add executable regression coverage for the stable and nightly upgrade scripts, including their existing success path.

## Issues

- Fixes #11571

## Category

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Preview

Not applicable; this changes shell upgrade failure handling.

## AI Assistance

- [x] AI was used in the development of this pull request.

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used for investigation, implementation, and tests. The changes and behavior were manually reviewed and verified in an isolated self-hosted Docker environment.

## Testing

- `php vendor/bin/pest --compact tests/Feature/UpgradeScriptTest.php tests/Unit/CoolifyUpgradeStatusTest.php tests/Unit/UpgradePostgresScriptTest.php` (43 passed, 178 assertions)
- `bash -n scripts/upgrade.sh`
- `bash -n other/nightly/upgrade.sh`
- Clean Docker-in-Docker self-hosted installation: confirmed Coolify 4.3.14 became healthy and `/api/health` returned 200.
- Occupied host port 6001 and reran the upgrade: Compose returned 1, `.upgrade-status` recorded the failure, the Docker error remained in the log, and no step 6 or successful completion message was written.
- Released port 6001 and reran the upgrade: the partially created stack recovered, Coolify became healthy, and the successful completion path ran.

## Contributor Agreement

- [x] I have read and agree to the project's contribution guidelines.
- [x] I have tested these changes on a clean Coolify instance.
- [x] I understand that maintainers may close this PR if it does not align with the project roadmap.
