### PR TITLE
fix(deploy): validate build secrets and escape Compose env values

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1403,7 +1403,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             });
 
             foreach ($runtime_environment_variables as $env) {
-                $envs->push($env->key.'='.$env->getResolvedValueWithServer($this->mainServer));
+                $envs->push($this->runtimeEnvironmentAssignment($env));
             }
 
             // Check for PORT environment variable mismatch with ports_exposes
@@ -1470,7 +1470,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             });
 
             foreach ($runtime_environment_variables_preview as $env) {
-                $envs->push($env->key.'='.$env->getResolvedValueWithServer($this->mainServer));
+                $envs->push($this->runtimeEnvironmentAssignment($env));
             }
 
             // Fall back to production env vars for keys not overridden by preview vars,
@@ -1484,7 +1484,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     return $env->is_runtime && ! in_array($env->key, $previewKeys);
                 });
                 foreach ($fallback_production_vars as $env) {
-                    $envs->push($env->key.'='.$env->getResolvedValueWithServer($this->mainServer));
+                    $envs->push($this->runtimeEnvironmentAssignment($env));
                 }
             }
 
@@ -1502,6 +1502,23 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         // Return the generated environment variables instead of storing them globally
         return $envs;
+    }
+
+    private function runtimeEnvironmentAssignment(EnvironmentVariable $environmentVariable): string
+    {
+        $resolvedValue = $environmentVariable->get_real_environment_variables_with_server(
+            $environmentVariable->value,
+            $environmentVariable->resourceable,
+            $this->mainServer,
+        );
+        $isJson = json_validate((string) $resolvedValue)
+            && (str_starts_with((string) $resolvedValue, '{') || str_starts_with((string) $resolvedValue, '['));
+        $allowInterpolation = ! $isJson && ! $environmentVariable->is_literal && ! $environmentVariable->is_multiline;
+
+        return $environmentVariable->key.'='.escapeComposeEnvFileValue(
+            $resolvedValue,
+            allowInterpolation: $allowInterpolation,
+        );
     }
 
     private function isGeneratedDockerComposeEnvironmentVariable(EnvironmentVariable $environmentVariable): bool

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1925,6 +1925,24 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
     }
 
+    private function assertDockerSecretCompatibleKeys(Collection $variables, string $origin): void
+    {
+        $incompatibleKeys = $variables->keys()
+            ->map(fn ($key): string => (string) $key)
+            ->filter(fn (string $key): bool => ! ValidationPatterns::isDockerSecretCompatibleKey($key))
+            ->values();
+
+        if ($incompatibleKeys->isEmpty()) {
+            return;
+        }
+
+        $this->logDottedDockerSecretKeys($incompatibleKeys->all(), $origin);
+
+        throw new DeploymentException(
+            'Dotted build-time environment variable names cannot be passed as Docker build secrets: '.$incompatibleKeys->implode(', ').'. Rename these keys to use underscores instead of dots, or disable build secrets and use a Dockerfile ARG.'
+        );
+    }
+
     private function save_buildtime_environment_variables()
     {
         $environment_variables = $this->generate_buildtime_environment_variables();
@@ -2875,6 +2893,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function railpack_build_secret_flags(Collection $variables): string
     {
+        $this->assertDockerSecretCompatibleKeys($variables, 'Railpack build secrets');
+
         if ($variables->isEmpty()) {
             return '';
         }
@@ -4400,6 +4420,8 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
     private function generate_build_secrets(Collection $variables)
     {
+        $this->assertDockerSecretCompatibleKeys($variables, 'Docker build secrets');
+
         if ($variables->isEmpty()) {
             $this->build_secrets = '';
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1911,12 +1911,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     private function save_buildtime_environment_variables()
     {
         $environment_variables = $this->generate_buildtime_environment_variables();
-        $shell_environment_variables = $environment_variables->filter(function (string $environmentVariable): bool {
-            [$key] = explode('=', $environmentVariable, 2);
-
-            return preg_match(ValidationPatterns::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $key) === 1;
-        });
-        $dotted_environment_variables = $environment_variables->reject(function (string $environmentVariable): bool {
+        [$shell_environment_variables, $dotted_environment_variables] = $environment_variables->partition(function (string $environmentVariable): bool {
             [$key] = explode('=', $environmentVariable, 2);
 
             return preg_match(ValidationPatterns::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $key) === 1;
@@ -4297,7 +4292,11 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
         if ($requiresDottedEnvironmentSecrets) {
             if (! $this->dockerSecretsAvailable) {
-                throw new DeploymentException('Dotted Nixpacks build-time environment variable names require Docker BuildKit support.');
+                $dottedKeys = $variables->keys()
+                    ->filter(fn ($key): bool => str_contains((string) $key, '.'))
+                    ->implode(', ');
+
+                throw new DeploymentException("Dotted Nixpacks build-time environment variable names require Docker BuildKit secret support: {$dottedKeys}. Rename these keys to use underscores instead of dots, or upgrade Docker on the build server.");
             }
 
             $this->dockerSecretsSupported = true;

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1631,11 +1631,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
 
                 foreach ($planVariables as $key => $value) {
+                    $key = (string) $key;
+
                     // Skip COOLIFY_* and SERVICE_* - they'll be added later with higher priority
                     if (str_starts_with($key, 'COOLIFY_') || str_starts_with($key, 'SERVICE_')) {
                         continue;
                     }
 
+                    $key = $this->validatedBuildtimeEnvironmentVariableKey($key, 'the Nixpacks plan');
                     $escapedValue = escapeBashEnvValue($value);
                     $envs_dict[$key] = $escapedValue;
 
@@ -1823,6 +1826,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         // Convert dictionary back to collection in KEY=VALUE format
         $envs = collect([]);
         foreach ($envs_dict as $key => $value) {
+            $key = $this->validatedBuildtimeEnvironmentVariableKey((string) $key, 'the build-time environment');
             $envs->push($key.'='.$value);
         }
 
@@ -1834,6 +1838,55 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
 
         return $envs;
+    }
+
+    private function validatedBuildtimeEnvironmentVariableKey(string $key, string $origin): string
+    {
+        try {
+            return ValidationPatterns::validatedShellEnvironmentVariableKey($key);
+        } catch (\InvalidArgumentException $exception) {
+            $this->logInvalidBuildtimeEnvironmentVariableKey($key, $origin);
+
+            throw new DeploymentException(
+                "Invalid environment variable name from {$origin}: ".ValidationPatterns::displayShellEnvironmentVariableKey($key).'. Names must start with a letter or underscore and contain only letters, numbers, and underscores.',
+                previous: $exception,
+            );
+        }
+    }
+
+    private function logInvalidBuildtimeEnvironmentVariableKey(string $key, string $origin): void
+    {
+        $displayKey = ValidationPatterns::displayShellEnvironmentVariableKey($key);
+
+        $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
+        $this->application_deployment_queue->addLogEntry("⚠️ Invalid environment variable name from {$origin}: {$displayKey}", 'stderr');
+        $this->application_deployment_queue->addLogEntry('Build-time variables are written to a file that bash sources during the image build. Names must start with a letter or underscore and contain only letters, numbers, and underscores (A-Z, a-z, 0-9, _).', 'stderr');
+        $this->application_deployment_queue->addLogEntry('💡 How to fix:', type: 'info');
+
+        if ($origin === 'the Nixpacks plan') {
+            $this->application_deployment_queue->addLogEntry('   1. Open nixpacks.toml and check the [variables] section. Quoted keys can contain characters that are not valid environment variable names.', type: 'info');
+            $this->application_deployment_queue->addLogEntry('   2. Rename the key to a plain name like MY_VARIABLE (underscores instead of dots, no spaces or $()).', type: 'info');
+            $this->logSuggestedShellEnvironmentVariableKey($key);
+            $this->application_deployment_queue->addLogEntry('   3. Commit, push, and redeploy.', type: 'info');
+            $this->application_deployment_queue->addLogEntry('Docs: https://nixpacks.com/docs/configuration/file', type: 'info');
+        } else {
+            $this->application_deployment_queue->addLogEntry('   Rename the environment variable to use only letters, numbers, and underscores, then redeploy.', type: 'info');
+            $this->logSuggestedShellEnvironmentVariableKey($key);
+        }
+
+        $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
+    }
+
+    private function logSuggestedShellEnvironmentVariableKey(string $key): void
+    {
+        $suggestedKey = str_replace('.', '_', $key);
+        if ($suggestedKey === $key || preg_match(ValidationPatterns::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $suggestedKey) !== 1) {
+            return;
+        }
+
+        $displaySuggestedKey = ValidationPatterns::displayShellEnvironmentVariableKey($suggestedKey);
+
+        $this->application_deployment_queue->addLogEntry("   Suggested name: {$displaySuggestedKey}", type: 'info');
     }
 
     private function save_buildtime_environment_variables()

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1908,6 +1908,23 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->application_deployment_queue->addLogEntry("   Suggested name: {$displaySuggestedKey}", type: 'info');
     }
 
+    private function logDottedDockerSecretKeys(array $keys, string $origin): void
+    {
+        $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
+        foreach ($keys as $key) {
+            $displayKey = ValidationPatterns::displayShellEnvironmentVariableKey($key);
+            $this->application_deployment_queue->addLogEntry("⚠️ Dotted environment variable name from {$origin}: {$displayKey}", 'stderr');
+            $this->logSuggestedShellEnvironmentVariableKey($key);
+        }
+        $this->application_deployment_queue->addLogEntry('Docker secret IDs cannot contain dots.', 'stderr');
+
+        if ($origin === 'the Nixpacks plan') {
+            $this->application_deployment_queue->addLogEntry('   Open nixpacks.toml and check the [variables] section. Rename dotted keys to use underscores.', type: 'info');
+        }
+
+        $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
+    }
+
     private function save_buildtime_environment_variables()
     {
         $environment_variables = $this->generate_buildtime_environment_variables();
@@ -4287,19 +4304,19 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $this->analyzeBuildTimeVariables($variables);
         }
 
-        $requiresDottedEnvironmentSecrets = $this->application->build_pack === 'nixpacks'
-            && $variables->keys()->contains(fn ($key): bool => str_contains((string) $key, '.'));
+        if ($this->build_pack === 'nixpacks') {
+            $incompatibleKeys = collect($variables->keys())
+                ->map(fn ($key): string => (string) $key)
+                ->filter(fn (string $key): bool => ! ValidationPatterns::isDockerSecretCompatibleKey($key) && str_contains($key, '.'))
+                ->values();
 
-        if ($requiresDottedEnvironmentSecrets) {
-            if (! $this->dockerSecretsAvailable) {
-                $dottedKeys = $variables->keys()
-                    ->filter(fn ($key): bool => str_contains((string) $key, '.'))
-                    ->implode(', ');
+            if ($incompatibleKeys->isNotEmpty()) {
+                $this->logDottedDockerSecretKeys($incompatibleKeys->all(), 'the Nixpacks plan');
 
-                throw new DeploymentException("Dotted Nixpacks build-time environment variable names require Docker BuildKit secret support: {$dottedKeys}. Rename these keys to use underscores instead of dots, or upgrade Docker on the build server.");
+                throw new DeploymentException(
+                    'Dotted Nixpacks build-time environment variable names cannot be passed as Docker build secrets: '.$incompatibleKeys->implode(', ').'. Rename these keys to use underscores instead of dots (for example '.$incompatibleKeys->map(fn (string $key): string => str_replace('.', '_', $key))->first().').'
+                );
             }
-
-            $this->dockerSecretsSupported = true;
         }
 
         if ($this->dockerSecretsSupported) {

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -44,6 +44,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     public const BUILD_TIME_ENV_PATH = '/artifacts/build-time.env';
 
+    public const BUILD_TIME_SHELL_ENV_PATH = '/artifacts/build-time-shell.env';
+
+    public const BUILD_TIME_ENV_LAUNCHER_PATH = '/artifacts/run-with-build-time-env';
+
     private const BUILD_SCRIPT_PATH = '/artifacts/build.sh';
 
     private const NIXPACKS_PLAN_PATH = '/artifacts/thegameplan.json';
@@ -200,6 +204,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     private bool $dockerBuildxAvailable = false;
 
     private bool $dockerSecretsSupported = false;
+
+    private bool $dockerSecretsAvailable = false;
+
+    private bool $useBuildtimeEnvironmentLauncher = false;
 
     private bool $skip_build = false;
 
@@ -418,6 +426,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function detectBuildKitCapabilities(): void
     {
+        $this->dockerBuildkitSupported = false;
+        $this->dockerBuildxAvailable = false;
+        $this->dockerSecretsSupported = false;
+        $this->dockerSecretsAvailable = false;
+
         $serverToCheck = $this->use_build_server ? $this->build_server : $this->server;
         $serverName = $this->use_build_server ? "build server ({$serverToCheck->name})" : "deployment server ({$serverToCheck->name})";
 
@@ -468,18 +481,19 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
             }
 
-            // If build secrets are enabled and BuildKit is available, verify --secret flag support
-            if ($this->application->settings->use_build_secrets && $this->dockerBuildkitSupported) {
+            if ($this->dockerBuildkitSupported) {
                 $secretsTest = instant_remote_process(
                     ["docker build --help 2>&1 | grep -q 'secret' && echo 'supported' || echo 'not-supported'"],
                     $serverToCheck
                 );
 
                 if (trim($secretsTest) === 'supported') {
-                    $this->dockerSecretsSupported = true;
-                    $this->application_deployment_queue->addLogEntry('Build secrets are enabled and will be used for enhanced security.');
-                } else {
-                    $this->dockerSecretsSupported = false;
+                    $this->dockerSecretsAvailable = true;
+                    if ($this->application->settings->use_build_secrets) {
+                        $this->dockerSecretsSupported = true;
+                        $this->application_deployment_queue->addLogEntry('Build secrets are enabled and will be used for enhanced security.');
+                    }
+                } elseif ($this->application->settings->use_build_secrets) {
                     $this->application_deployment_queue->addLogEntry("Docker on {$serverName} does not support build secrets. Using traditional build arguments.");
                 }
             }
@@ -487,6 +501,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->dockerBuildkitSupported = false;
             $this->dockerBuildxAvailable = false;
             $this->dockerSecretsSupported = false;
+            $this->dockerSecretsAvailable = false;
             $this->application_deployment_queue->addLogEntry("Could not detect BuildKit capabilities on {$serverName}: {$e->getMessage()}");
         }
     }
@@ -1843,12 +1858,16 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     private function validatedBuildtimeEnvironmentVariableKey(string $key, string $origin): string
     {
         try {
-            return ValidationPatterns::validatedShellEnvironmentVariableKey($key);
+            if (! ValidationPatterns::isValidEnvironmentVariableKey($key)) {
+                throw new \InvalidArgumentException('Invalid build-time environment variable key.');
+            }
+
+            return $key;
         } catch (\InvalidArgumentException $exception) {
             $this->logInvalidBuildtimeEnvironmentVariableKey($key, $origin);
 
             throw new DeploymentException(
-                "Invalid environment variable name from {$origin}: ".ValidationPatterns::displayShellEnvironmentVariableKey($key).'. Names must start with a letter or underscore and contain only letters, numbers, and underscores.',
+                "Invalid environment variable name from {$origin}: ".ValidationPatterns::displayShellEnvironmentVariableKey($key).'. Names must start with a letter or underscore and contain only letters, numbers, underscores, and dots.',
                 previous: $exception,
             );
         }
@@ -1860,12 +1879,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         $this->application_deployment_queue->addLogEntry('----------------------------------------', 'stderr');
         $this->application_deployment_queue->addLogEntry("⚠️ Invalid environment variable name from {$origin}: {$displayKey}", 'stderr');
-        $this->application_deployment_queue->addLogEntry('Build-time variables are written to a file that bash sources during the image build. Names must start with a letter or underscore and contain only letters, numbers, and underscores (A-Z, a-z, 0-9, _).', 'stderr');
+        $this->application_deployment_queue->addLogEntry('Build-time variable names must start with a letter or underscore and contain only letters, numbers, underscores, and dots.', 'stderr');
         $this->application_deployment_queue->addLogEntry('💡 How to fix:', type: 'info');
 
         if ($origin === 'the Nixpacks plan') {
             $this->application_deployment_queue->addLogEntry('   1. Open nixpacks.toml and check the [variables] section. Quoted keys can contain characters that are not valid environment variable names.', type: 'info');
-            $this->application_deployment_queue->addLogEntry('   2. Rename the key to a plain name like MY_VARIABLE (underscores instead of dots, no spaces or $()).', type: 'info');
+            $this->application_deployment_queue->addLogEntry('   2. Rename the key to a plain name like MY_VARIABLE (no spaces, shell syntax, or command substitutions).', type: 'info');
             $this->logSuggestedShellEnvironmentVariableKey($key);
             $this->application_deployment_queue->addLogEntry('   3. Commit, push, and redeploy.', type: 'info');
             $this->application_deployment_queue->addLogEntry('Docs: https://nixpacks.com/docs/configuration/file', type: 'info');
@@ -1891,40 +1910,78 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function save_buildtime_environment_variables()
     {
-        // Generate build-time environment variables locally
         $environment_variables = $this->generate_buildtime_environment_variables();
+        $shell_environment_variables = $environment_variables->filter(function (string $environmentVariable): bool {
+            [$key] = explode('=', $environmentVariable, 2);
 
-        // Save .env file for build phase in /artifacts to prevent it from being copied into Docker images
-        if ($environment_variables->isNotEmpty()) {
-            $envs_base64 = base64_encode($environment_variables->implode("\n"));
+            return preg_match(ValidationPatterns::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $key) === 1;
+        });
+        $dotted_environment_variables = $environment_variables->reject(function (string $environmentVariable): bool {
+            [$key] = explode('=', $environmentVariable, 2);
 
-            $this->application_deployment_queue->addLogEntry('Creating build-time .env file in /artifacts (outside Docker context).', hidden: true);
+            return preg_match(ValidationPatterns::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $key) === 1;
+        });
 
-            $this->execute_remote_command(
-                [
+        if ($dotted_environment_variables->isEmpty()) {
+            $this->useBuildtimeEnvironmentLauncher = false;
+
+            if ($environment_variables->isNotEmpty()) {
+                $envs_base64 = base64_encode($environment_variables->implode("\n"));
+
+                $this->application_deployment_queue->addLogEntry('Creating build-time .env file in /artifacts (outside Docker context).', hidden: true);
+                $this->execute_remote_command([
                     executeInDocker($this->deployment_uuid, "echo '$envs_base64' | base64 -d | tee ".self::BUILD_TIME_ENV_PATH.' > /dev/null'),
-                ]
-            );
+                ]);
 
-            if (isDev()) {
-                $this->execute_remote_command(
-                    [
+                if (isDev()) {
+                    $this->execute_remote_command([
                         executeInDocker($this->deployment_uuid, 'cat '.self::BUILD_TIME_ENV_PATH),
                         'hidden' => true,
-                    ]
-                );
-            }
-        } elseif (in_array($this->build_pack, ['dockercompose', 'dockerfile', 'railpack'], true)) {
-            // For build packs that source the build-time .env file, create an empty file even if there are no build-time variables
-            // This ensures the file exists when referenced in build commands
-            $this->application_deployment_queue->addLogEntry('Creating empty build-time .env file in /artifacts (no build-time variables defined).', hidden: true);
-
-            $this->execute_remote_command(
-                [
+                    ]);
+                }
+            } elseif (in_array($this->build_pack, ['dockercompose', 'dockerfile', 'railpack'], true)) {
+                $this->application_deployment_queue->addLogEntry('Creating empty build-time .env file in /artifacts (no build-time variables defined).', hidden: true);
+                $this->execute_remote_command([
                     executeInDocker($this->deployment_uuid, 'touch '.self::BUILD_TIME_ENV_PATH),
-                ]
-            );
+                ]);
+            }
+
+            return;
         }
+
+        $this->useBuildtimeEnvironmentLauncher = true;
+
+        $launcher = [
+            '#!/bin/bash',
+            'set -a',
+            'source '.self::BUILD_TIME_SHELL_ENV_PATH,
+            'set +a',
+        ];
+
+        $launcher[] = 'exec env \\';
+        foreach ($dotted_environment_variables as $environmentVariable) {
+            $launcher[] = "    {$environmentVariable} \\";
+        }
+        $launcher[] = '    "$@"';
+
+        $files = [
+            self::BUILD_TIME_ENV_PATH => $environment_variables->implode("\n"),
+            self::BUILD_TIME_SHELL_ENV_PATH => $shell_environment_variables->implode("\n"),
+            self::BUILD_TIME_ENV_LAUNCHER_PATH => implode("\n", $launcher)."\n",
+        ];
+
+        $this->application_deployment_queue->addLogEntry('Creating build-time environment files in /artifacts (outside Docker context).', hidden: true);
+
+        foreach ($files as $path => $contents) {
+            $contents_base64 = base64_encode($contents);
+            $this->execute_remote_command([
+                executeInDocker($this->deployment_uuid, "echo '$contents_base64' | base64 -d | tee {$path} > /dev/null"),
+            ]);
+        }
+
+        $this->execute_remote_command([
+            executeInDocker($this->deployment_uuid, 'chmod 700 '.self::BUILD_TIME_ENV_LAUNCHER_PATH),
+        ]);
     }
 
     private function elixir_finetunes()
@@ -3706,7 +3763,13 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
      */
     private function wrap_build_command_with_env_export(string $build_command): string
     {
-        return "cd {$this->workdir} && set -a && source ".self::BUILD_TIME_ENV_PATH." && set +a && {$build_command}";
+        if (! $this->useBuildtimeEnvironmentLauncher) {
+            return "cd {$this->workdir} && set -a && source ".self::BUILD_TIME_ENV_PATH." && set +a && {$build_command}";
+        }
+
+        $escapedBuildCommand = escapeBashEnvValue($build_command);
+
+        return "cd {$this->workdir} && bash ".self::BUILD_TIME_ENV_LAUNCHER_PATH." /bin/bash -c {$escapedBuildCommand}";
     }
 
     private function build_image()
@@ -4229,6 +4292,17 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $this->analyzeBuildTimeVariables($variables);
         }
 
+        $requiresDottedEnvironmentSecrets = $this->application->build_pack === 'nixpacks'
+            && $variables->keys()->contains(fn ($key): bool => str_contains((string) $key, '.'));
+
+        if ($requiresDottedEnvironmentSecrets) {
+            if (! $this->dockerSecretsAvailable) {
+                throw new DeploymentException('Dotted Nixpacks build-time environment variable names require Docker BuildKit support.');
+            }
+
+            $this->dockerSecretsSupported = true;
+        }
+
         if ($this->dockerSecretsSupported) {
             $this->generate_build_secrets($variables);
             $this->build_args = '';
@@ -4493,7 +4567,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
     private function modify_dockerfile_for_secrets($dockerfile_path)
     {
         // Only process if build secrets are enabled and we have secrets to mount
-        if (! $this->application->settings->use_build_secrets || empty($this->build_secrets)) {
+        if (empty($this->build_secrets)) {
             return;
         }
 
@@ -4517,9 +4591,42 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $this->generate_env_variables();
         }
 
-        $variables = $this->env_args;
+        $variables = $this->application->build_pack === 'nixpacks'
+            ? collect($this->nixpacks_plan_json->get('variables'))
+            : $this->env_args;
         if ($variables->isEmpty()) {
             return;
+        }
+
+        $dottedKeys = $variables->keys()
+            ->map(fn ($key): string => (string) $key)
+            ->filter(fn (string $key): bool => str_contains($key, '.'));
+
+        if ($dottedKeys->isNotEmpty()) {
+            $originalDockerfile = $dockerfile;
+            $dockerfile = $dockerfile->map(function (string $line) use ($dottedKeys): ?string {
+                $trimmedLine = trim($line);
+
+                if (! str_starts_with($trimmedLine, 'ARG ') && ! str_starts_with($trimmedLine, 'ENV ')) {
+                    return $line;
+                }
+
+                [$instruction, $arguments] = explode(' ', $trimmedLine, 2);
+                $filteredArguments = collect(preg_split('/\s+/', $arguments))
+                    ->reject(function (string $argument) use ($dottedKeys): bool {
+                        $key = str($argument)->before('=')->toString();
+
+                        return $dottedKeys->contains($key);
+                    });
+
+                if ($filteredArguments->isEmpty()) {
+                    return null;
+                }
+
+                return $instruction.' '.$filteredArguments->implode(' ');
+            })->filter()->values();
+
+            $modified = $dockerfile->all() !== $originalDockerfile->values()->all();
         }
 
         // Generate mount strings for all secrets
@@ -4528,7 +4635,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         // Add mount for the secrets hash to ensure cache invalidation
         $mountStrings .= ' --mount=type=secret,id=COOLIFY_BUILD_SECRETS_HASH,env=COOLIFY_BUILD_SECRETS_HASH';
 
-        $modified = false;
+        $modified ??= false;
         $dockerfile = $dockerfile->map(function ($line) use ($mountStrings, &$modified) {
             $trimmed = ltrim($line);
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -4636,37 +4636,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             return;
         }
 
-        $dottedKeys = $variables->keys()
-            ->map(fn ($key): string => (string) $key)
-            ->filter(fn (string $key): bool => str_contains($key, '.'));
-
-        if ($dottedKeys->isNotEmpty()) {
-            $originalDockerfile = $dockerfile;
-            $dockerfile = $dockerfile->map(function (string $line) use ($dottedKeys): ?string {
-                $trimmedLine = trim($line);
-
-                if (! str_starts_with($trimmedLine, 'ARG ') && ! str_starts_with($trimmedLine, 'ENV ')) {
-                    return $line;
-                }
-
-                [$instruction, $arguments] = explode(' ', $trimmedLine, 2);
-                $filteredArguments = collect(preg_split('/\s+/', $arguments))
-                    ->reject(function (string $argument) use ($dottedKeys): bool {
-                        $key = str($argument)->before('=')->toString();
-
-                        return $dottedKeys->contains($key);
-                    });
-
-                if ($filteredArguments->isEmpty()) {
-                    return null;
-                }
-
-                return $instruction.' '.$filteredArguments->implode(' ');
-            })->filter()->values();
-
-            $modified = $dockerfile->all() !== $originalDockerfile->values()->all();
-        }
-
         // Generate mount strings for all secrets
         $mountStrings = $variables->map(fn ($value, $key) => "--mount=type=secret,id={$key},env={$key}")->implode(' ');
 

--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -109,6 +109,11 @@ class ValidationPatterns
     public const ENVIRONMENT_VARIABLE_KEY_PATTERN = '/\A[A-Za-z_][A-Za-z0-9_.]*\z/u';
 
     /**
+     * Pattern for environment variable keys written to shell-sourced files.
+     */
+    public const SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN = '/\A[A-Za-z_][A-Za-z0-9_]*\z/u';
+
+    /**
      * Characters that are valid in some URL positions but unsafe for values
      * that are later reused in shell assignment contexts.
      */
@@ -190,6 +195,43 @@ class ValidationPatterns
     public static function isValidEnvironmentVariableKey(string $value): bool
     {
         return preg_match(self::ENVIRONMENT_VARIABLE_KEY_PATTERN, $value) === 1;
+    }
+
+    /**
+     * Make an environment variable key safe to show in deployment logs.
+     *
+     * Control characters are escaped and long values are truncated so an
+     * unexpected key cannot corrupt or overflow the deployment log output.
+     */
+    public static function displayShellEnvironmentVariableKey(string $value, int $maxLength = 80): string
+    {
+        $printable = str($value)
+            ->replace(["\0", "\r", "\n", "\t"], ['\\0', '\\r', '\\n', '\\t'])
+            ->value();
+
+        $printable = preg_replace_callback(
+            '/[\x00-\x1F\x7F]/',
+            fn (array $matches): string => sprintf('\\x%02X', ord($matches[0])),
+            $printable,
+        );
+
+        if ($printable === '') {
+            return '(empty)';
+        }
+
+        return str($printable)->limit($maxLength)->value();
+    }
+
+    /**
+     * Validate an environment variable key before writing it to a shell-sourced file.
+     */
+    public static function validatedShellEnvironmentVariableKey(string $value): string
+    {
+        if (preg_match(self::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $value) !== 1) {
+            throw new \InvalidArgumentException('Invalid environment variable name '.self::displayShellEnvironmentVariableKey($value).'. Names must start with a letter or underscore and contain only letters, numbers, and underscores.');
+        }
+
+        return $value;
     }
 
     /**

--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -198,6 +198,14 @@ class ValidationPatterns
     }
 
     /**
+     * Check if a string is a Docker secret-compatible environment variable key.
+     */
+    public static function isDockerSecretCompatibleKey(string $value): bool
+    {
+        return preg_match(self::SHELL_ENVIRONMENT_VARIABLE_KEY_PATTERN, $value) === 1;
+    }
+
+    /**
      * Make an environment variable key safe to show in deployment logs.
      *
      * Control characters are escaped and long values are truncated so an

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1552,6 +1552,17 @@ function escapeBashEnvValue(?string $value): string
     return "'{$escaped}'";
 }
 
+function escapeComposeEnvFileValue(?string $value, bool $allowInterpolation = false): string
+{
+    $escaped = str_replace(['\\', '"'], ['\\\\', '\\"'], $value ?? '');
+
+    if (! $allowInterpolation) {
+        $escaped = str_replace('$', '\\$', $escaped);
+    }
+
+    return '"'.$escaped.'"';
+}
+
 /**
  * Escape a value for bash double-quoted strings (allows $VAR expansion)
  *

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -12,6 +12,7 @@ use App\Models\Server;
 use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use Symfony\Component\Process\Process;
 
 uses(RefreshDatabase::class);
 
@@ -20,6 +21,8 @@ class TestableControlVarFilteringDeploymentJob extends ApplicationDeploymentJob
     public array $recordedCommands = [];
 
     public array $recordedLogEntries = [];
+
+    public array $writtenArtifacts = [];
 
     public ?string $writtenDockerfile = null;
 
@@ -38,6 +41,10 @@ class TestableControlVarFilteringDeploymentJob extends ApplicationDeploymentJob
 
             if (preg_match('/echo .*?([A-Za-z0-9+\\/=]{16,}).*?\\| base64 -d \\| tee \\/artifacts\\/test-app\\/Dockerfile > \\/dev\\/null/', $commandString, $matches) === 1) {
                 $this->writtenDockerfile = base64_decode($matches[1]) ?: null;
+            }
+
+            if (preg_match('~echo .*?([A-Za-z0-9+/=]{8,}).*?\\| base64 -d \\| tee (/artifacts/[^ ]+) > /dev/null~', $commandString, $matches) === 1) {
+                $this->writtenArtifacts[$matches[2]] = base64_decode($matches[1]);
             }
         }
     }
@@ -137,12 +144,12 @@ function makeControlVarFilteringJob(Application $application, Server $server, ar
     return [$job, $reflection];
 }
 
-function invokeDeploymentJobMethod(object $job, ReflectionClass $reflection, string $method): mixed
+function invokeDeploymentJobMethod(object $job, ReflectionClass $reflection, string $method, mixed ...$arguments): mixed
 {
     $reflectionMethod = $reflection->getMethod($method);
     $reflectionMethod->setAccessible(true);
 
-    return $reflectionMethod->invoke($job);
+    return $reflectionMethod->invoke($job, ...$arguments);
 }
 
 function readDeploymentJobProperty(object $job, ReflectionClass $reflection, string $property): mixed
@@ -232,7 +239,6 @@ it('rejects unsafe Nixpacks plan variable keys before writing the build-time env
     'backticks' => 'X`id`',
     'newline' => "X\nid",
     'shell assignment' => 'X=value',
-    'dot notation unsupported by bash' => 'X.VALUE',
     'semicolon' => 'X;id',
     'pipe' => 'X|id',
     'ampersand' => 'X&id',
@@ -240,7 +246,7 @@ it('rejects unsafe Nixpacks plan variable keys before writing the build-time env
     'command substitution with arguments' => 'X$(docker run --rm -v /:/mnt alpine true)',
 ]);
 
-it('rejects persisted user build-time variable keys that bash cannot export', function () {
+it('keeps persisted dotted user build-time variable keys', function () {
     [$application, $server] = makeDeploymentControlVarFixture();
 
     createApplicationEnvironmentVariable($application, [
@@ -250,8 +256,175 @@ it('rejects persisted user build-time variable keys that bash cannot export', fu
 
     [$job, $reflection] = makeControlVarFilteringJob($application, $server);
 
-    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
-        ->toThrow(DeploymentException::class, 'Invalid environment variable name from the build-time environment: X.VALUE');
+    /** @var Collection $buildtimeEnvs */
+    $buildtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables');
+
+    expect($buildtimeEnvs)->toContain('X.VALUE="unsafe"');
+});
+
+it('loads shell variables and passes dotted variables through the build-time environment launcher', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'BASE_VALUE',
+        'value' => 'expanded',
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'X.VALUE',
+        'value' => '$BASE_VALUE',
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'DOTTED.VALUE',
+        'value' => '$(touch /tmp/coolify-dotted-env-injection)',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+    invokeDeploymentJobMethod($job, $reflection, 'save_buildtime_environment_variables');
+
+    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_PATH])
+        ->toContain('BASE_VALUE="expanded"')
+        ->toContain('X.VALUE="$BASE_VALUE"');
+    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH])
+        ->toContain('BASE_VALUE="expanded"')
+        ->not->toContain('X.VALUE');
+    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH])
+        ->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH)
+        ->toContain('X.VALUE="$BASE_VALUE"')
+        ->toContain('exec env');
+
+    $wrappedCommand = invokeDeploymentJobMethod($job, $reflection, 'wrap_build_command_with_env_export', 'printenv X.VALUE');
+
+    expect($wrappedCommand)
+        ->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH)
+        ->toContain("/bin/bash -c 'printenv X.VALUE'")
+        ->not->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_ENV_PATH);
+
+    $temporaryDirectory = sys_get_temp_dir().'/coolify-build-env-'.str()->random(8);
+    mkdir($temporaryDirectory);
+    $shellEnvironmentPath = $temporaryDirectory.'/build-time-shell.env';
+    $launcherPath = $temporaryDirectory.'/run-with-build-time-env';
+    file_put_contents($shellEnvironmentPath, $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH]);
+    file_put_contents(
+        $launcherPath,
+        str_replace(
+            ['source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH, '#!/bin/bash'],
+            ['. '.$shellEnvironmentPath, '#!/bin/sh'],
+            $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH],
+        ),
+    );
+    chmod($launcherPath, 0700);
+    @unlink('/tmp/coolify-dotted-env-injection');
+
+    $process = new Process(['/bin/sh', $launcherPath, '/bin/sh', '-c', 'printenv X.VALUE; printenv DOTTED.VALUE']);
+    $process->mustRun();
+
+    expect($process->getOutput())
+        ->toContain("expanded\n")
+        ->toContain('$(touch /tmp/coolify-dotted-env-injection)');
+    expect(file_exists('/tmp/coolify-dotted-env-injection'))->toBeFalse();
+
+    unlink($launcherPath);
+    unlink($shellEnvironmentPath);
+    rmdir($temporaryDirectory);
+});
+
+it('keeps the original sourced environment path when build-time keys are shell safe', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'SAFE_VALUE',
+        'value' => 'safe',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+    invokeDeploymentJobMethod($job, $reflection, 'save_buildtime_environment_variables');
+
+    expect($job->writtenArtifacts)
+        ->toHaveKey(ApplicationDeploymentJob::BUILD_TIME_ENV_PATH)
+        ->not->toHaveKey(ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH)
+        ->not->toHaveKey(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH);
+
+    $wrappedCommand = invokeDeploymentJobMethod($job, $reflection, 'wrap_build_command_with_env_export', 'docker build .');
+
+    expect($wrappedCommand)
+        ->toContain('set -a && source '.ApplicationDeploymentJob::BUILD_TIME_ENV_PATH.' && set +a && docker build .')
+        ->not->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH);
+});
+
+it('uses BuildKit secrets for dotted Nixpacks variables instead of invalid Dockerfile expansion', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'dockerBuildkitSupported' => true,
+        'dockerSecretsAvailable' => true,
+        'env_args' => collect(['X.VALUE' => 'dotted-buildtime-ok']),
+        'nixpacks_plan_json' => collect([
+            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
+        ]),
+        'saved_outputs' => collect([
+            'dockerfile_content' => "FROM alpine\nARG SAFE X.VALUE\nENV SAFE=\$SAFE X.VALUE=\$X.VALUE\nRUN printenv X.VALUE",
+        ]),
+    ]);
+
+    invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables');
+
+    expect(readDeploymentJobProperty($job, $reflection, 'dockerSecretsSupported'))->toBeTrue();
+    expect(readDeploymentJobProperty($job, $reflection, 'build_secrets'))->toContain('--secret id=X.VALUE,env=X.VALUE');
+
+    invokeDeploymentJobMethod($job, $reflection, 'modify_dockerfile_for_secrets', '/artifacts/test-app/.nixpacks/Dockerfile');
+
+    $dockerfile = $job->writtenArtifacts['/artifacts/test-app/.nixpacks/Dockerfile'];
+
+    expect($dockerfile)
+        ->not->toContain('ARG X.VALUE')
+        ->not->toContain('X.VALUE=$X.VALUE')
+        ->toContain('ARG SAFE')
+        ->toContain('ENV SAFE=$SAFE')
+        ->toContain('RUN --mount=type=secret,id=X.VALUE,env=X.VALUE')
+        ->toContain('printenv X.VALUE');
+});
+
+it('rejects dotted Nixpacks variables when Docker build secrets are unavailable', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'dockerBuildkitSupported' => true,
+        'dockerSecretsAvailable' => false,
+        'nixpacks_plan_json' => collect([
+            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
+        ]),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables'))
+        ->toThrow(DeploymentException::class, 'require Docker BuildKit support');
+});
+
+it('writes dotted Nixpacks ARG and ENV removal when the Dockerfile has no run command', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'env_args' => collect(['X.VALUE' => 'dotted-buildtime-ok']),
+        'nixpacks_plan_json' => collect([
+            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
+        ]),
+        'build_secrets' => '--secret id=X.VALUE,env=X.VALUE',
+        'saved_outputs' => collect([
+            'dockerfile_content' => "FROM alpine\nARG X.VALUE=default\nENV X.VALUE=\$X.VALUE",
+        ]),
+    ]);
+
+    invokeDeploymentJobMethod($job, $reflection, 'modify_dockerfile_for_secrets', '/artifacts/test-app/.nixpacks/Dockerfile');
+
+    expect($job->writtenArtifacts['/artifacts/test-app/.nixpacks/Dockerfile'])
+        ->not->toContain('X.VALUE');
 });
 
 it('skips unsafe reserved Nixpacks plan variable keys before validation', function (string $key) {
@@ -284,22 +457,21 @@ it('explains invalid Nixpacks plan variable keys in deployment logs', function (
     [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
         'nixpacks_plan_json' => collect([
             'variables' => [
-                'XPACK.SECURITY.ENABLED' => 'true',
+                'XPACK;SECURITY;ENABLED' => 'true',
             ],
         ]),
     ]);
 
     expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
-        ->toThrow(DeploymentException::class, 'Invalid environment variable name from the Nixpacks plan: XPACK.SECURITY.ENABLED');
+        ->toThrow(DeploymentException::class, 'Invalid environment variable name from the Nixpacks plan: XPACK;SECURITY;ENABLED');
 
     $logs = implode("\n", $job->recordedLogEntries);
 
     expect($logs)
-        ->toContain('Invalid environment variable name from the Nixpacks plan: XPACK.SECURITY.ENABLED')
-        ->toContain('bash sources during the image build')
+        ->toContain('Invalid environment variable name from the Nixpacks plan: XPACK;SECURITY;ENABLED')
+        ->toContain('must start with a letter or underscore')
         ->toContain('How to fix')
         ->toContain('nixpacks.toml')
-        ->toContain('Suggested name: XPACK_SECURITY_ENABLED')
         ->toContain('https://nixpacks.com/docs/configuration/file');
 });
 
@@ -330,12 +502,12 @@ it('truncates long Nixpacks plan variable keys in deployment logs', function () 
         ->toContain('nixpacks.toml');
 });
 
-it('bounds every deployment log entry for long dotted Nixpacks variable keys', function () {
+it('bounds every deployment log entry for long invalid Nixpacks variable keys', function () {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'nixpacks',
     ]);
 
-    $key = 'X'.str_repeat('.', 10_000);
+    $key = 'X'.str_repeat('$', 10_000);
 
     [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
         'nixpacks_plan_json' => collect([
@@ -363,6 +535,7 @@ it('keeps shell-safe Nixpacks plan variables in the build-time env file', functi
             'variables' => [
                 'APP_NAME' => 'coolify',
                 '_PRIVATE_VALUE' => 'secret',
+                'X.VALUE' => 'dotted',
             ],
         ]),
     ]);
@@ -371,7 +544,8 @@ it('keeps shell-safe Nixpacks plan variables in the build-time env file', functi
     $buildtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables');
 
     expect($buildtimeEnvs)->toContain("APP_NAME='coolify'")
-        ->toContain("_PRIVATE_VALUE='secret'");
+        ->toContain("_PRIVATE_VALUE='secret'")
+        ->toContain("X.VALUE='dotted'");
 });
 
 it('does not let preview docker compose service names override generated build-time service names', function () {

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -263,70 +263,74 @@ it('keeps persisted dotted user build-time variable keys', function () {
 });
 
 it('loads shell variables and passes dotted variables through the build-time environment launcher', function () {
-    [$application, $server] = makeDeploymentControlVarFixture();
-
-    createApplicationEnvironmentVariable($application, [
-        'key' => 'BASE_VALUE',
-        'value' => 'expanded',
-    ]);
-    createApplicationEnvironmentVariable($application, [
-        'key' => 'X.VALUE',
-        'value' => '$BASE_VALUE',
-    ]);
-    createApplicationEnvironmentVariable($application, [
-        'key' => 'DOTTED.VALUE',
-        'value' => '$(touch /tmp/coolify-dotted-env-injection)',
-    ]);
-
-    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
-
-    invokeDeploymentJobMethod($job, $reflection, 'save_buildtime_environment_variables');
-
-    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_PATH])
-        ->toContain('BASE_VALUE="expanded"')
-        ->toContain('X.VALUE="$BASE_VALUE"');
-    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH])
-        ->toContain('BASE_VALUE="expanded"')
-        ->not->toContain('X.VALUE');
-    expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH])
-        ->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH)
-        ->toContain('X.VALUE="$BASE_VALUE"')
-        ->toContain('exec env');
-
-    $wrappedCommand = invokeDeploymentJobMethod($job, $reflection, 'wrap_build_command_with_env_export', 'printenv X.VALUE');
-
-    expect($wrappedCommand)
-        ->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH)
-        ->toContain("/bin/bash -c 'printenv X.VALUE'")
-        ->not->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_ENV_PATH);
-
     $temporaryDirectory = sys_get_temp_dir().'/coolify-build-env-'.str()->random(8);
-    mkdir($temporaryDirectory);
+    expect(mkdir($temporaryDirectory))->toBeTrue();
     $shellEnvironmentPath = $temporaryDirectory.'/build-time-shell.env';
     $launcherPath = $temporaryDirectory.'/run-with-build-time-env';
-    file_put_contents($shellEnvironmentPath, $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH]);
-    file_put_contents(
-        $launcherPath,
-        str_replace(
-            ['source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH, '#!/bin/bash'],
-            ['. '.$shellEnvironmentPath, '#!/bin/sh'],
-            $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH],
-        ),
-    );
-    chmod($launcherPath, 0700);
-    @unlink('/tmp/coolify-dotted-env-injection');
+    $injectionMarkerPath = $temporaryDirectory.'/injection-marker';
 
-    $process = new Process(['/bin/sh', $launcherPath, '/bin/sh', '-c', 'printenv X.VALUE; printenv DOTTED.VALUE']);
-    $process->mustRun();
+    try {
+        [$application, $server] = makeDeploymentControlVarFixture();
 
-    expect($process->getOutput())
-        ->toContain("expanded\n")
-        ->toContain('$(touch /tmp/coolify-dotted-env-injection)');
-    expect(file_exists('/tmp/coolify-dotted-env-injection'))->toBeFalse();
+        createApplicationEnvironmentVariable($application, [
+            'key' => 'BASE_VALUE',
+            'value' => 'expanded',
+        ]);
+        createApplicationEnvironmentVariable($application, [
+            'key' => 'X.VALUE',
+            'value' => '$BASE_VALUE',
+        ]);
+        createApplicationEnvironmentVariable($application, [
+            'key' => 'DOTTED.VALUE',
+            'value' => "$(touch {$injectionMarkerPath})",
+        ]);
 
-    unlink($launcherPath);
-    unlink($shellEnvironmentPath);
-    rmdir($temporaryDirectory);
+        [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+        invokeDeploymentJobMethod($job, $reflection, 'save_buildtime_environment_variables');
+
+        expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_PATH])
+            ->toContain('BASE_VALUE="expanded"')
+            ->toContain('X.VALUE="$BASE_VALUE"');
+        expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH])
+            ->toContain('BASE_VALUE="expanded"')
+            ->not->toContain('X.VALUE');
+        expect($job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH])
+            ->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH)
+            ->toContain('X.VALUE="$BASE_VALUE"')
+            ->toContain('exec env');
+
+        $wrappedCommand = invokeDeploymentJobMethod($job, $reflection, 'wrap_build_command_with_env_export', 'printenv X.VALUE');
+
+        expect($wrappedCommand)
+            ->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH)
+            ->toContain("/bin/bash -c 'printenv X.VALUE'")
+            ->not->toContain('source '.ApplicationDeploymentJob::BUILD_TIME_ENV_PATH);
+
+        file_put_contents($shellEnvironmentPath, $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH]);
+        file_put_contents(
+            $launcherPath,
+            str_replace(
+                'source '.ApplicationDeploymentJob::BUILD_TIME_SHELL_ENV_PATH,
+                'source '.$shellEnvironmentPath,
+                $job->writtenArtifacts[ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH],
+            ),
+        );
+        chmod($launcherPath, 0700);
+
+        $process = new Process(['/bin/bash', $launcherPath, '/bin/bash', '-c', 'printenv X.VALUE; printenv DOTTED.VALUE']);
+        $process->mustRun();
+
+        expect($process->getOutput())
+            ->toContain("expanded\n")
+            ->toContain("$(touch {$injectionMarkerPath})");
+        expect(file_exists($injectionMarkerPath))->toBeFalse();
+    } finally {
+        @unlink($launcherPath);
+        @unlink($shellEnvironmentPath);
+        @unlink($injectionMarkerPath);
+        @rmdir($temporaryDirectory);
+    }
 });
 
 it('keeps the original sourced environment path when build-time keys are shell safe', function () {
@@ -397,12 +401,18 @@ it('rejects dotted Nixpacks variables when Docker build secrets are unavailable'
         'dockerBuildkitSupported' => true,
         'dockerSecretsAvailable' => false,
         'nixpacks_plan_json' => collect([
-            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
+            'variables' => [
+                'X.VALUE' => 'dotted-buildtime-ok',
+                'ANOTHER.DOTTED.VALUE' => 'also-dotted',
+            ],
         ]),
     ]);
 
     expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables'))
-        ->toThrow(DeploymentException::class, 'require Docker BuildKit support');
+        ->toThrow(
+            DeploymentException::class,
+            'Dotted Nixpacks build-time environment variable names require Docker BuildKit secret support: X.VALUE, ANOTHER.DOTTED.VALUE. Rename these keys to use underscores instead of dots, or upgrade Docker on the build server.'
+        );
 });
 
 it('writes dotted Nixpacks ARG and ENV removal when the Dockerfile has no run command', function () {

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -730,6 +730,48 @@ it('filters buildpack control vars from dockerfile arg injection', function () {
     expect($job->writtenDockerfile)->not->toContain('ARG RAILPACK_NODE_VERSION=');
 });
 
+it('rejects dotted keys when dockerfile builds use docker secrets', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'dockerfile',
+    ]);
+    $application->settings()->update(['use_build_secrets' => true]);
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'DOTTED.USER',
+        'value' => 'df-dotted',
+        'is_buildtime' => true,
+        'is_runtime' => true,
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'dockerSecretsSupported' => true,
+        'env_args' => collect(['DOTTED.USER' => 'df-dotted', 'SAFE' => 'ok']),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_build_secrets', collect([
+        'DOTTED.USER' => 'df-dotted',
+        'SAFE' => 'ok',
+    ])))->toThrow(DeploymentException::class, 'DOTTED.USER');
+});
+
+it('keeps dotted dockerfile build args when secrets are not used', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'DOTTED.USER',
+        'value' => 'df-dotted',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+    invokeDeploymentJobMethod($job, $reflection, 'generate_env_variables');
+
+    /** @var Collection $envArgs */
+    $envArgs = readDeploymentJobProperty($job, $reflection, 'env_args');
+
+    expect($envArgs->get('DOTTED.USER'))->toBe('df-dotted');
+});
+
 it('builds railpack variables from generic buildtime vars railpack vars and coolify vars only', function () {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'railpack',

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -934,6 +934,14 @@ it('writes compose-safe runtime env files for user values', function () {
         'is_runtime' => true,
         'is_buildtime' => false,
     ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'MULTILINE_VALUE',
+        'value' => "\$BOTH_PHASES\nsecond line",
+        'is_literal' => false,
+        'is_multiline' => true,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
 
     [$job, $reflection] = makeControlVarFilteringJob($application, $server);
 
@@ -944,5 +952,62 @@ it('writes compose-safe runtime env files for user values', function () {
         ->toContain('QUOTED_VALUE='.escapeComposeEnvFileValue('hello world; quotes" \'$`'))
         ->toContain('INJECT_CMD='.escapeComposeEnvFileValue('$(touch /tmp/coolify-value-injection)'))
         ->toContain('EXPAND_ME='.escapeComposeEnvFileValue('$BOTH_PHASES', allowInterpolation: true))
-        ->toContain('EDGE_QUOTES='.escapeComposeEnvFileValue("'keep these quotes'"));
+        ->toContain('EDGE_QUOTES='.escapeComposeEnvFileValue("'keep these quotes'"))
+        ->toContain('MULTILINE_VALUE='.escapeComposeEnvFileValue("\$BOTH_PHASES\nsecond line"));
+});
+
+it('writes compose-safe preview runtime env files for user values', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'PREVIEW_QUOTED_VALUE',
+        'value' => 'preview quotes" \'$`',
+        'is_preview' => true,
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application->fresh(), $server, [
+        'pull_request_id' => 42,
+    ]);
+
+    /** @var Collection $runtimeEnvs */
+    $runtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_runtime_environment_variables');
+
+    expect($runtimeEnvs)
+        ->toContain('PREVIEW_QUOTED_VALUE='.escapeComposeEnvFileValue('preview quotes" \'$`'));
+});
+
+it('writes compose-safe production fallbacks to preview runtime env files', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'PREVIEW_TRIGGER',
+        'value' => 'preview-value',
+        'is_preview' => true,
+        'is_literal' => false,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'FALLBACK_QUOTED_VALUE',
+        'value' => 'fallback quotes" \'$`',
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
+    $application->environment_variables_preview()
+        ->where('key', 'FALLBACK_QUOTED_VALUE')
+        ->delete();
+
+    [$job, $reflection] = makeControlVarFilteringJob($application->fresh(), $server, [
+        'pull_request_id' => 42,
+    ]);
+
+    /** @var Collection $runtimeEnvs */
+    $runtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_runtime_environment_variables');
+
+    expect($runtimeEnvs)
+        ->toContain('FALLBACK_QUOTED_VALUE='.escapeComposeEnvFileValue('fallback quotes" \'$`'));
 });

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -240,6 +240,20 @@ it('rejects unsafe Nixpacks plan variable keys before writing the build-time env
     'command substitution with arguments' => 'X$(docker run --rm -v /:/mnt alpine true)',
 ]);
 
+it('rejects persisted user build-time variable keys that bash cannot export', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'X.VALUE',
+        'value' => 'unsafe',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
+        ->toThrow(DeploymentException::class, 'Invalid environment variable name from the build-time environment: X.VALUE');
+});
+
 it('skips unsafe reserved Nixpacks plan variable keys before validation', function (string $key) {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'nixpacks',

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -407,6 +407,29 @@ it('still allows underscore Nixpacks plan keys through generate_build_env_variab
     expect(readDeploymentJobProperty($job, $reflection, 'dockerSecretsSupported'))->toBeFalse();
 });
 
+it('mounts underscore nixpacks secrets on RUN lines when build secrets are enabled', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'env_args' => collect(['SAFE_FROM_TOML' => 'ok-from-toml']),
+        'nixpacks_plan_json' => collect([
+            'variables' => ['SAFE_FROM_TOML' => 'ok-from-toml'],
+        ]),
+        'build_secrets' => '--secret id=SAFE_FROM_TOML,env=SAFE_FROM_TOML',
+        'saved_outputs' => collect([
+            'dockerfile_content' => "FROM alpine\nARG SAFE_FROM_TOML\nRUN printenv SAFE_FROM_TOML",
+        ]),
+    ]);
+
+    invokeDeploymentJobMethod($job, $reflection, 'modify_dockerfile_for_secrets', '/artifacts/test-app/.nixpacks/Dockerfile');
+
+    expect($job->writtenArtifacts['/artifacts/test-app/.nixpacks/Dockerfile'])
+        ->toContain('RUN --mount=type=secret,id=SAFE_FROM_TOML,env=SAFE_FROM_TOML')
+        ->toContain('printenv SAFE_FROM_TOML');
+});
+
 it('skips unsafe reserved Nixpacks plan variable keys before validation', function (string $key) {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'nixpacks',

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\DeploymentException;
 use App\Jobs\ApplicationDeploymentJob;
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
@@ -17,6 +18,8 @@ uses(RefreshDatabase::class);
 class TestableControlVarFilteringDeploymentJob extends ApplicationDeploymentJob
 {
     public array $recordedCommands = [];
+
+    public array $recordedLogEntries = [];
 
     public ?string $writtenDockerfile = null;
 
@@ -92,7 +95,11 @@ function makeControlVarFilteringJob(Application $application, Server $server, ar
     $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
 
     $queue = Mockery::mock(ApplicationDeploymentQueue::class);
-    $queue->shouldReceive('addLogEntry')->andReturnNull();
+    $queue->shouldReceive('addLogEntry')->andReturnUsing(function (string $message, string $type = 'stdout', bool $hidden = false) use ($job) {
+        $job->recordedLogEntries[] = $message;
+
+        return null;
+    });
 
     $properties = [
         'application' => $application->fresh(),
@@ -203,6 +210,154 @@ it('filters buildpack control vars from preview build-time env files', function 
     expect($buildtimeEnvs->contains(fn (string $env) => str($env)->startsWith('APP_ENV=')))->toBeTrue();
     expect($buildtimeEnvs->contains(fn (string $env) => str($env)->startsWith('NIXPACKS_NODE_VERSION=')))->toBeFalse();
     expect($buildtimeEnvs->contains(fn (string $env) => str($env)->startsWith('RAILPACK_NODE_VERSION=')))->toBeFalse();
+});
+
+it('rejects unsafe Nixpacks plan variable keys before writing the build-time env file', function (string $key) {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                $key => 'value',
+            ],
+        ]),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
+        ->toThrow(DeploymentException::class);
+})->with([
+    'command substitution' => 'X$(id)',
+    'backticks' => 'X`id`',
+    'newline' => "X\nid",
+    'shell assignment' => 'X=value',
+    'dot notation unsupported by bash' => 'X.VALUE',
+    'semicolon' => 'X;id',
+    'pipe' => 'X|id',
+    'ampersand' => 'X&id',
+    'leading dollar' => '$(id)',
+    'command substitution with arguments' => 'X$(docker run --rm -v /:/mnt alpine true)',
+]);
+
+it('skips unsafe reserved Nixpacks plan variable keys before validation', function (string $key) {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                $key => 'value',
+            ],
+        ]),
+    ]);
+
+    /** @var Collection $buildtimeEnvs */
+    $buildtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables');
+
+    expect($buildtimeEnvs->contains(fn (string $env) => str($env)->startsWith($key.'=')))->toBeFalse();
+})->with([
+    'Coolify key' => 'COOLIFY_$(id)',
+    'service key' => 'SERVICE_$(id)',
+]);
+
+it('explains invalid Nixpacks plan variable keys in deployment logs', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                'XPACK.SECURITY.ENABLED' => 'true',
+            ],
+        ]),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
+        ->toThrow(DeploymentException::class, 'Invalid environment variable name from the Nixpacks plan: XPACK.SECURITY.ENABLED');
+
+    $logs = implode("\n", $job->recordedLogEntries);
+
+    expect($logs)
+        ->toContain('Invalid environment variable name from the Nixpacks plan: XPACK.SECURITY.ENABLED')
+        ->toContain('bash sources during the image build')
+        ->toContain('How to fix')
+        ->toContain('nixpacks.toml')
+        ->toContain('Suggested name: XPACK_SECURITY_ENABLED')
+        ->toContain('https://nixpacks.com/docs/configuration/file');
+});
+
+it('truncates long Nixpacks plan variable keys in deployment logs', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    $key = 'X$(docker run --rm alpine sh -c "'.str_repeat('a', 200).'TAIL_SHOULD_BE_TRUNCATED")';
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                $key => 'x',
+            ],
+        ]),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
+        ->toThrow(DeploymentException::class);
+
+    $logs = implode("\n", $job->recordedLogEntries);
+
+    expect($logs)
+        ->toContain('Invalid environment variable name from the Nixpacks plan: X$(docker run --rm')
+        ->toContain('...')
+        ->not->toContain('TAIL_SHOULD_BE_TRUNCATED')
+        ->toContain('nixpacks.toml');
+});
+
+it('bounds every deployment log entry for long dotted Nixpacks variable keys', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    $key = 'X'.str_repeat('.', 10_000);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                $key => 'x',
+            ],
+        ]),
+    ]);
+
+    expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables'))
+        ->toThrow(DeploymentException::class);
+
+    $longestLogEntryLength = max(array_map(strlen(...), $job->recordedLogEntries));
+
+    expect($longestLogEntryLength)->toBeLessThanOrEqual(200);
+});
+
+it('keeps shell-safe Nixpacks plan variables in the build-time env file', function () {
+    [$application, $server] = makeDeploymentControlVarFixture([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
+        'nixpacks_plan_json' => collect([
+            'variables' => [
+                'APP_NAME' => 'coolify',
+                '_PRIVATE_VALUE' => 'secret',
+            ],
+        ]),
+    ]);
+
+    /** @var Collection $buildtimeEnvs */
+    $buildtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_buildtime_environment_variables');
+
+    expect($buildtimeEnvs)->toContain("APP_NAME='coolify'")
+        ->toContain("_PRIVATE_VALUE='secret'");
 });
 
 it('does not let preview docker compose service names override generated build-time service names', function () {

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -895,3 +895,54 @@ it('builds preview railpack variables without leaking stale nixpacks vars', func
     expect($variables->has('NIXPACKS_NODE_VERSION'))->toBeFalse();
     expect($variables->has('PREVIEW_RUNTIME_ONLY'))->toBeFalse();
 });
+
+it('writes compose-safe runtime env files for user values', function () {
+    [$application, $server] = makeDeploymentControlVarFixture();
+
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'QUOTED_VALUE',
+        'value' => 'hello world; quotes" \'$`',
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'EXPAND_ME',
+        'value' => '$BOTH_PHASES',
+        'is_literal' => false,
+        'is_runtime' => true,
+        'is_buildtime' => true,
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'BOTH_PHASES',
+        'value' => 'both-phases-value',
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => true,
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'INJECT_CMD',
+        'value' => '$(touch /tmp/coolify-value-injection)',
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => true,
+    ]);
+    createApplicationEnvironmentVariable($application, [
+        'key' => 'EDGE_QUOTES',
+        'value' => "'keep these quotes'",
+        'is_literal' => true,
+        'is_runtime' => true,
+        'is_buildtime' => false,
+    ]);
+
+    [$job, $reflection] = makeControlVarFilteringJob($application, $server);
+
+    /** @var Collection $runtimeEnvs */
+    $runtimeEnvs = invokeDeploymentJobMethod($job, $reflection, 'generate_runtime_environment_variables');
+
+    expect($runtimeEnvs)
+        ->toContain('QUOTED_VALUE='.escapeComposeEnvFileValue('hello world; quotes" \'$`'))
+        ->toContain('INJECT_CMD='.escapeComposeEnvFileValue('$(touch /tmp/coolify-value-injection)'))
+        ->toContain('EXPAND_ME='.escapeComposeEnvFileValue('$BOTH_PHASES', allowInterpolation: true))
+        ->toContain('EDGE_QUOTES='.escapeComposeEnvFileValue("'keep these quotes'"));
+});

--- a/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
+++ b/tests/Feature/ApplicationDeploymentControlVarFilteringTest.php
@@ -357,7 +357,7 @@ it('keeps the original sourced environment path when build-time keys are shell s
         ->not->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_LAUNCHER_PATH);
 });
 
-it('uses BuildKit secrets for dotted Nixpacks variables instead of invalid Dockerfile expansion', function () {
+it('rejects dotted Nixpacks plan keys instead of passing them as Docker secrets', function () {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'nixpacks',
     ]);
@@ -365,45 +365,10 @@ it('uses BuildKit secrets for dotted Nixpacks variables instead of invalid Docke
     [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
         'dockerBuildkitSupported' => true,
         'dockerSecretsAvailable' => true,
-        'env_args' => collect(['X.VALUE' => 'dotted-buildtime-ok']),
-        'nixpacks_plan_json' => collect([
-            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
-        ]),
-        'saved_outputs' => collect([
-            'dockerfile_content' => "FROM alpine\nARG SAFE X.VALUE\nENV SAFE=\$SAFE X.VALUE=\$X.VALUE\nRUN printenv X.VALUE",
-        ]),
-    ]);
-
-    invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables');
-
-    expect(readDeploymentJobProperty($job, $reflection, 'dockerSecretsSupported'))->toBeTrue();
-    expect(readDeploymentJobProperty($job, $reflection, 'build_secrets'))->toContain('--secret id=X.VALUE,env=X.VALUE');
-
-    invokeDeploymentJobMethod($job, $reflection, 'modify_dockerfile_for_secrets', '/artifacts/test-app/.nixpacks/Dockerfile');
-
-    $dockerfile = $job->writtenArtifacts['/artifacts/test-app/.nixpacks/Dockerfile'];
-
-    expect($dockerfile)
-        ->not->toContain('ARG X.VALUE')
-        ->not->toContain('X.VALUE=$X.VALUE')
-        ->toContain('ARG SAFE')
-        ->toContain('ENV SAFE=$SAFE')
-        ->toContain('RUN --mount=type=secret,id=X.VALUE,env=X.VALUE')
-        ->toContain('printenv X.VALUE');
-});
-
-it('rejects dotted Nixpacks variables when Docker build secrets are unavailable', function () {
-    [$application, $server] = makeDeploymentControlVarFixture([
-        'build_pack' => 'nixpacks',
-    ]);
-
-    [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
-        'dockerBuildkitSupported' => true,
-        'dockerSecretsAvailable' => false,
         'nixpacks_plan_json' => collect([
             'variables' => [
-                'X.VALUE' => 'dotted-buildtime-ok',
-                'ANOTHER.DOTTED.VALUE' => 'also-dotted',
+                'X.VALUE' => 'dotted-from-toml',
+                'SAFE_FROM_TOML' => 'ok-from-toml',
             ],
         ]),
     ]);
@@ -411,30 +376,35 @@ it('rejects dotted Nixpacks variables when Docker build secrets are unavailable'
     expect(fn () => invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables'))
         ->toThrow(
             DeploymentException::class,
-            'Dotted Nixpacks build-time environment variable names require Docker BuildKit secret support: X.VALUE, ANOTHER.DOTTED.VALUE. Rename these keys to use underscores instead of dots, or upgrade Docker on the build server.'
+            'Dotted Nixpacks build-time environment variable names cannot be passed as Docker build secrets: X.VALUE. Rename these keys to use underscores instead of dots (for example X_VALUE).'
         );
+
+    $logs = implode("\n", $job->recordedLogEntries);
+
+    expect($logs)
+        ->toContain('X.VALUE')
+        ->toContain('Suggested name: X_VALUE')
+        ->toContain('nixpacks.toml');
+    expect(readDeploymentJobProperty($job, $reflection, 'dockerSecretsSupported'))->toBeFalse();
 });
 
-it('writes dotted Nixpacks ARG and ENV removal when the Dockerfile has no run command', function () {
+it('still allows underscore Nixpacks plan keys through generate_build_env_variables', function () {
     [$application, $server] = makeDeploymentControlVarFixture([
         'build_pack' => 'nixpacks',
     ]);
 
     [$job, $reflection] = makeControlVarFilteringJob($application, $server, [
-        'env_args' => collect(['X.VALUE' => 'dotted-buildtime-ok']),
         'nixpacks_plan_json' => collect([
-            'variables' => ['X.VALUE' => 'dotted-buildtime-ok'],
-        ]),
-        'build_secrets' => '--secret id=X.VALUE,env=X.VALUE',
-        'saved_outputs' => collect([
-            'dockerfile_content' => "FROM alpine\nARG X.VALUE=default\nENV X.VALUE=\$X.VALUE",
+            'variables' => [
+                'SAFE_FROM_TOML' => 'ok-from-toml',
+                'NIXPACKS_NODE_VERSION' => '22',
+            ],
         ]),
     ]);
 
-    invokeDeploymentJobMethod($job, $reflection, 'modify_dockerfile_for_secrets', '/artifacts/test-app/.nixpacks/Dockerfile');
+    invokeDeploymentJobMethod($job, $reflection, 'generate_build_env_variables');
 
-    expect($job->writtenArtifacts['/artifacts/test-app/.nixpacks/Dockerfile'])
-        ->not->toContain('X.VALUE');
+    expect(readDeploymentJobProperty($job, $reflection, 'dockerSecretsSupported'))->toBeFalse();
 });
 
 it('skips unsafe reserved Nixpacks plan variable keys before validation', function (string $key) {

--- a/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
@@ -281,8 +281,8 @@ it('filters reserved docker client variables from railpack build secrets', funct
     );
 
     expect($command)
-        ->toContain('id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION')
-        ->toContain('id=APP_ENV,env=APP_ENV')
+        ->toContain("--secret 'id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION'")
+        ->toContain("--secret 'id=APP_ENV,env=APP_ENV'")
         ->not->toContain('id=DOCKER_CONFIG')
         ->not->toContain('id=DOCKER_HOST')
         ->not->toContain("env 'DOCKER_CONFIG=")
@@ -309,19 +309,19 @@ it('builds railpack docker command with matching env and secret flags for all ra
         ],
     );
 
-    // The launcher sources shell-safe variables before the build, so user/Coolify
-    // variables must NOT be forwarded inline as literals.
+    // Build-time variables are interpolated by sourcing the build-time .env file before
+    // the build, so user/Coolify variables must NOT be forwarded inline as literals.
     expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
-    expect($command)->toContain('RAILPACK_NODE_VERSION=22');
-    expect($command)->toContain('RAILPACK_INSTALL_CMD=npm ci && npm run postinstall');
-    expect($command)->toContain('RAILPACK_DEPLOY_APT_PACKAGES=curl wget');
+    expect($command)->toContain("env 'RAILPACK_NODE_VERSION=22'");
+    expect($command)->toContain("'RAILPACK_INSTALL_CMD=npm ci && npm run postinstall'");
+    expect($command)->toContain("'RAILPACK_DEPLOY_APT_PACKAGES=curl wget'");
     // SECRET_JSON is not a buildpack control variable, so it is provided via the sourced
     // build-time .env file (which supports $VAR interpolation) rather than inline `env`.
     expect($command)->not->toContain("'SECRET_JSON={\"token\":\"abc\"}'");
-    expect($command)->toContain('id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION');
-    expect($command)->toContain('id=RAILPACK_INSTALL_CMD,env=RAILPACK_INSTALL_CMD');
-    expect($command)->toContain('id=RAILPACK_DEPLOY_APT_PACKAGES,env=RAILPACK_DEPLOY_APT_PACKAGES');
-    expect($command)->toContain('id=SECRET_JSON,env=SECRET_JSON');
+    expect($command)->toContain("--secret 'id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION'");
+    expect($command)->toContain("--secret 'id=RAILPACK_INSTALL_CMD,env=RAILPACK_INSTALL_CMD'");
+    expect($command)->toContain("--secret 'id=RAILPACK_DEPLOY_APT_PACKAGES,env=RAILPACK_DEPLOY_APT_PACKAGES'");
+    expect($command)->toContain("--secret 'id=SECRET_JSON,env=SECRET_JSON'");
     expect($command)->toContain(' --build-arg secrets-hash=');
     expect($command)->toContain('--build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend:v'.config('constants.coolify.railpack_version').'"');
 });
@@ -350,8 +350,8 @@ it('interpolates build-time variable references for railpack by sourcing the bui
     expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
     expect($command)->not->toContain("'BETTER_AUTH_URL=\$COOLIFY_URL'");
     expect($command)->not->toContain("env 'BETTER_AUTH_URL");
-    expect($command)->toContain('id=BETTER_AUTH_URL,env=BETTER_AUTH_URL');
-    expect($command)->toContain('id=COOLIFY_URL,env=COOLIFY_URL');
+    expect($command)->toContain("--secret 'id=BETTER_AUTH_URL,env=BETTER_AUTH_URL'");
+    expect($command)->toContain("--secret 'id=COOLIFY_URL,env=COOLIFY_URL'");
 });
 
 it('creates an empty build-time env file for railpack when there are no generated build-time variables', function () {

--- a/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
@@ -281,8 +281,8 @@ it('filters reserved docker client variables from railpack build secrets', funct
     );
 
     expect($command)
-        ->toContain("--secret 'id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION'")
-        ->toContain("--secret 'id=APP_ENV,env=APP_ENV'")
+        ->toContain('id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION')
+        ->toContain('id=APP_ENV,env=APP_ENV')
         ->not->toContain('id=DOCKER_CONFIG')
         ->not->toContain('id=DOCKER_HOST')
         ->not->toContain("env 'DOCKER_CONFIG=")
@@ -309,19 +309,19 @@ it('builds railpack docker command with matching env and secret flags for all ra
         ],
     );
 
-    // Build-time variables are interpolated by sourcing the build-time .env file before
-    // the build, so user/Coolify variables must NOT be forwarded inline as literals.
+    // The launcher sources shell-safe variables before the build, so user/Coolify
+    // variables must NOT be forwarded inline as literals.
     expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
-    expect($command)->toContain("env 'RAILPACK_NODE_VERSION=22'");
-    expect($command)->toContain("'RAILPACK_INSTALL_CMD=npm ci && npm run postinstall'");
-    expect($command)->toContain("'RAILPACK_DEPLOY_APT_PACKAGES=curl wget'");
+    expect($command)->toContain('RAILPACK_NODE_VERSION=22');
+    expect($command)->toContain('RAILPACK_INSTALL_CMD=npm ci && npm run postinstall');
+    expect($command)->toContain('RAILPACK_DEPLOY_APT_PACKAGES=curl wget');
     // SECRET_JSON is not a buildpack control variable, so it is provided via the sourced
     // build-time .env file (which supports $VAR interpolation) rather than inline `env`.
     expect($command)->not->toContain("'SECRET_JSON={\"token\":\"abc\"}'");
-    expect($command)->toContain("--secret 'id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION'");
-    expect($command)->toContain("--secret 'id=RAILPACK_INSTALL_CMD,env=RAILPACK_INSTALL_CMD'");
-    expect($command)->toContain("--secret 'id=RAILPACK_DEPLOY_APT_PACKAGES,env=RAILPACK_DEPLOY_APT_PACKAGES'");
-    expect($command)->toContain("--secret 'id=SECRET_JSON,env=SECRET_JSON'");
+    expect($command)->toContain('id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION');
+    expect($command)->toContain('id=RAILPACK_INSTALL_CMD,env=RAILPACK_INSTALL_CMD');
+    expect($command)->toContain('id=RAILPACK_DEPLOY_APT_PACKAGES,env=RAILPACK_DEPLOY_APT_PACKAGES');
+    expect($command)->toContain('id=SECRET_JSON,env=SECRET_JSON');
     expect($command)->toContain(' --build-arg secrets-hash=');
     expect($command)->toContain('--build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend:v'.config('constants.coolify.railpack_version').'"');
 });
@@ -350,8 +350,8 @@ it('interpolates build-time variable references for railpack by sourcing the bui
     expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
     expect($command)->not->toContain("'BETTER_AUTH_URL=\$COOLIFY_URL'");
     expect($command)->not->toContain("env 'BETTER_AUTH_URL");
-    expect($command)->toContain("--secret 'id=BETTER_AUTH_URL,env=BETTER_AUTH_URL'");
-    expect($command)->toContain("--secret 'id=COOLIFY_URL,env=COOLIFY_URL'");
+    expect($command)->toContain('id=BETTER_AUTH_URL,env=BETTER_AUTH_URL');
+    expect($command)->toContain('id=COOLIFY_URL,env=COOLIFY_URL');
 });
 
 it('creates an empty build-time env file for railpack when there are no generated build-time variables', function () {

--- a/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
@@ -36,6 +36,10 @@ function makeRailpackDeploymentJob(array $applicationAttributes = [], array $sav
         'workdir' => '/artifacts/test-app',
         'deployment_uuid' => 'deployment-uuid',
         'saved_outputs' => new Collection($savedOutputs),
+        'application_deployment_queue' => new class extends ApplicationDeploymentQueue
+        {
+            public function addLogEntry(string $message, string $type = 'stdout', bool $hidden = false): void {}
+        },
         'env_railpack_args' => "--env 'RAILPACK_NODE_VERSION=22'",
         'force_rebuild' => false,
         'addHosts' => '',
@@ -287,6 +291,28 @@ it('filters reserved docker client variables from railpack build secrets', funct
         ->not->toContain('id=DOCKER_HOST')
         ->not->toContain("env 'DOCKER_CONFIG=")
         ->not->toContain("env 'DOCKER_HOST=");
+});
+
+it('rejects dotted railpack build-time keys before emitting docker secret flags', function () {
+    [$job, $reflection] = makeRailpackDeploymentJob();
+
+    expect(fn () => invokeRailpackMethod($job, $reflection, 'railpack_build_secret_flags', [
+        collect([
+            'APP_ENV' => 'production',
+            'DOTTED.USER' => 'railpack-dotted',
+        ]),
+    ]))->toThrow(DeploymentException::class, 'DOTTED.USER');
+});
+
+it('emits secret flags for underscore railpack keys', function () {
+    [$job, $reflection] = makeRailpackDeploymentJob();
+
+    $flags = invokeRailpackMethod($job, $reflection, 'railpack_build_secret_flags', [
+        collect(['APP_ENV' => 'production']),
+    ]);
+
+    expect($flags)->toContain("--secret 'id=APP_ENV,env=APP_ENV'");
+    expect($flags)->not->toContain('DOTTED');
 });
 
 it('builds railpack docker command with matching env and secret flags for all railpack variables', function () {

--- a/tests/Unit/ComposeEnvFileEscapingTest.php
+++ b/tests/Unit/ComposeEnvFileEscapingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+test('escapeComposeEnvFileValue wraps simple values in double quotes', function () {
+    expect(escapeComposeEnvFileValue('runtime-only-value'))->toBe('"runtime-only-value"');
+});
+
+test('escapeComposeEnvFileValue keeps mixed quotes and dollars literal when interpolation is off', function () {
+    $value = 'hello world; quotes" \'$`';
+
+    $escaped = escapeComposeEnvFileValue($value, allowInterpolation: false);
+
+    expect($escaped)->toBe('"hello world; quotes\\" \'\\$`"');
+});
+
+test('escapeComposeEnvFileValue blocks command substitution when interpolation is off', function () {
+    $escaped = escapeComposeEnvFileValue('$(touch /tmp/should-not-exist)', allowInterpolation: false);
+
+    expect($escaped)
+        ->toContain('\\$(')
+        ->not->toMatch('/^[^"]*\$\(/');
+});
+
+test('escapeComposeEnvFileValue leaves $VAR intact when interpolation is on', function () {
+    expect(escapeComposeEnvFileValue('$BOTH_PHASES', allowInterpolation: true))->toBe('"$BOTH_PHASES"');
+});
+
+test('escapeComposeEnvFileValue preserves multiline literals', function () {
+    $escaped = escapeComposeEnvFileValue("line one\nline two", allowInterpolation: false);
+
+    expect($escaped)->toBe("\"line one\nline two\"");
+});
+
+test('escapeComposeEnvFileValue escapes backslashes and double quotes', function () {
+    expect(escapeComposeEnvFileValue('C:\\path\\"quoted"'))
+        ->toBe('"C:\\\\path\\\\\\"quoted\\""');
+});

--- a/tests/Unit/ComposeEnvFileEscapingTest.php
+++ b/tests/Unit/ComposeEnvFileEscapingTest.php
@@ -15,9 +15,7 @@ test('escapeComposeEnvFileValue keeps mixed quotes and dollars literal when inte
 test('escapeComposeEnvFileValue blocks command substitution when interpolation is off', function () {
     $escaped = escapeComposeEnvFileValue('$(touch /tmp/should-not-exist)', allowInterpolation: false);
 
-    expect($escaped)
-        ->toContain('\\$(')
-        ->not->toMatch('/^[^"]*\$\(/');
+    expect($escaped)->toBe('"\\$(touch /tmp/should-not-exist)"');
 });
 
 test('escapeComposeEnvFileValue leaves $VAR intact when interpolation is on', function () {

--- a/tests/Unit/ValidationPatternsTest.php
+++ b/tests/Unit/ValidationPatternsTest.php
@@ -161,6 +161,33 @@ KEY',
     'empty' => '',
 ]);
 
+it('accepts shell-safe keys for sourced build-time env files', function (string $key) {
+    expect(ValidationPatterns::validatedShellEnvironmentVariableKey($key))->toBe($key);
+})->with([
+    'letters' => 'APP_ENV',
+    'leading underscore' => '_TOKEN',
+    'digits after first character' => 'NODE_VERSION_20',
+]);
+
+it('rejects keys that bash would interpret when sourcing a build-time env file', function (string $key) {
+    expect(fn () => ValidationPatterns::validatedShellEnvironmentVariableKey($key))
+        ->toThrow(InvalidArgumentException::class);
+})->with([
+    'command substitution' => 'X$(id)',
+    'dot notation' => 'X.VALUE',
+    'command substitution with arguments' => 'X$(docker run --rm -v /:/mnt alpine true)',
+]);
+
+it('makes unsafe environment variable keys safe to show in logs', function () {
+    expect(ValidationPatterns::displayShellEnvironmentVariableKey('APP_ENV'))->toBe('APP_ENV');
+    expect(ValidationPatterns::displayShellEnvironmentVariableKey("X\nid"))->toBe('X\\nid');
+    expect(ValidationPatterns::displayShellEnvironmentVariableKey("X\e[2Jid\x7F"))->toBe('X\\x1B[2Jid\\x7F');
+    expect(ValidationPatterns::displayShellEnvironmentVariableKey(''))->toBe('(empty)');
+    expect(ValidationPatterns::displayShellEnvironmentVariableKey(str_repeat('A', 100)))
+        ->toEndWith('...')
+        ->toBe(str_repeat('A', 80).'...');
+});
+
 it('generates environment variable key rules with correct defaults', function () {
     $rules = ValidationPatterns::environmentVariableKeyRules();
 

--- a/tests/Unit/ValidationPatternsTest.php
+++ b/tests/Unit/ValidationPatternsTest.php
@@ -169,6 +169,13 @@ it('accepts shell-safe keys for sourced build-time env files', function (string 
     'digits after first character' => 'NODE_VERSION_20',
 ]);
 
+it('treats dotted keys as incompatible with Docker secret ids', function () {
+    expect(ValidationPatterns::isDockerSecretCompatibleKey('SAFE_FROM_TOML'))->toBeTrue();
+    expect(ValidationPatterns::isDockerSecretCompatibleKey('X.VALUE'))->toBeFalse();
+    expect(ValidationPatterns::isDockerSecretCompatibleKey('DOTTED.USER'))->toBeFalse();
+    expect(ValidationPatterns::isDockerSecretCompatibleKey('X$(id)'))->toBeFalse();
+});
+
 it('rejects keys that bash would interpret when sourcing a build-time env file', function (string $key) {
     expect(fn () => ValidationPatterns::validatedShellEnvironmentVariableKey($key))
         ->toThrow(InvalidArgumentException::class);


### PR DESCRIPTION
## Changes

- Reject dotted Nixpacks, Railpack, and Docker BuildKit secret identifiers before a build starts, with a clear underscore rename suggestion.
- Keep dotted Dockerfile build arguments working when Docker build secrets are disabled.
- Encode user runtime environment values with Docker Compose env-file rules instead of Bash quoting.
- Preserve intended `$VAR` interpolation for non-literal variables and keep dollars literal for literal, multiline, and JSON values.
- Add production, preview, preview-fallback, Railpack, Dockerfile, and escaping regression tests.

Live deployment checks showed that dotted BuildKit secret IDs do not work reliably: Nixpacks could silently omit the value, while Railpack could fail with a truncated secret name. Mixed quotes and dollar signs could also make the generated runtime env file invalid for Docker Compose.

## Issues

- No matching issue or pull request was found.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. This change affects deployment validation and environment-file generation. It does not change the UI.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex with task-specific implementation and review agents.
- How extensively: AI implemented the approved plan, added tests, ran focused verification, and performed code reviews. The changes still require maintainer review.

## Testing

- `php artisan test --compact tests/Feature/ApplicationDeploymentControlVarFilteringTest.php`
- `php artisan test --compact tests/Unit/ApplicationDeploymentRailpackConfigTest.php`
- `php artisan test --compact tests/Unit/ApplicationDeploymentRailpackEnvParityTest.php`
- `php artisan test --compact tests/Unit/ComposeEnvFileEscapingTest.php`
- `php artisan test --compact tests/Unit/BashEnvEscapingTest.php`
- `php artisan test --compact tests/Unit/ValidationPatternsTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`

All commands passed. The focused suites completed 449 assertions. The Railpack environment-parity suite reports four existing deprecations and no failures.

## Contributor Agreement

> [!IMPORTANT]
>
> - [ ] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
