### PR TITLE
fix(database): use MongoDB writable-primary health check

### DIFF
--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -109,11 +109,7 @@ class StartMongodb
                         $this->database->destination->network,
                     ],
                     'labels' => defaultDatabaseLabels($this->database)->toArray(),
-                    'healthcheck' => $this->database->healthCheckConfiguration([
-                        'CMD',
-                        'echo',
-                        'ok',
-                    ]),
+                    'healthcheck' => $this->database->healthCheckConfiguration($this->generate_health_check_command()),
                     'mem_limit' => $this->database->limits_memory,
                     'memswap_limit' => $this->database->limits_memory_swap,
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
@@ -322,6 +318,43 @@ class StartMongodb
         add_coolify_default_environment_variables($this->database, $environment_variables, $environment_variables);
 
         return $environment_variables->all();
+    }
+
+    private function generate_health_check_command(): array
+    {
+        $usesLegacyShell = str($this->database->image)->startsWith('mongo:4');
+        $command = [
+            'CMD',
+            $usesLegacyShell ? 'mongo' : 'mongosh',
+            '--quiet',
+            '--host',
+            $this->database->uuid,
+        ];
+
+        if ($this->database->enable_ssl) {
+            $command = [
+                ...$command,
+                $usesLegacyShell ? '--ssl' : '--tls',
+                $usesLegacyShell ? '--sslCAFile' : '--tlsCAFile',
+                '/etc/mongo/certs/ca.pem',
+            ];
+
+            if ($this->database->ssl_mode === 'verify-full') {
+                $command = [
+                    ...$command,
+                    $usesLegacyShell ? '--sslPEMKeyFile' : '--tlsCertificateKeyFile',
+                    '/etc/mongo/certs/server.pem',
+                ];
+            }
+        }
+
+        return [
+            ...$command,
+            '--eval',
+            $usesLegacyShell
+                ? 'quit(db.isMaster().ismaster === true ? 0 : 1)'
+                : 'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+        ];
     }
 
     private function add_custom_mongo_conf()

--- a/tests/Unit/StartMongodbHealthCheckTest.php
+++ b/tests/Unit/StartMongodbHealthCheckTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Actions\Database\StartMongodb;
+use App\Models\StandaloneMongodb;
+
+it('uses the generated MongoDB health check in the Compose configuration', function () {
+    $source = remoteOutputSource('app/Actions/Database/StartMongodb.php');
+
+    expect($source)
+        ->toContain("'healthcheck' => \$this->database->healthCheckConfiguration(\$this->generate_health_check_command())")
+        ->not->toContain("'healthcheck' => \$this->database->healthCheckConfiguration([\n                        'CMD',\n                        'echo',\n                        'ok'");
+});
+
+function generatedMongodbHealthCheckCommand(array $attributes): array
+{
+    $action = new StartMongodb;
+    $action->database = new StandaloneMongodb;
+    $action->database->setRawAttributes($attributes, true);
+    $method = new ReflectionMethod(StartMongodb::class, 'generate_health_check_command');
+
+    return $method->invoke($action);
+}
+
+it('generates a credential-free writable-primary MongoDB health check', function (string $image, bool $enableSsl, ?string $sslMode, array $expectedCommand) {
+    $command = generatedMongodbHealthCheckCommand([
+        'uuid' => 'mongodb-test-resource',
+        'image' => $image,
+        'enable_ssl' => $enableSsl,
+        'ssl_mode' => $sslMode,
+        'mongo_initdb_root_username' => 'root-user',
+        'mongo_initdb_root_password' => 'root-password',
+    ]);
+
+    expect($command)->toBe($expectedCommand)
+        ->and(implode(' ', $command))
+        ->not->toContain('root-user')
+        ->not->toContain('root-password')
+        ->not->toContain('--tlsAllowInvalidHostnames')
+        ->not->toContain('--tlsAllowInvalidCertificates');
+})->with([
+    'without TLS' => ['mongo:8', false, null, [
+        'CMD', 'mongosh', '--quiet', '--host', 'mongodb-test-resource', '--eval',
+        'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+    ]],
+    'TLS allow mode' => ['mongo:8', true, 'allow', [
+        'CMD', 'mongosh', '--quiet', '--host', 'mongodb-test-resource',
+        '--tls', '--tlsCAFile', '/etc/mongo/certs/ca.pem', '--eval',
+        'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+    ]],
+    'TLS prefer mode' => ['mongo:8', true, 'prefer', [
+        'CMD', 'mongosh', '--quiet', '--host', 'mongodb-test-resource',
+        '--tls', '--tlsCAFile', '/etc/mongo/certs/ca.pem', '--eval',
+        'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+    ]],
+    'TLS require mode' => ['mongo:8', true, 'require', [
+        'CMD', 'mongosh', '--quiet', '--host', 'mongodb-test-resource',
+        '--tls', '--tlsCAFile', '/etc/mongo/certs/ca.pem', '--eval',
+        'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+    ]],
+    'TLS verify-full mode' => ['mongo:8', true, 'verify-full', [
+        'CMD', 'mongosh', '--quiet', '--host', 'mongodb-test-resource',
+        '--tls',
+        '--tlsCAFile',
+        '/etc/mongo/certs/ca.pem',
+        '--tlsCertificateKeyFile',
+        '/etc/mongo/certs/server.pem',
+        '--eval',
+        'quit(db.hello().isWritablePrimary === true ? 0 : 1)',
+    ]],
+    'MongoDB 4 without TLS' => ['mongo:4.4', false, null, [
+        'CMD', 'mongo', '--quiet', '--host', 'mongodb-test-resource', '--eval',
+        'quit(db.isMaster().ismaster === true ? 0 : 1)',
+    ]],
+    'MongoDB 4 TLS require mode' => ['mongo:4.4', true, 'require', [
+        'CMD', 'mongo', '--quiet', '--host', 'mongodb-test-resource',
+        '--ssl', '--sslCAFile', '/etc/mongo/certs/ca.pem', '--eval',
+        'quit(db.isMaster().ismaster === true ? 0 : 1)',
+    ]],
+    'MongoDB 4 TLS verify-full mode' => ['mongo:4.4', true, 'verify-full', [
+        'CMD', 'mongo', '--quiet', '--host', 'mongodb-test-resource',
+        '--ssl',
+        '--sslCAFile',
+        '/etc/mongo/certs/ca.pem',
+        '--sslPEMKeyFile',
+        '/etc/mongo/certs/server.pem',
+        '--eval',
+        'quit(db.isMaster().ismaster === true ? 0 : 1)',
+    ]],
+]);


### PR DESCRIPTION
## Changes

- Replace the standalone MongoDB placeholder `CMD echo ok` health check with a credential-free writable-primary probe.
- Use `mongosh` and `db.hello().isWritablePrimary` for current images while preserving the existing MongoDB 4 compatibility convention with `mongo` and `db.isMaster().ismaster`.
- Validate the generated CA and database UUID when TLS is enabled, and present the existing in-container certificate in `verify-full` mode without exposing credentials or adding insecure TLS flags.
- Add focused regression coverage for non-TLS, every current TLS mode, and MongoDB 4 variants.

## Issues

- Fixes #11728
- #10481 was reviewed as a possible duplicate. It was a broader, closed `next`-branch change for configurable health-check timing and did not replace MongoDB's placeholder probe.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this changes the generated backend Compose health check and adds unit coverage.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex assisted with source analysis, implementation, tests, live command verification, and preparation of this pull request. The submitted diff and validation output were reviewed for scope, security, and compatibility before publication.

## Testing

- `php ~/composer.phar install --no-interaction --no-progress`: passed, including package discovery.
- `php ~/composer.phar check-platform-reqs --no-interaction`: passed for the selected PHP 8.4 runtime.
- `php artisan test --compact tests/Unit/StartMongodbHealthCheckTest.php`: 9 passed, 42 assertions, without a bootstrap shim.
- `vendor/bin/pint app/Actions/Database/StartMongodb.php tests/Unit/StartMongodbHealthCheckTest.php --format agent`: passed.
- `php -l` for both changed PHP files: passed.
- The exact modified files in the publication branch are byte-identical to the files used for the focused test and formatter run.
- On an existing non-production Coolify MongoDB 8 deployment, the exact strict-TLS `mongosh` writable-primary expression exited 0 while writable; the inverted expression exited 1. The `verify-full` command shape with the existing in-container certificate/key file also exited 0. These were read-only probes; this patch was not deployed there.
- `php artisan test --compact tests/Feature/DatabaseHealthCheckTest.php`: 6 passed and 1 failed. The remaining failure is the existing PostgreSQL health-check toggle assertion at line 172; the test and the exercised `App\Livewire\Project\Database\Health` and `StandalonePostgresql` code are unchanged by this PR.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this is not a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

The final agreement item remains unchecked because a complete local Coolify development instance was not available. Focused unit, formatting, syntax, and live command-level validation are listed above.
