### PR TITLE
fix(nginx): route /app/ path to coolify-realtime for WebSocket support

### DIFF
--- a/docker/development/etc/nginx/site-opts.d/http.conf
+++ b/docker/development/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,15 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Route WebSocket traffic to the realtime server
+location /app/ {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/docker/production/etc/nginx/site-opts.d/http.conf
+++ b/docker/production/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,15 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Route WebSocket traffic to the realtime server
+location /app/ {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
### Description
WebSocket connections to the Coolify dashboard fail when the instance is behind a reverse proxy (such as Tailscale Serve) that terminates TLS.

**Symptom:**
The browser console displays the following error:
'WebSocket connection to wss://<your-domain>/app/<id>... failed: There was a bad response from the server.'

### Cause
The default Nginx configuration in the coolify container does not have a specific route for the /app/ path (which is used for WebSockets). In a standard setup, this might work, but when a reverse proxy is used, the WebSocket upgrade request is routed to the PHP application instead of being proxied to the coolify-realtime container on port 6001.

### Workaround/Fix
Added a specific location /app/ block to the Nginx configuration in both production and development environments to explicitly proxy the path to the coolify-realtime service.

### AI Disclosure
This contribution was assisted by an AI agent running Gemma4 31B locally, using a local Paritok instance.

Fixes #11707