### PR TITLE
fix(scheduled-task): prevent overlapping runs via WithoutOverlapping lock

### DIFF
--- a/app/Jobs/ScheduledTaskJob.php
+++ b/app/Jobs/ScheduledTaskJob.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
@@ -64,6 +65,20 @@ class ScheduledTaskJob implements ShouldBeEncrypted, ShouldQueue
     public array $containers = [];
 
     public string $server_timezone = 'UTC';
+
+    /**
+     * Prevent overlapping runs of the same task.
+     *
+     * A job recovered after the Redis visibility timeout (retry_after) can be
+     * replayed while its remote command is still executing, and a later cron
+     * dispatch would collide with it. The lock is scoped to the task and held
+     * for the task timeout plus a safety margin, so a recovered or concurrent
+     * dispatch is discarded instead of starting a second run.
+     */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping('scheduled-task-'.$this->task->id))->expireAfter($this->timeout + 300)->dontRelease()];
+    }
 
     public function __construct(ScheduledTask $task)
     {


### PR DESCRIPTION
Fixes #11648.

## The bug

@imdavidthornton reported scheduled tasks running twice. Verified in source: `ScheduledTaskJob` ships with **no overlap guard** (`tries=3`, per-task timeout), while the redis queue connection sets `retry_after=86400` (config/queue.php). A reservation lost to a Redis or Coolify recreate replays up to a day later as a fresh attempt, and that replay can collide with the next cron dispatch while the original remote command is still running - two executions of the same task at once.

## The fix

Add the repo's own established guard, mirroring `DatabaseBackupJob`: a task-scoped `WithoutOverlapping('scheduled-task-'.$this->task->id)` middleware with `expireAfter($this->timeout + 300)` and `dontRelease()`. A recovered or concurrent dispatch is discarded instead of starting a second run, and a worker death stays protected until the lock expires. The `+300` margin over the task timeout is the same tradeoff `DatabaseBackupJob` makes - a legitimately long-running task keeps its lock for the full timeout plus margin.

## Tests

Laravel queue semantics + the repo's own pattern verified in source (`DatabaseBackupJob` middleware shape, queue config `retry_after`, job timeout source). **Not run:** `php -l` / Pest (no PHP runtime in our build environment) - one import plus a 4-line `middleware()` method; CI lints.

> Built by breken, your AI support engineer - breken.ai - this one's on us.