### PR TITLE
fix(deployments): gzip compose before base64 transmission

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -727,9 +727,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
             $yaml = Yaml::dump(convertToArray($composeFile), 10);
         }
-        $this->docker_compose_base64 = base64_encode($yaml);
+        $this->docker_compose_base64 = base64_encode(gzencode($yaml, 9));
         $this->execute_remote_command([
-            executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}{$this->docker_compose_location} > /dev/null"),
+            executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee {$this->workdir}{$this->docker_compose_location} > /dev/null"),
             'hidden' => true,
         ]);
 
@@ -1112,7 +1112,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     "mkdir -p $mainDir",
                 ],
                 [
-                    "echo '{$this->docker_compose_base64}' | base64 -d | tee $composeFileName > /dev/null",
+                    "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee $composeFileName > /dev/null",
                 ],
                 [
                     "echo '{$readme}' > $mainDir/README.md",
@@ -3599,8 +3599,8 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
 
         $this->docker_compose = Yaml::dump($docker_compose, 10);
-        $this->docker_compose_base64 = base64_encode($this->docker_compose);
-        $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
+        $this->docker_compose_base64 = base64_encode(gzencode($this->docker_compose, 9));
+        $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
     }
 
     private function generate_local_persistent_volumes()


### PR DESCRIPTION
## Changes

Large compose stacks cannot deploy. The rendered compose is base64-encoded and passed as one argv, and the kernel caps a single argv at `MAX_ARG_STRLEN` (128 KiB). Past that every deploy fails with `posix_spawn() failed: Argument list too long` before anything reaches disk, naming neither the file nor the cause.

This compresses with `gzencode()` before encoding and pipes through `gunzip` on the way out. The written file is byte-identical; on an 89 KB compose the argv drops from 118680 to 8320 bytes. `gunzip` is already in coolify-helper (Alpine/BusyBox), so no new dependency.

Five lines: two encodes, three decodes.

## Issues

- Fixes #11737

Earlier attempts closed unmerged: #10402, #10403, #10664. #5447 was closed via a domains-only workaround that does not cover this variant.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: heavily. Patch, tests and this description were drafted with AI, then reviewed and verified by me on a local instance. Flagging it since the template asks for a human-written Changes section.

## Testing

Local dev instance, fresh `migrate:fresh --seed`:

1. Deployed the seeded Docker Compose Example with the patch: finished, five containers up on the testing host, written compose valid (195 lines, 5 services).
2. Same `proc_open` path, 143756-byte compose: unpatched argv 191729 bytes failed with `Argument list too long`; patched argv 9151 bytes exited 0, file matched byte for byte.
3. Confirmed `gunzip` exists in coolify-helper and the round trip is lossless there.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
