### PR TITLE
fix(database): recover DockerCleanupExecution rows orphaned by interrupted workers

### DIFF
--- a/app/Jobs/DockerCleanupJob.php
+++ b/app/Jobs/DockerCleanupJob.php
@@ -46,6 +46,23 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
     public function handle(): void
     {
         try {
+            // Recover executions orphaned by an interrupted worker. The
+            // WithoutOverlapping middleware guarantees no other cleanup job
+            // for this server is running right now, and its lock expires
+            // after the job timeout, so any record still "running" past the
+            // timeout belongs to a dead worker and would otherwise stay
+            // "running" forever (failed() never runs on a hard kill).
+            DockerCleanupExecution::query()
+                ->where('server_id', $this->server->id)
+                ->where('status', 'running')
+                ->whereNull('finished_at')
+                ->where('created_at', '<', Carbon::now()->subSeconds($this->timeout))
+                ->update([
+                    'status' => 'failed',
+                    'message' => 'Marked as failed: the queue worker was interrupted before this execution finished.',
+                    'finished_at' => Carbon::now()->toImmutable(),
+                ]);
+
             $this->execution_log = DockerCleanupExecution::create([
                 'server_id' => $this->server->id,
             ]);


### PR DESCRIPTION
Fixes #11643.

## The bug

`DockerCleanupJob` opens its `docker_cleanup_executions` row at the start of `handle()` and relies on `failed()` to close it. But a hard worker kill (SIGKILL, host reboot, OOM) never runs `failed()`, and with `tries=1` plus `WithoutOverlapping(...)->dontRelease()` nothing ever recovers the row - the cleanup shows as **running forever** in the UI, exactly as @naumanahmed19 reported.

## The fix

At the top of `handle()`, before the new row is created, sweep rows for this server still `running` with `finished_at` null and `created_at` older than the job timeout, and mark them failed with an explicit interrupted-worker message.

Race-safety: the `WithoutOverlapping` lock is keyed per server uuid with `expireAfter` equal to the job timeout, so while any legitimate run is in progress no sweeper can be looking at it, and any row older than the timeout cannot belong to a live worker - the sweep is provably confined to dead-worker rows.

## Tests

Claims + race analysis verified against current source (`handle()` row creation, `failed()` as the only closer, `tries=1`, lock expiry == timeout). **Not run:** `php -l` / Pest (no PHP runtime in our build environment) - the change is one Eloquent update block inside the existing `try`; CI lints.

> Built by breken, your AI support engineer - breken.ai - this one's on us.