### PR TITLE
fix(service): allow desktop app origins in Buzz template CORS (#11044)

### DIFF
--- a/templates/compose/buzz.yaml
+++ b/templates/compose/buzz.yaml
@@ -16,7 +16,7 @@ services:
       - RELAY_URL=wss://${SERVICE_FQDN_BUZZ}
       - BUZZ_MEDIA_BASE_URL=${SERVICE_URL_BUZZ}/media
       - BUZZ_MEDIA_SERVER_DOMAIN=${SERVICE_FQDN_BUZZ}
-      - BUZZ_CORS_ORIGINS=${SERVICE_URL_BUZZ}
+      - BUZZ_CORS_ORIGINS=${SERVICE_URL_BUZZ},tauri://localhost,http://tauri.localhost
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-buzz}
       - REDIS_URL=redis://:${SERVICE_PASSWORD_REDIS}@redis:6379
       - BUZZ_S3_ENDPOINT=http://minio:9000


### PR DESCRIPTION
## Changes

Allow Buzz desktop application (Tauri webview) origins in the Buzz service template CORS configuration.

* Appends `tauri://localhost` (macOS) and `http://tauri.localhost` (Windows/Linux) to `BUZZ_CORS_ORIGINS`.
* Resolves the `Load failed` error when connecting the Buzz desktop app to a self-hosted Buzz community relay.
* Follows the official Buzz documentation and expected origin configuration in `crates/buzz-relay/src/config.rs` and `desktop/src-tauri/src/media_proxy.rs`.

## Issues

* Fixes #11044

## Category

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Adding new one click service
* [x] Fixing or updating existing one click service

## Preview

N/A — service compose template update.

## AI Assistance

* [ ] AI was NOT used to create this PR
* [x] AI was used (please describe below)

**If AI was used:**
* Tools used: Claude / GPT
* How extensively: Used to verify issue details and upstream Buzz relay CORS configuration references.

## Testing

* Confirmed `BUZZ_CORS_ORIGINS` parses comma-separated origins without breaking existing web URL origin.
* Verified YAML syntax and trailing newline adherence.

## Contributor Agreement

> [!IMPORTANT]
>
> * [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/main/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/main/CONTRIBUTING.md).
> * [x] I have searched [[existing issues](https://github.com/coollabsio/coolify/issues)](https://github.com/coollabsio/coolify/issues) and [[pull requests](https://github.com/coollabsio/coolify/pulls)](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> * [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
