### PR TITLE
fix(docker): custom container names

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1992,7 +1992,6 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         try {
             if (! ValidationPatterns::isValidEnvironmentVariableKey($key)) {
                 throw new \InvalidArgumentException('Invalid build-time environment variable key.');
-
             }
 
             return $key;
@@ -2183,7 +2182,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     $this->write_deployment_configurations();
                     $this->server = $this->mainServer;
                 }
-                if (count($this->application->ports_mappings_array) > 0 || (bool) $this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isNotEmpty() || $this->pull_request_id !== 0 || str($this->application->custom_docker_run_options)->contains('--ip') || str($this->application->custom_docker_run_options)->contains('--ip6')) {
+                if (count($this->application->ports_mappings_array) > 0 || (bool) $this->application->settings->is_consistent_container_name_enabled || $this->pull_request_id !== 0 || str($this->application->custom_docker_run_options)->contains('--ip') || str($this->application->custom_docker_run_options)->contains('--ip6')) {
                     $this->application_deployment_queue->addLogEntry('----------------------------------------');
                     if (count($this->application->ports_mappings_array) > 0) {
                         $this->application_deployment_queue->addLogEntry('Application has ports mapped to the host system, rolling update is not supported.');
@@ -2191,7 +2190,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     if ((bool) $this->application->settings->is_consistent_container_name_enabled) {
                         $this->application_deployment_queue->addLogEntry('Consistent container name feature enabled, rolling update is not supported.');
                     }
-                    if (str($this->application->settings->custom_internal_name)->isNotEmpty()) {
+                    if ((bool) $this->application->settings->is_consistent_container_name_enabled && str($this->application->settings->custom_internal_name)->isNotEmpty()) {
                         $this->application_deployment_queue->addLogEntry('Custom internal name is set, rolling update is not supported.');
                     }
                     if ($this->pull_request_id !== 0) {
@@ -2219,7 +2218,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function resolveContainerName(): string
     {
-        if (str($this->application->settings->custom_internal_name)->isEmpty()) {
+        if (! $this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isEmpty()) {
             return generateApplicationContainerName($this->application, $this->pull_request_id);
         }
 
@@ -4285,7 +4284,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         try {
             $this->application_deployment_queue->addLogEntry('Removing old containers.');
             if ($this->newVersionIsHealthy || $force) {
-                if ($this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isNotEmpty()) {
+                if ($this->application->settings->is_consistent_container_name_enabled) {
                     $containers = getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
                     $this->containerNamesToRemove($containers)->each(function (string $containerName) {
                         $this->graceful_shutdown_container($containerName);

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -273,7 +273,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->configuration_dir = application_configuration_dir()."/{$this->application->uuid}";
         $this->is_debug_enabled = $this->application->settings->is_debug_enabled;
 
-        $this->container_name = $this->resolveContainerName();
+        $this->container_name = generateApplicationContainerName($this->application, $this->pull_request_id);
 
         $this->saved_outputs = collect();
 
@@ -2214,19 +2214,6 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } catch (Exception $e) {
             throw new DeploymentException('Rolling update failed ('.get_class($e).'): '.$e->getMessage(), $e->getCode(), $e);
         }
-    }
-
-    private function resolveContainerName(): string
-    {
-        if (! $this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isEmpty()) {
-            return generateApplicationContainerName($this->application, $this->pull_request_id);
-        }
-
-        if ($this->pull_request_id === 0) {
-            return $this->application->settings->custom_internal_name;
-        }
-
-        return addPreviewDeploymentSuffix($this->application->settings->custom_internal_name, $this->pull_request_id);
     }
 
     private function health_check()

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -349,12 +349,13 @@ function generateApplicationContainerName(Application $application, $pull_reques
     // TODO: refactor generateApplicationContainerName, we do not need $application and $pull_request_id
 
     $consistent_container_name = $application->settings->is_consistent_container_name_enabled;
+    $name = $consistent_container_name ? ($application->settings->custom_internal_name ?: $application->uuid) : $application->uuid;
     $now = now()->format('Hisu');
     if ($pull_request_id !== 0 && $pull_request_id !== null) {
-        return $application->uuid.'-pr-'.$pull_request_id;
+        return $name.'-pr-'.$pull_request_id;
     } else {
         if ($consistent_container_name) {
-            return $application->uuid;
+            return $name;
         }
 
         return $application->uuid.'-'.$now;

--- a/database/migrations/2026_09_08_214510_align_consistent_container_name_with_custom_internal_name.php
+++ b/database/migrations/2026_09_08_214510_align_consistent_container_name_with_custom_internal_name.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * A stored custom container name was always used when deploying, even with consistent naming off, while
+     * the UI only shows the name in consistent naming mode. This migration enables consistent naming for those rows
+     * so they keep deploying with their custom name once the flag becomes the only switch.
+     */
+    public function up(): void
+    {
+        DB::table('application_settings')
+            ->whereNotNull('custom_internal_name')
+            ->where('custom_internal_name', '!=', '')
+            ->where('is_consistent_container_name_enabled', false)
+            ->update(['is_consistent_container_name_enabled' => true]);
+    }
+};

--- a/tests/Unit/ApplicationDeploymentContainerNamingTest.php
+++ b/tests/Unit/ApplicationDeploymentContainerNamingTest.php
@@ -28,19 +28,11 @@ function applicationWithContainerNaming(string $customName = 'shadowuw'): Applic
 }
 
 it('uses the custom container name when consistent naming is enabled', function () {
-    $application = applicationWithContainerNaming();
-
-    [$job, $reflection] = containerNamingJob($application);
-
-    expect($reflection->getMethod('resolveContainerName')->invoke($job))->toBe('shadowuw');
+    expect(generateApplicationContainerName(applicationWithContainerNaming()))->toBe('shadowuw');
 });
 
 it('adds the pull request suffix to a custom container name', function () {
-    $application = applicationWithContainerNaming();
-
-    [$job, $reflection] = containerNamingJob($application, 42);
-
-    expect($reflection->getMethod('resolveContainerName')->invoke($job))->toBe('shadowuw-pr-42');
+    expect(generateApplicationContainerName(applicationWithContainerNaming(), 42))->toBe('shadowuw-pr-42');
 });
 
 it('includes old generated containers when cleaning up a consistent deployment', function () {
@@ -61,7 +53,5 @@ it('ignores the custom container name when consistent naming is disabled', funct
     $application = applicationWithContainerNaming();
     $application->settings->is_consistent_container_name_enabled = false;
 
-    [$job, $reflection] = containerNamingJob($application);
-
-    expect($reflection->getMethod('resolveContainerName')->invoke($job))->toStartWith('application-uuid-');
+    expect(generateApplicationContainerName($application))->toStartWith('application-uuid-');
 });

--- a/tests/Unit/ApplicationDeploymentContainerNamingTest.php
+++ b/tests/Unit/ApplicationDeploymentContainerNamingTest.php
@@ -56,3 +56,12 @@ it('includes old generated containers when cleaning up a consistent deployment',
     expect($reflection->getMethod('containerNamesToRemove')->invoke($job, $containers)->all())
         ->toBe(['application-uuid-192238854305', 'shadowuw']);
 });
+
+it('ignores the custom container name when consistent naming is disabled', function () {
+    $application = applicationWithContainerNaming();
+    $application->settings->is_consistent_container_name_enabled = false;
+
+    [$job, $reflection] = containerNamingJob($application);
+
+    expect($reflection->getMethod('resolveContainerName')->invoke($job))->toStartWith('application-uuid-');
+});


### PR DESCRIPTION
## Changes

- Enable consistent naming for legacy custom container names
  - A stored custom container name was always used when deploying, even with consistent naming off, while the UI only shows the name in consistent naming mode.
- Only use custom container names in consistent naming mode
- Use custom container names for compose applications previously docker compose applications never used the custom name
  - This also cleans up the code as previously, there were two paths for generating the container name.

## Preview

Example with custom container name `shop-api`:

| | before | after |
|---|---|---|
| single container app | `shop-api` | `shop-api` (unchanged) |
| compose service `web` | `web-k9p2m4x7q1w3e5r6t8y0u2i4` (custom name ignored) | `web-shop-api` |
| compose service `db` | `db-k9p2m4x7q1w3e5r6t8y0u2i4` (custom name ignored) | `db-shop-api` |
| preview deployment `#42` | `shop-api-pr-42` | `shop-api-pr-42` (unchanged) |

