### PR TITLE
feat(server): Docker images management view

### DIFF
--- a/app/Livewire/Server/DockerImages.php
+++ b/app/Livewire/Server/DockerImages.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Livewire\Server;
+
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DockerImages extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public array $parameters = [];
+
+    public array $images = [];
+
+    public string $search = '';
+
+    public bool $loaded = false;
+
+    public function mount(string $server_uuid)
+    {
+        try {
+            $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+            $this->parameters = get_route_parameters();
+        } catch (\Throwable) {
+            return redirect()->route('server.index');
+        }
+    }
+
+    public function load(): void
+    {
+        try {
+            if ($this->server->isFunctional()) {
+                $containersByImage = $this->containersByImage();
+                $this->images = format_docker_command_output_to_json(
+                    instant_remote_process(["docker image ls --no-trunc --format '{{json .}}'"], $this->server, false)
+                )
+                    ->map(fn (array $image) => $this->summarize($image, $containersByImage))
+                    ->values()
+                    ->all();
+            }
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        } finally {
+            $this->loaded = true;
+        }
+    }
+
+    public function delete(string $reference)
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $image = collect($this->images)->firstWhere('reference', $reference);
+            if ($image === null) {
+                throw new \RuntimeException('This image is no longer listed. Refresh and try again.');
+            }
+            if ($image['usedBy'] !== []) {
+                throw new \RuntimeException('Image is in use by: '.implode(', ', $image['usedBy']));
+            }
+            instant_remote_process(['docker rmi '.escapeshellarg($reference)], $this->server);
+            auditLog('ui.server.docker_image_deleted', [
+                'team_id' => $this->server->team_id,
+                'server_uuid' => $this->server->uuid,
+                'server_name' => $this->server->name,
+                'image' => $reference,
+            ]);
+            $this->dispatch('success', "Image {$reference} deleted.");
+            $this->load();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function deleteUnused()
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $unused = collect($this->images)
+                ->filter(fn (array $image) => $image['usedBy'] === [])
+                ->pluck('reference')
+                ->values();
+            if ($unused->isEmpty()) {
+                throw new \RuntimeException('There are no unused images to delete.');
+            }
+            $references = $unused->map(fn (string $reference) => escapeshellarg($reference))->implode(' ');
+            instant_remote_process(["docker rmi {$references}"], $this->server);
+            auditLog('ui.server.docker_unused_images_deleted', [
+                'team_id' => $this->server->team_id,
+                'server_uuid' => $this->server->uuid,
+                'server_name' => $this->server->name,
+                'images' => $unused->all(),
+            ]);
+            $this->dispatch('success', $unused->count().' unused image(s) deleted.');
+            $this->load();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function unusedCount(): int
+    {
+        return collect($this->images)->filter(fn (array $image) => $image['usedBy'] === [])->count();
+    }
+
+    private function containersByImage(): array
+    {
+        return format_docker_command_output_to_json(
+            instant_remote_process(["docker ps -a --format '{{json .}}'"], $this->server, false)
+        )
+            ->groupBy(fn (array $container) => $this->normalizeReference((string) data_get($container, 'Image')))
+            ->map(fn ($containers) => $containers
+                ->map(fn (array $container) => ltrim((string) data_get($container, 'Names'), '/'))
+                ->sort()
+                ->values()
+                ->all())
+            ->all();
+    }
+
+    // `docker ps` shows whatever reference the container was created with, so
+    // "nginx" and "nginx:latest" must map to the same image list entry.
+    private function normalizeReference(string $reference): string
+    {
+        if ($reference === '') {
+            return $reference;
+        }
+        $slash = strrpos($reference, '/');
+        $colon = strrpos($reference, ':');
+        if ($colon !== false && ($slash === false || $colon > $slash)) {
+            return $reference;
+        }
+
+        return $reference.':latest';
+    }
+
+    private function summarize(array $image, array $containersByImage): array
+    {
+        $repository = (string) data_get($image, 'Repository');
+        $tag = (string) data_get($image, 'Tag');
+        $id = (string) data_get($image, 'ID');
+        $dangling = $repository === '<none>' || $tag === '<none>';
+        $reference = $dangling ? $id : $this->normalizeReference("{$repository}:{$tag}");
+        $usedBy = $containersByImage[$reference] ?? $containersByImage[$id] ?? [];
+
+        return [
+            'id' => $id,
+            'shortId' => str($id)->after('sha256:')->limit(12, '')->value(),
+            'repository' => $repository,
+            'tag' => $tag,
+            'dangling' => $dangling,
+            'reference' => $reference,
+            'size' => data_get($image, 'Size'),
+            'created' => data_get($image, 'CreatedSince'),
+            'usedBy' => $usedBy,
+        ];
+    }
+
+    public function render()
+    {
+        $search = trim($this->search);
+        $visibleImages = collect($this->images);
+        if ($search !== '') {
+            $visibleImages = $visibleImages->filter(fn (array $image) => str($image['repository'].' '.$image['tag'].' '.$image['shortId'])
+                ->contains($search, ignoreCase: true));
+        }
+
+        return view('livewire.server.docker-images', [
+            'visibleImages' => $visibleImages->values(),
+        ]);
+    }
+}

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -109,6 +109,14 @@
             'visible' => ! $server->isBuildServer() && ! $server->settings->is_cloudflare_tunnel,
         ],
         [
+            'label' => 'Images',
+            'route' => 'server.docker-images',
+            'active' => $activeMenu === 'docker-images',
+            'icon' => 'storages',
+            'group' => 'Operations',
+            'visible' => $server->isFunctional(),
+        ],
+        [
             'label' => 'Docker Cleanup',
             'route' => 'server.docker-cleanup',
             'active' => $activeMenu === 'docker-cleanup',

--- a/resources/views/livewire/server/docker-images.blade.php
+++ b/resources/views/livewire/server/docker-images.blade.php
@@ -1,0 +1,124 @@
+<div wire:init="load">
+    <x-slot:title>
+        {{ data_get_str($server, 'name')->limit(10) }} > Images | Coolify
+    </x-slot>
+
+    <livewire:server.navbar :server="$server" />
+
+    <div
+        class="server-settings-workspace application-settings-workspace mt-4 grid w-full max-w-none min-w-0 gap-8 lg:mt-0 xl:grid-cols-[210px_minmax(0,1fr)] xl:gap-8">
+        <x-server.sidebar :server="$server" activeMenu="docker-images" />
+
+        <div class="application-settings-form w-full min-w-0">
+            <x-application.settings-section id="server-docker-images-section" title="Docker images"
+                helper="Images stored on this server. Images that no container uses are marked unused and can be deleted."
+                flush>
+                <x-slot:actions>
+                    @if ($loaded && $server->isFunctional() && $this->unusedCount() > 0)
+                        @can('update', $server)
+                            <x-modal-confirmation title="Delete unused images?"
+                                buttonTitle="Delete unused images" submitAction="deleteUnused"
+                                :actions="[
+                                    'Deletes all images that are not used by any container.',
+                                    'Old application images are removed, so rollback to previous versions may stop working.',
+                                ]" :confirmWithText="false" :confirmWithPassword="false"
+                                step2ButtonText="Delete unused images" />
+                        @endcan
+                    @endif
+                    <x-forms.button wire:click="load">
+                        <x-reicon name="refresh" class="size-3.5" />
+                        Refresh
+                    </x-forms.button>
+                </x-slot:actions>
+
+                @if (! $server->isFunctional())
+                    <div class="p-6">
+                        <x-callout type="warning" title="Server is not functional">
+                            Validate and connect this server before managing its Docker images.
+                        </x-callout>
+                    </div>
+                @elseif (! $loaded)
+                    <div class="p-6">
+                        <x-loading text="Reading images from the Docker daemon" />
+                    </div>
+                @else
+                    <div class="border-b border-neutral-200 p-3 dark:border-white/[0.08]">
+                        <div class="relative w-full max-w-sm">
+                            <x-reicon name="search"
+                                class="pointer-events-none absolute top-1/2 left-2.5 z-10 size-3.5 -translate-y-1/2 text-neutral-400 dark:text-fg-faint" />
+                            <input wire:model.live.debounce.300ms="search" type="search"
+                                placeholder="Search by repository, tag or image ID" aria-label="Search images"
+                                class="h-8! w-full rounded-lg! border-neutral-200! bg-white! py-0! pr-8! pl-8! text-[12px]! shadow-none! placeholder:text-neutral-400 focus:border-accent! focus:ring-0! dark:border-white/[0.08]! dark:bg-white/[0.035]! dark:text-fg! dark:placeholder:text-fg-faint">
+                        </div>
+                    </div>
+
+                    @if ($visibleImages->isEmpty())
+                        <div class="p-6">
+                            <x-empty size="sm"
+                                :title="trim($search) !== '' ? 'No matching images' : 'No images found'"
+                                :description="trim($search) !== ''
+                                    ? 'Try another repository, tag or ID, or clear the search.'
+                                    : 'Images pulled or built on this server will appear here.'"
+                                icon-name="storages" />
+                        </div>
+                    @else
+                        <div class="hidden items-center gap-3 border-b border-neutral-200 px-4 py-2 text-[11px] font-medium tracking-wide text-neutral-500 uppercase md:flex dark:border-white/[0.08] dark:text-fg-dim">
+                            <span class="min-w-0 flex-1">Image</span>
+                            <span class="min-w-0 flex-1">Used by</span>
+                            <span class="hidden w-28 shrink-0 lg:block">Image ID</span>
+                            <span class="hidden w-24 shrink-0 lg:block">Created</span>
+                            <span class="w-20 shrink-0">Size</span>
+                            <span class="w-20 shrink-0"></span>
+                        </div>
+                        @foreach ($visibleImages as $image)
+                            <div wire:key="docker-image-{{ $image['reference'] }}"
+                                class="flex flex-wrap items-center gap-3 border-b border-neutral-200 px-4 py-3 last:border-b-0 md:flex-nowrap dark:border-white/[0.08]">
+                                <div class="min-w-0 flex-1">
+                                    <p class="truncate text-[13px] font-medium text-neutral-950 dark:text-fg"
+                                        title="{{ $image['reference'] }}">
+                                        {{ $image['repository'] }}
+                                        <span class="font-normal text-neutral-500 dark:text-fg-dim">:{{ $image['tag'] }}</span>
+                                    </p>
+                                    @if ($image['dangling'])
+                                        <x-status-badge status="Dangling" type="warning" class="mt-1" />
+                                    @endif
+                                </div>
+                                <div class="min-w-0 flex-1">
+                                    @if ($image['usedBy'] === [])
+                                        <x-status-badge status="Unused" type="warning" />
+                                    @else
+                                        <span class="block truncate text-[11px] text-neutral-600 dark:text-fg-dim"
+                                            title="{{ implode(', ', $image['usedBy']) }}">
+                                            {{ implode(', ', $image['usedBy']) }}
+                                        </span>
+                                    @endif
+                                </div>
+                                <div class="hidden w-28 shrink-0 items-center gap-1 lg:flex">
+                                    <span class="truncate font-mono text-[11px] text-neutral-600 dark:text-fg-dim">
+                                        {{ $image['shortId'] }}
+                                    </span>
+                                    <x-copy-button :value="$image['id']" label="Copy image ID" />
+                                </div>
+                                <div class="hidden w-24 shrink-0 truncate text-[11px] text-neutral-600 lg:block dark:text-fg-dim">
+                                    {{ $image['created'] }}
+                                </div>
+                                <div class="w-20 shrink-0 truncate text-[11px] text-neutral-600 dark:text-fg-dim">
+                                    {{ $image['size'] }}
+                                </div>
+                                <div class="w-20 shrink-0 text-right">
+                                    @if ($image['usedBy'] === [])
+                                        <x-forms.button canGate="update" :canResource="$server" isError
+                                            wire:click="delete('{{ $image['reference'] }}')"
+                                            wire:confirm="Delete {{ $image['reference'] }} from this server? It has to be pulled or built again before it can be used.">
+                                            Delete
+                                        </x-forms.button>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
+                @endif
+            </x-application.settings-section>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,7 @@ use App\Livewire\Server\CreatePage as ServerCreatePage;
 use App\Livewire\Server\Delete as DeleteServer;
 use App\Livewire\Server\Destinations as ServerDestinations;
 use App\Livewire\Server\DockerCleanup;
+use App\Livewire\Server\DockerImages;
 use App\Livewire\Server\Index as ServerIndex;
 use App\Livewire\Server\LogDrains;
 use App\Livewire\Server\PrivateKey\Show as PrivateKeyShow;
@@ -388,6 +389,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/proxy/logs', ProxyLogs::class)->name('server.proxy.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('server.command')->middleware('can.access.terminal');
         Route::get('/docker-cleanup', DockerCleanup::class)->name('server.docker-cleanup');
+        Route::get('/images', DockerImages::class)->name('server.docker-images');
         Route::get('/security', fn () => redirect(route('dashboard')))->name('server.security')->middleware('can.update.resource');
         Route::get('/security/patches', Patches::class)->name('server.security.patches')->middleware('can.update.resource');
         Route::get('/security/terminal-access', TerminalAccess::class)->name('server.security.terminal-access')->middleware('can.update.resource');

--- a/tests/Feature/ServerDockerImagesTest.php
+++ b/tests/Feature/ServerDockerImagesTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Livewire\Server\DockerImages;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create(['id' => 0]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    $privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    $this->server = Server::factory()->create(['team_id' => $this->team->id, 'private_key_id' => $privateKey->id]);
+    $this->server->settings->update(['is_reachable' => true, 'is_usable' => true]);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+$latestId = 'sha256:'.str_repeat('a', 64);
+$oldId = 'sha256:'.str_repeat('b', 64);
+$danglingId = 'sha256:'.str_repeat('c', 64);
+
+$fakeDocker = function () use ($latestId, $oldId, $danglingId) {
+    Process::fake([
+        '*docker image ls*' => Process::result(output: implode("\n", [
+            json_encode(['Repository' => 'nginx', 'Tag' => 'latest', 'ID' => $latestId, 'Size' => '52.5MB', 'CreatedSince' => '3 weeks ago']),
+            json_encode(['Repository' => 'nginx', 'Tag' => '1.27', 'ID' => $oldId, 'Size' => '52.2MB', 'CreatedSince' => '2 months ago']),
+            json_encode(['Repository' => '<none>', 'Tag' => '<none>', 'ID' => $danglingId, 'Size' => '11MB', 'CreatedSince' => '2 days ago']),
+        ])),
+        '*docker ps -a*' => Process::result(output: implode("\n", [
+            json_encode(['Image' => 'nginx', 'Names' => '/coolify-web']),
+            json_encode(['Image' => $danglingId, 'Names' => '/oneoff-worker']),
+        ])),
+        '*docker rmi*' => Process::result(output: 'Deleted'),
+    ]);
+};
+
+it('renders the docker images page for a server', function () use ($fakeDocker) {
+    $fakeDocker();
+
+    $this->get(route('server.docker-images', ['server_uuid' => $this->server->uuid]))
+        ->assertOk()
+        ->assertSee('Docker images');
+});
+
+it('lists images and marks the ones no container uses', function () use ($fakeDocker, $danglingId) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->assertSet('loaded', true)
+        ->assertSet('images.0.repository', 'nginx')
+        ->assertSet('images.0.reference', 'nginx:latest')
+        ->assertSet('images.0.usedBy', ['coolify-web'])
+        ->assertSet('images.1.reference', 'nginx:1.27')
+        ->assertSet('images.1.usedBy', [])
+        ->assertSet('images.2.reference', $danglingId)
+        ->assertSet('images.2.dangling', true)
+        ->assertSee('Unused');
+});
+
+it('matches a container created without an explicit tag and one pinned to an image ID', function () use ($fakeDocker) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->assertSet('images.0.usedBy', ['coolify-web'])
+        ->assertSet('images.1.usedBy', [])
+        ->assertSet('images.2.usedBy', ['oneoff-worker']);
+});
+
+it('deletes an unused image', function () use ($fakeDocker, $oldId) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->call('delete', 'nginx:1.27')
+        ->assertDispatched('success');
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'docker rmi') && str_contains($process->command, 'nginx:1.27'));
+});
+
+it('refuses to delete an image that a container is using', function () use ($fakeDocker) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->call('delete', 'nginx:latest')
+        ->assertDispatched('error');
+
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'docker rmi'));
+});
+
+it('refuses to delete an image reference that is not listed', function () use ($fakeDocker) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->call('delete', 'alpine:latest')
+        ->assertDispatched('error');
+
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'docker rmi'));
+});
+
+it('deletes all unused images at once', function () use ($fakeDocker, $danglingId) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->call('deleteUnused')
+        ->assertDispatched('success');
+
+    Process::assertRan(function ($process) use ($danglingId) {
+        return str_contains($process->command, 'docker rmi')
+            && str_contains($process->command, 'nginx:1.27')
+            && ! str_contains($process->command, 'nginx:latest')
+            && ! str_contains($process->command, $danglingId);
+    });
+});
+
+it('filters images by the search term', function () use ($fakeDocker) {
+    $fakeDocker();
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->call('load')
+        ->set('search', '1.27')
+        ->assertSee(str_repeat('b', 12))
+        ->assertDontSee(str_repeat('a', 12));
+});
+
+it('redirects users of another team away from the page', function () {
+    $otherTeam = Team::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherTeam->members()->attach($otherUser->id, ['role' => 'owner']);
+    $this->actingAs($otherUser);
+    session(['currentTeam' => $otherTeam]);
+
+    Livewire::test(DockerImages::class, ['server_uuid' => $this->server->uuid])
+        ->assertRedirect(route('server.index'));
+});


### PR DESCRIPTION
## Changes

Adds an "Images" section to the server page listing the Docker images stored on a server.

- New server page (Livewire component + Blade view, route, sidebar entry) reading images via `docker image ls` (repository, tag, ID, created, size, used by).
- Images no container uses (including dangling ones) are marked "Unused"; delete them individually with confirmation or all at once with "Delete unused images".
- Usage detection runs `docker ps -a`, normalizing implicit latest tags and ID pins; removal goes through `docker rmi`, so the daemon stays the final guard.
- Follows existing server-page conventions (settings-section, sidebar, auditLog, handleError) and includes Pest tests for listing, unused detection, deletes, refusals, search, cross-team access.

This overlaps with #11689 but adds bulk unused-image deletion, search and a cross-team test, with no CSS changes.

## Issues

- Improves #2499: list a server's images, mark unused ones, and delete selected or unused images; other checklist items there are out of scope here.

/claim #2499

## Category

- [x] New feature

## Preview

No screenshot available here; happy to attach one on request. Server > Images shows a search bar, an image table with usage info, a Delete button per unused image, and a bulk-delete modal.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

- Tools used: ZCode agent (GLM) with gh CLI
- How extensively: drafted by the agent, reviewed and submitted by me

## Testing

- php -l passes on the changed files. Pint/Pest not runnable here (no vendor, no Docker); changes hand-verified against existing component APIs and covered by the new tests in tests/Feature/ServerDockerImagesTest.php.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

> **Disclosure:** This PR was authored by @Furox-Art (AI-assisted). Happy to adjust anything.
