### PR TITLE
fix: preserve repository paths for github and gitlab service website links

### DIFF
--- a/resources/views/livewire/project/new/select.blade.php
+++ b/resources/views/livewire/project/new/select.blade.php
@@ -469,7 +469,16 @@
                             if (!source) return null;
 
                             try {
-                                return new URL(source).origin;
+                                const url = new URL(source);
+                                const hostname = url.hostname.toLowerCase();
+                                if (hostname === 'github.com' || hostname === 'www.github.com' || hostname === 'gitlab.com' || hostname === 'www.gitlab.com') {
+                                    const pathSegments = url.pathname.split('/').filter(Boolean);
+                                    if (pathSegments.length >= 2) {
+                                        return `${url.protocol}//${url.hostname}/${pathSegments[0]}/${pathSegments[1]}`;
+                                    }
+                                    return url.href;
+                                }
+                                return url.origin;
                             } catch (error) {
                                 return null;
                             }

--- a/tests/Feature/ServiceTemplatesLastUpdatedHintTest.php
+++ b/tests/Feature/ServiceTemplatesLastUpdatedHintTest.php
@@ -174,3 +174,16 @@ it('preserves one click service key casing when selecting a service template', f
 
     expect($component->type)->toBe('one-click-service-denoKV');
 });
+
+it('formats service website links to preserve repository paths for github and gitlab', function () {
+    View::share('errors', new ViewErrorBag);
+
+    $view = $this->view('livewire.project.new.select', [
+        'current_step' => 'type',
+        'environments' => collect(),
+    ]);
+
+    $view->assertSee("hostname === 'github.com' || hostname === 'www.github.com' || hostname === 'gitlab.com' || hostname === 'www.gitlab.com'", false);
+    $view->assertSee('${url.protocol}//${url.hostname}/${pathSegments[0]}/${pathSegments[1]}', false);
+});
+


### PR DESCRIPTION
### Description
On the "Add New Resource -> Services" page, clicking the **Website** button on service cards whose documentation is hosted on GitHub (such as Alexandrie, Beszel, Uptime Kuma, IT-Tools, etc.) was stripping the owner/repository path and redirecting users to generic `https://github.com`.

### Solution
- Updated `serviceWebsiteUrl(service)` in `resources/views/livewire/project/new/select.blade.php` to parse `github.com` and `gitlab.com` URLs, preserving the `owner/repository` path (`https://github.com/owner/repo`).
- Added automated feature test coverage in `tests/Feature/ServiceTemplatesLastUpdatedHintTest.php`.

### Tests
- Added Pest feature test verifying `serviceWebsiteUrl` formatting in `select.blade.php`.
