### PR TITLE
fix(database): make custom-config.cnf world-readable for non-root SSH servers

### DIFF
--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -287,5 +287,13 @@ class StartMariadb
         $content = $this->database->mariadb_conf;
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        // The file is bind-mounted into the container, where mysqld reads it
+        // as the mysql user. When the server is connected over a non-root SSH
+        // user, tee leaves the host file owned by that user with the SSH
+        // user's umask (e.g. 0600), so mysqld gets EACCES on the includedir
+        // directive and silently skips ALL custom configuration. Make the
+        // file world-readable; the owner stays the SSH user, so later
+        // rewrites via tee keep working.
+        $this->commands[] = "chmod 644 $this->configuration_dir/{$filename}";
     }
 }

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -289,5 +289,13 @@ class StartMysql
         $content = $this->database->mysql_conf;
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        // The file is bind-mounted into the container, where mysqld reads it
+        // as the mysql user. When the server is connected over a non-root SSH
+        // user, tee leaves the host file owned by that user with the SSH
+        // user's umask (e.g. 0600), so mysqld gets EACCES on the includedir
+        // directive and silently skips ALL custom configuration. Make the
+        // file world-readable; the owner stays the SSH user, so later
+        // rewrites via tee keep working.
+        $this->commands[] = "chmod 644 $this->configuration_dir/{$filename}";
     }
 }


### PR DESCRIPTION
Fixes #11600.

## The bug

@kleintonno diagnosed this in the issue: on a server connected over a **non-root SSH user**, `add_custom_mysql()` writes `custom-config.cnf` with `tee`, leaving the host file owned by the SSH user with that user's umask (e.g. 0600). The compose service bind-mounts the file and mysqld reads it as the `mysql` user, so the includedir gets EACCES and every custom setting silently vanishes - no error anywhere in the UI.

## The fix

Append `chmod 644 $this->configuration_dir/{$filename}` immediately after the `tee` in both `StartMysql::add_custom_mysql()` and `StartMariadb::add_custom_mysql()`. Ownership stays with the SSH user, so later rewrites via `tee` keep working; the file just becomes readable by the `mysql` user inside the container.

On @djsisson's `pre_start` hint from the issue thread: the chmod is deliberately done in the same command sequence that writes the file rather than moved to a `pre_start` hook - the file is rewritten on every deploy, and a container-side hook would not fix host-side ownership of the bind-mounted source. Happy to recut if you prefer the hook.

## Tests

Shell red-green on the exact emitted command sequence: `umask 077; echo ... | tee file` -> 0600, container-user read gets EACCES (the reported symptom); after the appended `chmod 644` the read succeeds, and a second `tee` rewrite still works as the SSH user. **Not run:** `php -l` / Pest (no PHP runtime in our build environment) - the change appends one string element to the existing commands array in each twin method; CI lints.

> Built by breken, your AI support engineer - breken.ai - this one's on us.