### PR TITLE
fix(proxy): enable IPv6 on proxy ingress network to preserve client IP

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify').' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1729,7 +1729,7 @@ $siteAddress {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify').' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -52,9 +52,7 @@ class StandaloneDocker extends BaseModel
 
     public function networkCreateCommand(): string
     {
-        $safeNetwork = escapeshellarg($this->network);
-
-        return "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --attachable {$safeNetwork} >/dev/null";
+        return dockerNetworkCreateCommand($this->network);
     }
 
     public function setNetworkAttribute(string $value): void

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -191,6 +191,22 @@ function format_docker_envs_to_json($rawOutput)
         return collect([]);
     }
 }
+
+/**
+ * Command that ensures a standalone Docker network exists, preferring an
+ * IPv6-enabled network so the proxy receives real IPv6 client addresses
+ * instead of the docker-proxy gateway IP in X-Forwarded-For.
+ *
+ * Falls back to an IPv4-only network when the daemon cannot allocate an
+ * IPv6 subnet (Docker < 27 without IPv6 configured in daemon.json).
+ */
+function dockerNetworkCreateCommand(string $network): string
+{
+    $safeNetwork = escapeshellarg($network);
+
+    return "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --attachable --ipv6 {$safeNetwork} >/dev/null 2>&1 || docker network create --attachable {$safeNetwork} >/dev/null";
+}
+
 function checkMinimumDockerEngineVersion($dockerVersion)
 {
     $majorDockerVersion = (int) str($dockerVersion)->before('.')->value();

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -160,7 +160,7 @@ function ensureProxyNetworksExist(Server $server)
 
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+it('generates a command that checks for the network, prefers IPv6 and falls back to IPv4-only', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)->toBe(
+        "docker network inspect 'coolify' >/dev/null 2>&1"
+        .' || docker network create --attachable --ipv6 \'coolify\' >/dev/null 2>&1'
+        .' || docker network create --attachable \'coolify\' >/dev/null'
+    );
+});
+
+it('skips creation when the network already exists', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)->toStartWith("docker network inspect 'coolify'");
+});
+
+it('escapes the network name in every part of the command', function () {
+    $command = dockerNetworkCreateCommand('net; rm -rf /');
+
+    expect($command)
+        ->toContain("inspect 'net; rm -rf /'")
+        ->toContain("--ipv6 'net; rm -rf /'")
+        ->toContain("--attachable 'net; rm -rf /' >/dev/null");
+});

--- a/tests/Unit/DockerNetworkInjectionTest.php
+++ b/tests/Unit/DockerNetworkInjectionTest.php
@@ -27,12 +27,12 @@ it('StandaloneDocker accepts valid network names', function (string $network) {
     'alphanumeric' => 'network123',
 ]);
 
-it('creates standalone destinations with a bridge network', function () {
+it('creates standalone destinations with an IPv6-enabled network and falls back to IPv4-only', function () {
     $model = new StandaloneDocker;
     $model->network = 'test-network';
 
     expect($model->networkCreateCommand())
-        ->toBe("docker network inspect 'test-network' >/dev/null 2>&1 || docker network create --attachable 'test-network' >/dev/null");
+        ->toBe("docker network inspect 'test-network' >/dev/null 2>&1 || docker network create --attachable --ipv6 'test-network' >/dev/null 2>&1 || docker network create --attachable 'test-network' >/dev/null");
 });
 
 it('SwarmDocker rejects network names with shell metacharacters', function (string $network) {


### PR DESCRIPTION
## Changes

Coolify created its standalone proxy ingress network (`coolify`) as IPv4-only. When an external client connects via IPv6, the connection routes through the Linux userland `docker-proxy`, causing Traefik and Caddy to observe the internal Docker bridge gateway IP (e.g. 172.18.0.1) in the `X-Forwarded-For` header instead of the true visitor IP.

This PR introduces a centralized helper `dockerNetworkCreateCommand()` that:
1. Skips recreation if the network already exists (`docker network inspect`).
2. Attempts to create an attachable bridge network with `--ipv6` so the proxy receives the true client IPv6 address.
3. Automatically falls back to the previous IPv4-only creation command when the host Docker daemon does not support IPv6 address pools.

The helper is integrated consistently across proxy network creation, standalone Docker destinations, server network validation, and initial Docker installation. Swarm overlay networks remain untouched.

## Issues

- Fixes #3436

/claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Assisted with tracing network creation call sites and drafting test assertions; implementation and shell safety were manually verified.

## Testing

- Added `tests/Unit/DockerNetworkCreateCommandTest.php` validating network inspection, dual-stack fallback chaining, and shell argument escaping.
- Updated `tests/Unit/DockerNetworkInjectionTest.php` to match the enhanced command structure.
- Verified shell escaping with `escapeshellarg()` on inputs to prevent injection.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
