### PR TITLE
feat(ui): show container networks and add network connect/disconnect to resource views

### DIFF
--- a/app/Livewire/Project/Shared/ContainerNetworks.php
+++ b/app/Livewire/Project/Shared/ContainerNetworks.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\ServiceApplication;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class ContainerNetworks extends Component
+{
+    use AuthorizesRequests;
+
+    public $resource;
+
+    public Collection $connectedNetworks;
+
+    public Collection $availableNetworks;
+
+    public string $selectedNetwork = '';
+
+    public ?Server $server = null;
+
+    public ?string $containerName = null;
+
+    public bool $isSwarm = false;
+
+    public bool $isSupported = false;
+
+    public function mount()
+    {
+        $this->connectedNetworks = collect();
+        $this->availableNetworks = collect();
+        $this->refreshNetworks();
+    }
+
+    public function refreshNetworks()
+    {
+        try {
+            $this->authorize('view', $this->resource);
+            $this->connectedNetworks = collect();
+            $this->availableNetworks = collect();
+            $this->isSupported = false;
+            $this->resolveContainerContext();
+            if (! $this->server || ! $this->containerName) {
+                return;
+            }
+            $this->isSwarm = $this->server->isSwarm();
+            if ($this->isSwarm || ! $this->server->isFunctional()) {
+                return;
+            }
+            $this->isSupported = true;
+            $this->connectedNetworks = $this->getConnectedNetworks();
+            $this->availableNetworks = $this->getAvailableNetworks();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function connectNetwork()
+    {
+        try {
+            $this->authorize('update', $this->resource);
+            if (! $this->isSupported) {
+                $this->dispatch('error', 'Container networks cannot be managed right now.');
+
+                return;
+            }
+            if (str($this->selectedNetwork)->isEmpty()) {
+                $this->dispatch('error', 'Please select a network to connect.');
+
+                return;
+            }
+            if ($this->connectedNetworks->contains($this->selectedNetwork)) {
+                $this->dispatch('error', 'The container is already connected to this network.');
+
+                return;
+            }
+            $safeNetwork = escapeshellarg($this->selectedNetwork);
+            $safeContainer = escapeshellarg($this->containerName);
+            instant_remote_process(["docker network connect {$safeNetwork} {$safeContainer}"], $this->server);
+            $this->selectedNetwork = '';
+            $this->refreshNetworks();
+            $this->dispatch('success', 'Container connected to the network.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function disconnectNetwork(string $network)
+    {
+        try {
+            $this->authorize('update', $this->resource);
+            if (! $this->isSupported) {
+                $this->dispatch('error', 'Container networks cannot be managed right now.');
+
+                return;
+            }
+            if (! $this->connectedNetworks->contains($network)) {
+                return;
+            }
+            $safeNetwork = escapeshellarg($network);
+            $safeContainer = escapeshellarg($this->containerName);
+            instant_remote_process(["docker network disconnect {$safeNetwork} {$safeContainer}"], $this->server);
+            $this->refreshNetworks();
+            $this->dispatch('success', 'Container disconnected from the network.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    private function resolveContainerContext(): void
+    {
+        $this->server = null;
+        $this->containerName = null;
+        $this->isSwarm = false;
+        if (! $this->resource) {
+            return;
+        }
+        if ($this->resource instanceof Application) {
+            if (data_get($this->resource, 'build_pack') === 'dockercompose') {
+                return;
+            }
+            $this->server = $this->resource->destination->server;
+            $this->containerName = $this->resolveApplicationContainerName($this->server, $this->resource->id) ?? $this->resource->uuid;
+        } elseif ($this->resource instanceof ServiceApplication || $this->resource instanceof ServiceDatabase) {
+            $this->server = $this->resource->service->destination->server;
+            $this->containerName = "{$this->resource->name}-{$this->resource->service->uuid}";
+        } elseif (str($this->resource->getMorphClass())->startsWith('App\Models\Standalone')) {
+            $this->server = $this->resource->destination->server;
+            $this->containerName = $this->resource->uuid;
+        }
+    }
+
+    private function resolveApplicationContainerName(Server $server, int $applicationId): ?string
+    {
+        try {
+            $containers = getCurrentApplicationContainerStatus($server, $applicationId);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return data_get($containers->first(), 'Names');
+    }
+
+    private function getConnectedNetworks(): Collection
+    {
+        $container = getContainerStatus($this->server, $this->containerName, all_data: true, throwError: false);
+        if (! is_array($container)) {
+            return collect();
+        }
+        $networks = data_get($container, 'NetworkSettings.Networks', []);
+
+        return collect($networks)->keys()->values();
+    }
+
+    private function getAvailableNetworks(): Collection
+    {
+        $networks = instant_remote_process(['docker network ls --format "{{json .}}"'], $this->server, false);
+        if (! $networks) {
+            return collect();
+        }
+
+        return format_docker_command_output_to_json($networks)
+            ->filter(function ($network) {
+                $name = data_get($network, 'Name');
+
+                return $name !== 'bridge' && $name !== 'host' && $name !== 'none';
+            })
+            ->reject(fn ($network) => $this->connectedNetworks->contains(data_get($network, 'Name')))
+            ->map(fn ($network) => [
+                'name' => data_get($network, 'Name'),
+                'driver' => data_get($network, 'Driver'),
+            ])
+            ->values();
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.container-networks');
+    }
+}

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -144,6 +144,9 @@
                         </section>
                     </form>
 
+                    <livewire:project.shared.container-networks :resource="$serviceApplication"
+                        :key="'container-networks-'.$serviceApplication->uuid" lazy />
+
                     <x-domain-conflict-modal
                         :conflicts="$domainConflicts"
                         :showModal="$showDomainConflictModal"
@@ -333,6 +336,9 @@
                             </div>
                         </section>
                     </form>
+
+                    <livewire:project.shared.container-networks :resource="$serviceDatabase"
+                        :key="'container-networks-'.$serviceDatabase->uuid" lazy />
                 @endif
             @endif
         </div>

--- a/resources/views/livewire/project/shared/container-networks.blade.php
+++ b/resources/views/livewire/project/shared/container-networks.blade.php
@@ -1,0 +1,69 @@
+@if ($server && $containerName)
+    <x-application.settings-section id="container-networks-section" title="Networks"
+        helper="Networks the container is currently connected to. Connecting or disconnecting is applied to the container immediately, but it is not persisted and will be reset after a restart or redeploy unless the network is part of the resource configuration.">
+        @if (! $isSupported)
+            <x-callout type="info" title="{{ $isSwarm ? 'Docker Swarm' : 'Server unavailable' }}" class="mb-0">
+                @if ($isSwarm)
+                    Managing container networks from the UI is not supported for Swarm mode yet.
+                @else
+                    The server is currently unreachable, so the container networks cannot be loaded.
+                @endif
+            </x-callout>
+        @else
+            <div class="flex flex-col gap-4">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                    <p class="text-[13px] text-neutral-500 dark:text-fg-dim">
+                        @if ($connectedNetworks->isEmpty())
+                            This container is not connected to any network.
+                        @elseif ($connectedNetworks->count() === 1)
+                            This container is connected to 1 network.
+                        @else
+                            This container is connected to {{ $connectedNetworks->count() }} networks.
+                        @endif
+                    </p>
+                    <div class="flex items-center gap-2">
+                        <x-loading wire:loading wire:target="connectNetwork, disconnectNetwork, refreshNetworks" />
+                        <x-forms.button wire:click="refreshNetworks">Refresh</x-forms.button>
+                    </div>
+                </div>
+                @if ($connectedNetworks->isNotEmpty())
+                    <div class="divide-y divide-neutral-200 dark:divide-white/[0.07]">
+                        @foreach ($connectedNetworks as $network)
+                            <div class="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                                wire:key="connected-network-{{ $network }}">
+                                <div class="flex min-w-0 items-center gap-3">
+                                    <div
+                                        class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-neutral-100 text-neutral-500 ring-1 ring-neutral-200 dark:bg-white/[0.05] dark:text-fg-dim dark:ring-white/[0.07]">
+                                        <x-reicon name="network" class="size-[18px]" />
+                                    </div>
+                                    <code
+                                        class="truncate rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-xs text-neutral-700 dark:bg-white/[0.05] dark:text-fg-dim">{{ $network }}</code>
+                                </div>
+                                <x-forms.button canGate="update" :canResource="$resource"
+                                    wire:click="disconnectNetwork('{{ $network }}')">
+                                    Disconnect
+                                </x-forms.button>
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <x-empty size="sm" title="No networks connected"
+                        description="Connect this container to a network to communicate with other containers on it."
+                        icon-name="network" />
+                @endif
+                @if ($availableNetworks->isNotEmpty())
+                    <div class="flex flex-col gap-3 border-t border-neutral-200 pt-4 sm:flex-row sm:items-end sm:justify-between dark:border-white/[0.08]">
+                        <div class="w-full sm:max-w-xs">
+                            <x-forms.listbox id="selectedNetwork" label="Connect to a network" canGate="update"
+                                :canResource="$resource"
+                                :options="$availableNetworks->map(fn ($network) => ['value' => $network['name'], 'label' => $network['name']])->values()->all()" />
+                        </div>
+                        <x-forms.button canGate="update" :canResource="$resource" wire:click="connectNetwork">
+                            Connect
+                        </x-forms.button>
+                    </div>
+                @endif
+            </div>
+        @endif
+    </x-application.settings-section>
+@endif

--- a/resources/views/livewire/project/shared/destination.blade.php
+++ b/resources/views/livewire/project/shared/destination.blade.php
@@ -235,4 +235,6 @@
             </x-application.settings-section>
         </div>
     @endif
+
+    <livewire:project.shared.container-networks :resource="$resource" lazy />
 </div>


### PR DESCRIPTION
## Changes

Adds a Networks section to the individual resource pages: it shows which Docker networks a container is currently connected to, and lets you connect or disconnect it without redeploying.

- New shared Livewire component: resolves the real container of an application, service application, service database or standalone database, reads its current networks live via docker inspect, lists the server networks via docker network ls, and connects/disconnects the container with the same Docker commands the codebase uses for the proxy.
- New Blade view styled like the existing settings cards, lazy-loaded so SSH calls never block page load. Callouts for Docker Swarm and unreachable servers; hidden for Docker Compose apps.
- Shown on the Servers tab of standalone databases and applications, and on the General page of each container in a service stack. Runtime connects are not persisted and reset on redeploy; the helper text in the section says so.

## Issues

- Improves #2495: see which networks a container is in, and connect containers to networks from the UI after creation, including standalone databases which have no network option today. Left out for now: network selection at creation time, IPv6, and the container info items from that issue.

/claim #2495

## Category

- [x] Improvement

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

- Tools used: ZCode agent (GLM) with gh CLI
- How extensively: drafted by the agent, reviewed and submitted by me

## Testing

- php -l passes on the changed PHP file. pint and the Pest suite were not runnable here (no vendor directory, no Docker), so the changes were hand-verified against existing component APIs and patterns.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

> **Disclosure:** This PR was authored by @Furox-Art (AI-assisted). Happy to adjust anything.
