### PR TITLE
fix(server): persist proxy status from Sentinel pushes while in sync

### DIFF
--- a/app/Jobs/PushServerUpdateJob.php
+++ b/app/Jobs/PushServerUpdateJob.php
@@ -334,8 +334,11 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
             } else {
                 $uuid = $labels->get('com.docker.compose.service');
                 $type = $labels->get('coolify.type');
-                if ($name === 'coolify-proxy' && $this->isRunning($containerStatus)) {
-                    $this->foundProxy = true;
+                if ($name === 'coolify-proxy') {
+                    if ($this->isRunning($containerStatus)) {
+                        $this->foundProxy = true;
+                    }
+                    $this->persistProxyStatus(data_get($container, 'state', 'exited'));
                 } elseif ($type === 'service' && $this->isRunning($containerStatus)) {
                 } else {
                     if ($this->allDatabaseUuids->contains($uuid) && $this->isActiveOrTransient($containerStatus)) {
@@ -782,6 +785,24 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
         if ($previewIdsToUpdate->isNotEmpty()) {
             ApplicationPreview::whereIn('id', $previewIdsToUpdate)->update(['status' => 'exited']);
         }
+    }
+
+    private function persistProxyStatus(string $status): void
+    {
+        // While Sentinel is in sync, ServerCheckJob (the only other automatic
+        // writer of the proxy status) never runs, so the stored status can
+        // stay "exited"/"starting" forever even though the proxy is healthy.
+        // Persist the state observed in the Sentinel push here. The UI
+        // compares against the plain container state, so store it without
+        // the ":health" suffix $containerStatus carries.
+        if (! $this->server->proxy) {
+            return;
+        }
+        if ($this->server->proxy->get('status') === $status) {
+            return;
+        }
+        $this->server->proxy->set('status', $status);
+        $this->server->save();
     }
 
     private function updateProxyStatus()


### PR DESCRIPTION
Fixes #11539.

## The bug

@onur-tellioglu reported the proxy status getting stuck. The chain, verified in source: `ServerCheckJob` is the only automatic writer of the proxy status, but `ServerManagerJob` dispatches it **only when Sentinel is out of sync**. On the in-sync path, `PushServerUpdateJob` sees the `coolify-proxy` container in the Sentinel push but only sets its internal `foundProxy` flag - it never writes the observed state. So a stale `exited` (from onboarding) or `starting` (from StartProxy) survives reboots indefinitely, until someone clicks refresh manually.

## The fix

When the Sentinel push contains the `coolify-proxy` container, persist the observed container state (change-gated - no write when the status already matches). The UI strict-compares against the plain container state, so we store `data_get($container, 'state', 'exited')` **without** the `:health` suffix that `$containerStatus` carries.

Scope note: standalone servers only. Swarm proxy task names are a pre-existing separate gap, deliberately untouched here.

## Tests

Chain re-verified against current source (`ServerManagerJob` dispatch condition, `PushServerUpdateJob` proxy branch, `CheckProxy` manual-path write, the Livewire strict comparison, and the `:health` suffix site). **Not run:** `php -l` / Pest (no PHP runtime in our build environment) - one guarded branch change plus one private helper; CI lints.

> Built by breken, your AI support engineer - breken.ai - this one's on us.