### PR TITLE
fix(service): add explicit sqlite scheme to default DATABASE_URL for Vaultwarden (#11051)

### DIFF
--- a/templates/compose/vaultwarden.yaml
+++ b/templates/compose/vaultwarden.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - SERVICE_URL_VAULTWARDEN
       - DOMAIN=${SERVICE_URL_VAULTWARDEN}
-      - DATABASE_URL=${VAULTWARDEN_DB_URL:-data/db.sqlite3}
+      - DATABASE_URL=${VAULTWARDEN_DB_URL:-sqlite://data/db.sqlite3}
       - SIGNUPS_ALLOWED=${SIGNUP_ALLOWED:-true}
       - ADMIN_TOKEN=${SERVICE_PASSWORD_64_ADMIN}
       - IP_HEADER=X-Forwarded-For


### PR DESCRIPTION
## Changes

Add explicit sqlite scheme to default DATABASE_URL in Vaultwarden service template.

* Updates default database URL from data/db.sqlite3 to sqlite://data/db.sqlite3.
* Resolves startup crash on fresh installs running Vaultwarden 1.37.0 or newer.

## Issues

* Fixes #11051

## Category

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Adding new one click service
* [x] Fixing or updating existing one click service

## Preview

N/A — service compose template update.

## AI Assistance

* [ ] AI was NOT used to create this PR
* [x] AI was used (please describe below)

**If AI was used:**
* Tools used: Claude / GPT
* How extensively: Used to verify issue details and Vaultwarden validation specification.

## Testing

* Verified default value format matches Vaultwarden requirement.
* Verified YAML syntax and trailing newline compliance.

## Contributor Agreement

> [!IMPORTANT]
>
> * [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/main/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/main/CONTRIBUTING.md).
> * [x] I have searched [[existing issues](https://github.com/coollabsio/coolify/issues)](https://github.com/coollabsio/coolify/issues) and [[pull requests](https://github.com/coollabsio/coolify/pulls)](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> * [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
