### PR TITLE
fix(nixpacks): allow the PHP template variables through the runtime buildpack filter

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1028,7 +1028,7 @@ class Application extends BaseModel
     {
         return $this->morphMany(EnvironmentVariable::class, 'resourceable')
             ->where('is_preview', false)
-            ->withoutBuildpackControlVariables();
+            ->withoutBuildpackControlVariables(EnvironmentVariable::RUNTIME_BUILDPACK_VARIABLE_KEYS);
     }
 
     public function nixpacks_environment_variables()
@@ -1063,7 +1063,7 @@ class Application extends BaseModel
     {
         return $this->morphMany(EnvironmentVariable::class, 'resourceable')
             ->where('is_preview', true)
-            ->withoutBuildpackControlVariables();
+            ->withoutBuildpackControlVariables(EnvironmentVariable::RUNTIME_BUILDPACK_VARIABLE_KEYS);
     }
 
     public function nixpacks_environment_variables_preview()

--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -36,6 +36,11 @@ class EnvironmentVariable extends BaseModel
 {
     public const BUILDPACK_CONTROL_VARIABLE_PREFIXES = ['NIXPACKS_', 'RAILPACK_'];
 
+    public const RUNTIME_BUILDPACK_VARIABLE_KEYS = [
+        'NIXPACKS_PHP_FALLBACK_PATH',
+        'NIXPACKS_PHP_ROOT_DIR',
+    ];
+
     protected $attributes = [
         'is_runtime' => true,
         'is_buildtime' => true,
@@ -133,13 +138,23 @@ class EnvironmentVariable extends BaseModel
         return $this->belongsTo(Service::class);
     }
 
-    public function scopeWithoutBuildpackControlVariables(Builder $query): Builder
+    public function scopeWithoutBuildpackControlVariables(Builder $query, array $allowedKeys = []): Builder
     {
         foreach (self::BUILDPACK_CONTROL_VARIABLE_PREFIXES as $prefix) {
-            $query->where('key', 'not like', "{$prefix}%");
+            $query->where(function (Builder $query) use ($prefix, $allowedKeys) {
+                $query->where('key', 'not like', "{$prefix}%");
+                if ($allowedKeys !== []) {
+                    $query->orWhereIn('key', $allowedKeys);
+                }
+            });
         }
 
         return $query;
+    }
+
+    public static function isRuntimeBuildpackKey(?string $key): bool
+    {
+        return in_array($key, self::RUNTIME_BUILDPACK_VARIABLE_KEYS, true);
     }
 
     public static function isBuildpackControlKey(?string $key): bool

--- a/tests/Unit/EnvironmentVariableBuildpackControlTest.php
+++ b/tests/Unit/EnvironmentVariableBuildpackControlTest.php
@@ -72,3 +72,13 @@ it('rejects shared environment variable keys Docker cannot represent on the mode
         $env->key = 'BAD=KEY';
     })->toThrow(InvalidArgumentException::class, 'Docker-compatible');
 });
+
+it('only allows the Nixpacks PHP template variables at runtime', function (string $key, bool $allowed) {
+    expect(EnvironmentVariable::isRuntimeBuildpackKey($key))->toBe($allowed);
+})->with([
+    'root directory' => ['NIXPACKS_PHP_ROOT_DIR', true],
+    'fallback path' => ['NIXPACKS_PHP_FALLBACK_PATH', true],
+    'build-only Nixpacks control' => ['NIXPACKS_NODE_VERSION', false],
+    'build-only Railpack control' => ['RAILPACK_NODE_VERSION', false],
+    'ordinary variable' => ['APP_ENV', false],
+]);


### PR DESCRIPTION
Fixes #11628.

## The bug

@mpoweredo diagnosed this completely, including the regression boundary: since #9117 (v4.1.0), `scopeWithoutBuildpackControlVariables` strips every `NIXPACKS_`/`RAILPACK_` key from the runtime environment. That also strips `NIXPACKS_PHP_ROOT_DIR` and `NIXPACKS_PHP_FALLBACK_PATH` - the exact two keys the Nixpacks PHP prestart template reads at **container start** to render nginx's document root (`$if(NIXPACKS_PHP_ROOT_DIR) ( root ${NIXPACKS_PHP_ROOT_DIR}; ) else ( root /app; )`, nixpacks' own `nginx.template.conf`). Empty at runtime -> `root /app` -> every route 404s while `/public/index.php` still works, so the official Laravel guide's `nixpacks.toml` contradicts the runtime.

## The fix

Keep the global filter for build-control variables, but give the scope an allow-list (`RUNTIME_BUILDPACK_VARIABLE_KEYS` = exactly the two PHP template keys) and pass it through both runtime relations (production + preview). Build-time call sites are untouched. Adds a decision-table unit test: the two template keys allowed, other `NIXPACKS_` keys (e.g. `NIXPACKS_NODE_VERSION`) still excluded, unrelated variables unaffected.

## Tests

- Allow-list predicate semantics verified against the generated SQL shape (grouped `where (not like prefix OR key IN (allow))` per prefix).
- Nixpacks template cross-checked in the railwayapp/nixpacks repo.
- **Not run:** PHP/Pest (no PHP runtime in our build environment) - CI will run the suite.

> Built by breken, your AI support engineer - breken.ai - this one's on us.