### PR TITLE
feat(docker): use ISO 8601 timestamp suffix for generated container names

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -339,7 +339,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                         if ($containerName === 'coolify-proxy') {
                             continue;
                         }
-                        if (preg_match('/-(\d{12})/', $containerName)) {
+                        if (isGeneratedContainerName($containerName)) {
                             continue;
                         }
                         $containerIp = data_get($container, 'IPv4Address');

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -350,7 +350,7 @@ function generateApplicationContainerName(Application $application, $pull_reques
 
     $consistent_container_name = $application->settings->is_consistent_container_name_enabled;
     $name = $consistent_container_name ? ($application->settings->custom_internal_name ?: $application->uuid) : $application->uuid;
-    $now = now()->format('Hisu');
+    $now = now()->format('Ymd\THis');
     if ($pull_request_id !== 0 && $pull_request_id !== null) {
         return $name.'-pr-'.$pull_request_id;
     } else {
@@ -361,6 +361,20 @@ function generateApplicationContainerName(Application $application, $pull_reques
         return $application->uuid.'-'.$now;
     }
 }
+
+/**
+ * Generated (rolling update) container names end with the timestamp from generateApplicationContainerName().
+ * Drop the legacy pattern once containers created before the ISO 8601 suffix are gone.
+ */
+function isGeneratedContainerName(string $containerName): bool
+{
+    $isoTimestampSuffix = '/-\d{8}T\d{6}$/';
+    $legacyTimestampSuffix = '/-\d{12}$/';
+
+    return preg_match($isoTimestampSuffix, $containerName) === 1
+        || preg_match($legacyTimestampSuffix, $containerName) === 1;
+}
+
 function get_port_from_dockerfile($dockerfile): ?int
 {
     $dockerfile_array = explode("\n", $dockerfile);

--- a/tests/Unit/ApplicationDeploymentContainerNamingTest.php
+++ b/tests/Unit/ApplicationDeploymentContainerNamingTest.php
@@ -55,3 +55,12 @@ it('ignores the custom container name when consistent naming is disabled', funct
 
     expect(generateApplicationContainerName($application))->toStartWith('application-uuid-');
 });
+
+it('recognises generated container names in both timestamp formats', function () {
+    expect(isGeneratedContainerName('application-uuid-20260908T141530'))->toBeTrue()
+        ->and(isGeneratedContainerName('my-api-20260908T141530'))->toBeTrue()
+        ->and(isGeneratedContainerName('application-uuid-192238854305'))->toBeTrue()
+        ->and(isGeneratedContainerName('application-uuid'))->toBeFalse()
+        ->and(isGeneratedContainerName('application-uuid-pr-42'))->toBeFalse()
+        ->and(isGeneratedContainerName('my-api'))->toBeFalse();
+});


### PR DESCRIPTION
## Changes

- Switch to an ISO 8601 timestamp suffix for generated container names

## Why?

- Generated (rolling update) container names ended in HHMMSS plus microseconds (`k9p2m4x7q1w3e5r6t8y0u2i4-141530123456`), which is unreadable and does not sort across days. The new format (`k9p2m4x7q1w3e5r6t8y0u2i4-20260908T141530`) is much cleaner, more readable, shows you when the container was created, sorts chronologically as a plain strings and is standard format that people and tools recognize (`isGeneratedContainerName()` still recognizes the old 12-digit suffix)
- We also do not really need microseconds. Seconds are sufficient because deployments of one application never run concurrently.

