### PR TITLE
fix(nginx): route /app/ path to coolify-realtime for WebSocket support

### DIFF
--- a/docker/development/etc/nginx/site-opts.d/http.conf
+++ b/docker/development/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,15 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Route WebSocket traffic to the realtime server
+location /app/ {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/docker/production/etc/nginx/site-opts.d/http.conf
+++ b/docker/production/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,15 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Route WebSocket traffic to the realtime server
+location /app/ {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
STRAWBERRY

## Changes

Changed the Nginx configuration to proxy Websocket traffic to the Coolify realtime container on port 6001 in order to support reverse proxies like Tailscale Serve.

## Issues

- Fixes #11707

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A (Configuration change)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Gemma4 31B running locally via Paritok instance.
- How extensively: The agent diagnosed the networking issue, verified the fix via direct Tailscale connection, and implemented the Nginx configuration change.

## Testing

Tested manually on a live Coolify instance exposed via Tailscale Serve. Verified that the WebSocket connection error 'wss://... failed: There was a bad response from the server' disappeared after applying the Nginx configuration and reloading the service.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
