### PR TITLE
fix(ui): open configuration diff modal directly when clicking changes pending badge

### DIFF
--- a/resources/views/components/configuration-warning.blade.php
+++ b/resources/views/components/configuration-warning.blade.php
@@ -2,7 +2,7 @@
 
 <div class="relative" x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false">
     <button type="button" aria-label="Configuration changes not applied" aria-haspopup="dialog"
-        :aria-expanded="open" @click="open = !open"
+        :aria-expanded="open" @click="{{ data_get($diff, 'count') ? "$dispatch('open-configuration-diff')" : 'open = !open' }}"
         class="flex h-8 items-center justify-center gap-1.5 rounded-lg px-2 text-amber-700 transition-colors hover:bg-amber-100 dark:text-warning dark:hover:bg-warning/10">
         <x-reicon name="alert-triangle" class="size-4" />
         <span class="hidden text-xs font-medium lg:inline">Changes pending</span>

--- a/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
+++ b/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
@@ -371,6 +371,12 @@ it('renders configuration warnings as navbar popovers instead of floating notifi
         ->toContain("\$dispatch('open-configuration-diff')");
 });
 
+it('dispatches open-configuration-diff directly when clicking changes pending with unapplied diffs', function () {
+    $warning = file_get_contents(resource_path('views/components/configuration-warning.blade.php'));
+
+    expect($warning)->toContain("@click=\"{{ data_get(\$diff, 'count') ? \"\$dispatch('open-configuration-diff')\" : 'open = !open' }}\"");
+});
+
 it('renders only one configuration warning on database runtime logs', function () {
     $logs = file_get_contents(resource_path('views/livewire/project/shared/logs.blade.php'));
     $databaseHeading = file_get_contents(resource_path('views/livewire/project/database/heading.blade.php'));


### PR DESCRIPTION
Fixes #11692

### Problem
Clicking the "Changes pending" navbar badge was opening a popover rather than directly triggering the configuration differences modal, requiring an extra click or failing to open the diff view.

### Solution
- Updated `@click` handler on `<x-configuration-warning>` in `resources/views/components/configuration-warning.blade.php` to dispatch `$dispatch('open-configuration-diff')` directly when unapplied configuration diffs are present.
- Added feature test coverage in `tests/Feature/ResourceHeadingUnifiedNavbarTest.php`.

### Tests
- Added Pest feature test verifying `open-configuration-diff` dispatch on `configuration-warning` click.