### PR TITLE
fix(templates): drop -c from mosquitto_passwd in the mosquitto template

### DIFF
--- a/templates/compose/mosquitto.yaml
+++ b/templates/compose/mosquitto.yaml
@@ -40,7 +40,7 @@ services:
       touch /mosquitto/config/passwords &&
       chmod 0700 /mosquitto/config/passwords &&
       chown root:root /mosquitto/config/passwords &&
-      mosquitto_passwd -b -c /mosquitto/config/passwords $SERVICE_USER_MOSQUITTO $SERVICE_PASSWORD_MOSQUITTO &&
+      mosquitto_passwd -b /mosquitto/config/passwords $SERVICE_USER_MOSQUITTO $SERVICE_PASSWORD_MOSQUITTO &&
       chown mosquitto:mosquitto /mosquitto/config/passwords;
       fi &&
       exec mosquitto -c /mosquitto/config/mosquitto.conf


### PR DESCRIPTION
Fixes #11691.

## The bug

@Pete93-ASB reported the mosquitto service failing on start and pinned it to the password-file step. The template's entrypoint does `touch /mosquitto/config/passwords` and then runs `mosquitto_passwd -b -c` - but `-c` selects **create** mode, which in mosquitto's source opens the file via `mosquitto_fopen(path, "wt", true)` -> `O_WRONLY|O_TRUNC|O_CREAT|O_EXCL`. The `touch` just created the file, so the `O_EXCL` open fails with EEXIST on **every** start.

## The fix

Drop the `-c`. Without it, `mosquitto_passwd` takes the update path (`"r+t"` - `O_RDWR`, no `O_EXCL`/`O_CREAT`) and updates the existing file in place. The `touch` stays because that update path requires the file to pre-exist.

## Tests

Verified against mosquitto master's source: `file_common.c` restrict_read `'w'` -> `O_WRONLY|O_TRUNC|O_CREAT|O_EXCL`; `mosquitto_passwd.c` create-new branch (`"wt"`) vs the no-`-c` branch (`"r+t"`). The template line was byte-checked against current main. **Not run:** the container binary itself (source-level proof only) - disclosed; the change is one flag on one line.

> Built by breken, your AI support engineer - breken.ai - this one's on us.